### PR TITLE
Fix misc pinctrl bugs

### DIFF
--- a/drivers/pinctrl/pinctrl_mci_io_mux.c
+++ b/drivers/pinctrl/pinctrl_mci_io_mux.c
@@ -36,12 +36,12 @@ static void configure_pin_props(uint32_t pin_mux, uint8_t gpio_idx)
 
 	/* GPIO 22-27 use always on configuration registers */
 	if (gpio_idx > 21 && gpio_idx < 28) {
-		pull_reg = (&aon_soc_ciu->PAD_PU_PD_EN1 - 1);
-		slew_reg = (&aon_soc_ciu->SR_CONFIG1 - 1);
-		sleep_force_en = &aon_soc_ciu->PAD_SLP_EN0;
-		sleep_force_val = &aon_soc_ciu->PAD_SLP_VAL0;
+	pull_reg = &aon_soc_ciu->PAD_PU_PD_EN0;
+	slew_reg = &aon_soc_ciu->SR_CONFIG0;
+	sleep_force_en = &aon_soc_ciu->PAD_SLP_EN0;
+	sleep_force_val = &aon_soc_ciu->PAD_SLP_VAL0;
 	}
-	/* Calculate register offset for pull and slew regs.
+		/* Calculate register offset for pull and slew regs.
 	 * Use bit shifting as opposed to division
 	 */
 	pull_reg += (gpio_idx >> 4);
@@ -147,8 +147,8 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 		case IOMUX_SGPIO:
 			mci_iomux->S_GPIO |= (0x1 << (gpio_idx - 32));
 			break;
-		case IOMUX_GPIO:
-			if (gpio_idx > 32) {
+               case IOMUX_GPIO:
+                       if (gpio_idx >= 32) {
 				mci_iomux->GPIO_GRP1 |= (0x1 << (gpio_idx - 32));
 			} else {
 				mci_iomux->GPIO_GRP0 |= (0x1 << gpio_idx);

--- a/drivers/pinctrl/pinctrl_ti_k3.c
+++ b/drivers/pinctrl/pinctrl_ti_k3.c
@@ -15,17 +15,22 @@ static struct pinctrl_ti_k3_dev_data {
 	DEVICE_MMIO_RAM;
 } pinctrl_ti_k3_dev;
 
-static struct pinctrl_ti_k3_cfg_data {
-	DEVICE_MMIO_ROM;
+static const struct pinctrl_ti_k3_cfg_data {
+       DEVICE_MMIO_ROM;
 } pinctrl_ti_k3_cfg = {
-	DEVICE_MMIO_ROM_INIT(PINCTRL_NODE)
+       DEVICE_MMIO_ROM_INIT(PINCTRL_NODE)
 };
 
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintptr_t reg)
 {
 	ARG_UNUSED(reg);
-	const struct device *dev = DEVICE_DT_GET(PINCTRL_NODE);
-	uintptr_t virt_reg_base = DEVICE_MMIO_GET(dev);
+       const struct device *dev = DEVICE_DT_GET(PINCTRL_NODE);
+
+       if (!device_is_ready(dev)) {
+               return -ENODEV;
+       }
+
+       uintptr_t virt_reg_base = DEVICE_MMIO_GET(dev);
 
 	for (uint8_t i = 0; i < pin_cnt; i++) {
 		sys_write32(pins[i].value, virt_reg_base + pins[i].offset);

--- a/drivers/pinctrl/pinctrl_wch_00x_afio.c
+++ b/drivers/pinctrl/pinctrl_wch_00x_afio.c
@@ -53,7 +53,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 			/* Reset the pin. */
 			regs->BSHR |= BIT(pin + 16);
 		} else {
-			regs->OUTDR &= ~(1 << pin);
+                       regs->OUTDR &= ~BIT(pin);
 			if (pins->bias_pull_up) {
 				regs->BSHR = BIT(pin);
 			}

--- a/drivers/pinctrl/pinctrl_wch_afio.c
+++ b/drivers/pinctrl/pinctrl_wch_afio.c
@@ -52,7 +52,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt, uintp
 			/* Reset the pin. */
 			regs->BSHR |= BIT(pin + 16);
 		} else {
-			regs->OUTDR &= ~(1 << pin);
+                       regs->OUTDR &= ~BIT(pin);
 			if (pins->bias_pull_up) {
 				regs->BSHR = BIT(pin);
 			}


### PR DESCRIPTION
## Summary
- fix MCU I/O mux register selection and group boundary check
- use BIT macro for pin clear
- mark TI K3 pinctrl config const
- verify TI K3 pinctrl device readiness before access

## Testing
- `cppcheck --quiet drivers/pinctrl/pinctrl_mci_io_mux.c drivers/pinctrl/pinctrl_ti_k3.c drivers/pinctrl/pinctrl_wch_afio.c drivers/pinctrl/pinctrl_wch_00x_afio.c`

------
https://chatgpt.com/codex/tasks/task_e_6844c3d907e0832192c0a82a771373a6