### PR TITLE
Fix RTC driver issues

### DIFF
--- a/drivers/rtc/rtc_pcf8563.c
+++ b/drivers/rtc/rtc_pcf8563.c
@@ -379,14 +379,15 @@ static int pcf8563_alarm_is_pending(const struct device *dev, uint16_t id)
 		return err;
 	}
 
-	/* Only the last bits use useful here */
-	if (reg & GENMASK(3, 2)) {
-		/* Clean the alarm */
-		err = i2c_reg_write_byte_dt(&config->i2c, PCF8563_CONTROL2_REGISTER, GENMASK(1, 0));
-		if (err) {
-			LOG_ERR("Error when clearing alarms: %d", err);
-			return err;
-		}
+        /* Only the last bits are useful here */
+        if (reg & GENMASK(3, 2)) {
+                /* Clear the alarm flags while preserving other bits */
+                reg &= ~GENMASK(3, 2);
+                err = i2c_reg_write_byte_dt(&config->i2c, PCF8563_CONTROL2_REGISTER, reg);
+                if (err) {
+                        LOG_ERR("Error when clearing alarms: %d", err);
+                        return err;
+                }
 		/* There was an alarm */
 		return 1;
 	}

--- a/drivers/rtc/rtc_smartbond.c
+++ b/drivers/rtc/rtc_smartbond.c
@@ -114,7 +114,7 @@ static void smartbond_rtc_isr(const struct device *dev)
 	struct rtc_smartbond_data *data = dev->data;
 	/* Exercise which events asserted the RTC IRQ line. Register is cleared upon read. */
 	uint32_t rtc_event_flags_reg = RTC->RTC_EVENT_FLAGS_REG;
-	/* RTC_EVENT_FLASH_REG will be updated regardless of the interrupt mask. */
+       /* RTC_EVENT_FLAGS_REG will be updated regardless of the interrupt mask. */
 	uint32_t rtc_interrupt_mask_reg = RTC->RTC_INTERRUPT_MASK_REG;
 
 #if defined(CONFIG_RTC_ALARM)


### PR DESCRIPTION
## Summary
- correct comment typo in smartbond RTC driver
- preserve control register bits when clearing PCF8563 alarm

## Testing
- `scripts/checkpatch.pl drivers/rtc/rtc_pcf8563.c drivers/rtc/rtc_smartbond.c`

------
https://chatgpt.com/codex/tasks/task_e_684d6f5eee60832187a826121f007af4