### PR TITLE
Fix typos and macro issues in shell modules

### DIFF
--- a/drivers/modem/modem_at_shell.c
+++ b/drivers/modem/modem_at_shell.c
@@ -65,10 +65,8 @@ static void at_shell_print_match(struct modem_chat *chat, char **argv, uint16_t 
 	shell_print(at_shell_active_shell, "%s", argv[0]);
 }
 
-MODEM_CHAT_MATCHES_DEFINE(
-	at_shell_abort_matches,
-	MODEM_CHAT_MATCH("ERROR", "", at_shell_print_match),
-);
+MODEM_CHAT_MATCHES_DEFINE(at_shell_abort_matches,
+        MODEM_CHAT_MATCH("ERROR", "", at_shell_print_match));
 
 static void at_shell_script_callback(struct modem_chat *chat,
 				     enum modem_chat_script_result result,

--- a/drivers/regulator/regulator_shell.c
+++ b/drivers/regulator/regulator_shell.c
@@ -243,9 +243,9 @@ static int cmd_vget(const struct shell *sh, size_t argc, char **argv)
 
 static int cmd_clist(const struct shell *sh, size_t argc, char **argv)
 {
-	const struct device *dev;
-	unsigned int current_cnt;
-	int32_t last_current_ua;
+        const struct device *dev;
+        unsigned int current_cnt;
+        int32_t last_current_ua = 0;
 
 	ARG_UNUSED(argc);
 

--- a/modules/lvgl/lvgl_shell.c
+++ b/modules/lvgl/lvgl_shell.c
@@ -188,7 +188,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 		      "Usage: lvgl monkey create [pointer|keypad|button|encoder]",
 		      cmd_lvgl_monkey_create, 1, 1),
 	SHELL_CMD_ARG(set, NULL,
-		      "Activate/deactive a monkey instance\n"
+                     "Activate/deactivate a monkey instance\n"
 		      "Usage: lvgl monkey set <index> <active|inactive>\n",
 		      cmd_lvgl_monkey_set, 3, 0),
 	SHELL_SUBCMD_SET_END);

--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -937,7 +937,7 @@ static bool check_priority(const struct shell *sh, int priority)
 		shell_fprintf(sh, SHELL_WARNING,
 			      "Invalid priority: %d\n"
 			      "Valid values are [%d, %d] for co-operative "
-			      "and [%d, %d] for pre-emptive threads\n",
+                             "and [%d, %d] for preemptive threads\n",
 			      priority,
 			      -CONFIG_NUM_COOP_PRIORITIES, -1,
 			      0, CONFIG_NUM_PREEMPT_PRIORITIES - 1);
@@ -2041,9 +2041,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(zperf_cmd_udp,
 );
 
 SHELL_STATIC_SUBCMD_SET_CREATE(zperf_cmd_jobs,
-	SHELL_CMD(all, NULL, "Show all statistics", cmd_jobs_all),
-	SHELL_CMD(clear, NULL, "Clear all statistics", cmd_jobs_clear),
-	SHELL_CMD(start, NULL, "Start waiting jobs", cmd_jobs_start),
+        SHELL_CMD(all, NULL, "Show all statistics", cmd_jobs_all),
+        SHELL_CMD(clear, NULL, "Clear all statistics", cmd_jobs_clear),
+        SHELL_CMD(start, NULL, "Start waiting jobs", cmd_jobs_start),
+        SHELL_SUBCMD_SET_END
 );
 
 SHELL_STATIC_SUBCMD_SET_CREATE(zperf_commands,


### PR DESCRIPTION
## Summary
- correct a typo in `lvgl_shell`
- fix typo and missing command sentinel in `zperf_shell`
- initialize a variable in `regulator_shell`
- clean up `modem_at_shell` chat match definition

## Testing
- `codespell -q 3 -L isnt,smpt $(git ls-files '*_shell.c')`
- `cppcheck $(git ls-files '*_shell.c')` *(fails: unknown macro warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684d3bfcace08321a2702c921f56fb49