### PR TITLE
Fix logging parameter order in cellular modem drivers

### DIFF
--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -85,8 +85,8 @@ static int modem_atoi(const char *s, const int err_value,
 
 	ret = (int)strtol(s, &endptr, 10);
 	if (!endptr || *endptr != '\0') {
-		LOG_ERR("bad %s '%s' in %s", s, desc,
-			func);
+	LOG_ERR("bad %s '%s' in %s", desc, s,
+	func);
 		return err_value;
 	}
 

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -190,8 +190,8 @@ static int modem_atoi(const char *s, const int err_value,
 
 	ret = (int)strtol(s, &endptr, 10);
 	if (!endptr || *endptr != '\0') {
-		LOG_ERR("bad %s '%s' in %s", s, desc,
-			func);
+	LOG_ERR("bad %s '%s' in %s", desc, s,
+	func);
 		return err_value;
 	}
 


### PR DESCRIPTION
## Summary
- fix error log parameter order in ublox-sara-r4 driver
- fix error log parameter order in quectel bg9x driver

## Testing
- `scripts/checkpatch.pl` on the patch
- `pip install west` *(for building, west not previously installed)*
- `west build` failed: `west: unknown command "build"; do you need to run this inside a workspace?`

------
https://chatgpt.com/codex/tasks/task_e_68444aa855708321ba5067f2a4c59239