### PR TITLE
Fix UART driver typos and W1C bug

### DIFF
--- a/doc/releases/release-notes-2.6.rst
+++ b/doc/releases/release-notes-2.6.rst
@@ -1289,7 +1289,7 @@ release:
 * :github:`34950` - xtensa arch ：The source code version is too old
 * :github:`34948` - SoF module is not pointing at Zehpyr repo
 * :github:`34935` - LwM2M: Block transfer with TLV format does not work
-* :github:`34932` - drvers/flash/nrf_qspi_nor: high power consumption on nrf52840
+* :github:`34932` - drivers/flash/nrf_qspi_nor: high power consumption on nrf52840
 * :github:`34931` - dns resolve timeout leads to CPU memory access violation error
 * :github:`34925` - tests/lib/cbprintf_package fails to build
 * :github:`34923` - net.socket.get_addr_info: frdm_k64f test fails

--- a/drivers/serial/uart_renesas_ra8_sci_b.c
+++ b/drivers/serial/uart_renesas_ra8_sci_b.c
@@ -385,8 +385,8 @@ static int uart_ra_sci_b_fifo_read(const struct device *dev, uint8_t *rx_data, c
 		}
 	}
 
-	/* Clear overrun error flag */
-	cfg->regs->CFCLR_b.ORERC = 0U;
+/* Clear overrun error flag */
+cfg->regs->CFCLR_b.ORERC = 1U;
 
 	return num_rx;
 }


### PR DESCRIPTION
## Summary
- fix typos in release notes
- correct ORERC bit handling in RA8 UART driver

## Testing
- `scripts/twister -T tests/drivers/uart/uart_basic_api -p native_sim --inline-logs -v` *(fails: fatal error bits/libc-header-start.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d57bc7c348321a93e9d960916433b