### PR TITLE
Fix uninitialized variable in DS3231 RTC driver

### DIFF
--- a/drivers/rtc/rtc_ds3231.c
+++ b/drivers/rtc/rtc_ds3231.c
@@ -56,10 +56,10 @@ struct rtc_ds3231_conf {
 	struct gpio_dt_spec isw_gpios;
 };
 
-static int rtc_ds3231_modify_register(const struct device *dev, uint8_t reg, uint8_t *buf,
-				      const uint8_t bitmask)
+static int rtc_ds3231_modify_register(const struct device *dev, uint8_t reg,
+				uint8_t *buf, const uint8_t bitmask)
 {
-	int err;
+	int err = 0;
 	const struct rtc_ds3231_conf *config = dev->config;
 
 	if (bitmask != 255) {


### PR DESCRIPTION
## Summary
- fix `err` variable initialization in DS3231 RTC driver

## Testing
- `./scripts/checkpatch.pl --no-tree -f drivers/rtc/rtc_ds3231.c`
- `./scripts/twister -T tests/drivers/rtc/rtc_utils --platform native_sim --build-only` *(fails: Build failure)*

------
https://chatgpt.com/codex/tasks/task_e_6844461ca7708321ace524c34b4c442d