### PR TITLE
Fix UART driver typos and W1C handling

### DIFF
--- a/drivers/serial/Kconfig.npcx
+++ b/drivers/serial/Kconfig.npcx
@@ -17,8 +17,8 @@ config UART_NPCX
 	  processors.
 	  Say y if you wish to use serial port on NPCX MCU.
 
-# Expose this option when the reg porperty has two register base address.
-# i.e. One UART register bass address and one MDMA register base address.
+# Expose this option when the reg property has two register base addresses.
+# i.e. One UART register base address and one MDMA register base address.
 config UART_NPCX_USE_MDMA
 	bool "Nuvoton NPCX embedded controller (EC) serial driver DMA support"
 	depends on UART_NPCX && "$(dt_node_reg_addr_hex,$(DT_UART_NPCX),1)" != 0

--- a/drivers/serial/uart_bt.c
+++ b/drivers/serial/uart_bt.c
@@ -316,7 +316,7 @@ static int uart_bt_workqueue_init(void)
 	return 0;
 }
 
-/** The work-queue is shared across all instances, hence we initialize it separatedly */
+/** The work-queue is shared across all instances, hence we initialize it separately */
 SYS_INIT(uart_bt_workqueue_init, POST_KERNEL, CONFIG_SERIAL_INIT_PRIORITY);
 
 static int uart_bt_init(const struct device *dev)

--- a/drivers/serial/uart_max32.c
+++ b/drivers/serial/uart_max32.c
@@ -187,7 +187,7 @@ static int api_configure(const struct device *dev, const struct uart_config *uar
 		if (err < 0) {
 			return -ENOTSUP;
 		}
-		/* incase of success keep configuration */
+               /* in case of success keep configuration */
 		data->conf.parity = uart_cfg->parity;
 	}
 
@@ -205,7 +205,7 @@ static int api_configure(const struct device *dev, const struct uart_config *uar
 		if (err < 0) {
 			return -ENOTSUP;
 		}
-		/* incase of success keep configuration */
+               /* in case of success keep configuration */
 		data->conf.stop_bits = uart_cfg->stop_bits;
 	}
 
@@ -220,7 +220,7 @@ static int api_configure(const struct device *dev, const struct uart_config *uar
 		if (err < 0) {
 			return -ENOTSUP;
 		}
-		/* incase of success keep configuration */
+               /* in case of success keep configuration */
 		data->conf.data_bits = uart_cfg->data_bits;
 	}
 

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -129,7 +129,7 @@ static void mcux_flexcomm_pm_unlock_if_idle(const struct device *dev)
 		data->pm_policy_state_lock = false;
 		pm_policy_device_power_lock_put(dev);
 	} else {
-		/* can't block systemn workqueue so keep re-submitting until it's done */
+               /* can't block system workqueue so keep re-submitting until it's done */
 		k_work_submit(&data->pm_lock_work);
 	}
 }
@@ -1054,8 +1054,8 @@ static void mcux_flexcomm_isr(const struct device *dev)
 						K_USEC(data->rx_data.timeout));
 			}
 
-			/* Write 1 to clear start bit status bit */
-			config->base->STAT |= USART_STAT_START_MASK;
+                       /* Write 1 to clear start bit status bit */
+                       config->base->STAT = USART_STAT_START_MASK;
 		}
 
 		/* Handle TX interrupt (TXLVL = 0)


### PR DESCRIPTION
## Summary
- fix typos in NPCX Kconfig description
- fix typos in Bluetooth UART and MAX32 driver comments
- fix a comment typo in mcux flexcomm driver
- correctly clear `STAT` start-bit flag without read-modify-write

## Testing
- `codespell -q 3 -L ueon,rsource,Synopsys,SERIE,ser drivers/serial | head`

------
https://chatgpt.com/codex/tasks/task_e_684d57bc7c348321a93e9d960916433b