### PR TITLE
Fix BBRAM driver issues

### DIFF
--- a/drivers/bbram/bbram_microchip_mcp7940n.c
+++ b/drivers/bbram/bbram_microchip_mcp7940n.c
@@ -81,7 +81,7 @@ static int microchip_mcp7940n_bbram_is_invalid(const struct device *dev)
 	if ((buffer & MICROCHIP_MCP7940N_RTCWKDAY_PWRFAIL_BIT)) {
 		data_valid = false;
 
-		buffer &= (buffer ^ MICROCHIP_MCP7940N_RTCWKDAY_PWRFAIL_BIT);
+               buffer &= ~MICROCHIP_MCP7940N_RTCWKDAY_PWRFAIL_BIT;
 
 		rc = i2c_reg_write_byte_dt(&config->i2c,
 					   MICROCHIP_MCP7940N_RTCWKDAY_REGISTER_ADDRESS,
@@ -97,9 +97,9 @@ static int microchip_mcp7940n_bbram_is_invalid(const struct device *dev)
 finish:
 	k_mutex_unlock(&data->lock);
 
-	if (rc == 0 && data_valid == true) {
-		rc = 1;
-	}
+       if (rc == 0 && !data_valid) {
+               rc = 1;
+       }
 
 	return rc;
 }
@@ -138,9 +138,9 @@ static int microchip_mcp7940n_bbram_check_standby_power(const struct device *dev
 finish:
 	k_mutex_unlock(&data->lock);
 
-	if (rc == 0 && power_enabled == true) {
-		rc = 1;
-	}
+       if (rc == 0 && !power_enabled) {
+               rc = 1;
+       }
 
 	return rc;
 }

--- a/drivers/bbram/bbram_microchip_mcp7940n_emul.c
+++ b/drivers/bbram/bbram_microchip_mcp7940n_emul.c
@@ -87,15 +87,15 @@ static int mcp7940n_emul_transfer_i2c(const struct emul *target, struct i2c_msg 
 			data->rtcwkday = msgs->buf[1];
 			return 0;
 		}
-		if (regn >= MICROCHIP_MCP7940N_SRAM_OFFSET &&
-		    regn + msgs->len - 1 <=
-			    MICROCHIP_MCP7940N_SRAM_OFFSET + MICROCHIP_MCP7940N_SRAM_SIZE) {
-			for (int i = 0; i < msgs->len; ++i) {
-				data->data[regn + i - MICROCHIP_MCP7940N_SRAM_OFFSET] =
-					msgs->buf[1 + i];
-			}
-			return 0;
-		}
+               if (regn >= MICROCHIP_MCP7940N_SRAM_OFFSET &&
+                   regn + msgs->len - 1 <=
+                           MICROCHIP_MCP7940N_SRAM_OFFSET + MICROCHIP_MCP7940N_SRAM_SIZE) {
+                        for (int i = 0; i < msgs->len - 1; ++i) {
+                                data->data[regn + i - MICROCHIP_MCP7940N_SRAM_OFFSET] =
+                                        msgs->buf[1 + i];
+                        }
+                        return 0;
+                }
 	}
 
 	return -EIO;

--- a/drivers/bbram/bbram_rts5912.c
+++ b/drivers/bbram/bbram_rts5912.c
@@ -24,7 +24,7 @@ static int bbram_rts5912_get_size(const struct device *dev, size_t *size)
 	const struct bbram_rts5912_config *config = dev->config;
 
 	*size = config->size;
-	LOG_INF("size: 0x%08x", *size);
+       LOG_INF("size: 0x%zx", *size);
 	return 0;
 }
 


### PR DESCRIPTION
## Summary
- fix inverted checks in MCP7940N BBRAM driver
- fix loop bounds in MCP7940N BBRAM emulator
- correct log format in RTS5912 BBRAM driver

## Testing
- `scripts/twister -T tests/drivers/bbram/emul -M` *(fails: Build failure - bits/libc-header-start.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684d57b041dc83218dfdff8a623dac58