### PR TITLE
Fix shell typos

### DIFF
--- a/drivers/w1/w1_shell.c
+++ b/drivers/w1/w1_shell.c
@@ -176,7 +176,7 @@ static int cmd_w1_write_bit(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	(void)w1_lock_bus(dev);
-	ret = w1_write_byte(dev, (bool)input);
+        ret = w1_write_bit(dev, (bool)input);
 	if (ret < 0) {
 		shell_error(sh, "Failed to write bit [%d]", ret);
 	}
@@ -234,7 +234,7 @@ out:
 	return ret;
 }
 
-/* 1-Wire write_block <device> <byt1> [byte2, ...] */
+/* 1-Wire write_block <device> <byte1> [byte2, ...] */
 static int cmd_w1_write_block(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;

--- a/include/zephyr/bluetooth/mesh/statistic.h
+++ b/include/zephyr/bluetooth/mesh/statistic.h
@@ -34,7 +34,7 @@ struct bt_mesh_statistic {
 	/** Received frames over proxy. */
 	uint32_t rx_proxy;
 	/** Received over unknown interface. */
-	uint32_t rx_uknown;
+	uint32_t rx_unknown;
 	/** Counter of frames that were initiated to relay over advertiser bearer. */
 	uint32_t tx_adv_relay_planned;
 	/** Counter of frames that succeeded relaying over advertiser bearer. */

--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -1598,7 +1598,7 @@ static int cmd_stat_get(const struct shell *sh, size_t argc, char *argv[])
 	shell_print(sh, "adv:       %d", st.rx_adv);
 	shell_print(sh, "loopback:  %d", st.rx_loopback);
 	shell_print(sh, "proxy:     %d", st.rx_proxy);
-	shell_print(sh, "unknown:   %d", st.rx_uknown);
+	shell_print(sh, "unknown:   %d", st.rx_unknown);
 
 	shell_print(sh, "Transmitted frames: <planned> - <succeeded>");
 	shell_print(sh, "relay adv:   %d - %d", st.tx_adv_relay_planned, st.tx_adv_relay_succeeded);

--- a/subsys/bluetooth/mesh/statistic.c
+++ b/subsys/bluetooth/mesh/statistic.c
@@ -56,8 +56,8 @@ void bt_mesh_stat_rx(enum bt_mesh_net_if net_if)
 	case BT_MESH_NET_IF_PROXY_CFG:
 		stat.rx_proxy++;
 		break;
-	default:
-		stat.rx_uknown++;
-		break;
-	}
+       default:
+               stat.rx_unknown++;
+               break;
+       }
 }


### PR DESCRIPTION
## Summary
- correct a comment in w1 shell and use `w1_write_bit()`
- fix `rx_unknown` field name in mesh statistics and update its usages

## Testing
- `scripts/checkpatch.pl -f drivers/w1/w1_shell.c subsys/bluetooth/mesh/statistic.c subsys/bluetooth/mesh/shell/shell.c include/zephyr/bluetooth/mesh/statistic.h`

------
https://chatgpt.com/codex/tasks/task_e_684d347559388321b556229a19791fe7