### PR TITLE
Fix INFO2 clearing in Renesas SDHC driver

### DIFF
--- a/drivers/sdhc/rcar_mmc.c
+++ b/drivers/sdhc/rcar_mmc.c
@@ -780,9 +780,10 @@ static int rcar_mmc_sd_buf_rx_tx_data(const struct device *dev, struct sdhc_data
 		}
 
 		/* clear write/read buffer ready flag */
-		info2_reg = rcar_mmc_read_reg32(dev, RCAR_MMC_INFO2);
-		info2_reg &= ~info2_poll_flag;
-		rcar_mmc_write_reg32(dev, RCAR_MMC_INFO2, info2_reg);
+               info2_reg = rcar_mmc_read_reg32(dev, RCAR_MMC_INFO2);
+               info2_reg &= ~info2_poll_flag;
+               info2_reg |= RCAR_MMC_INFO2_CLEAR;
+               rcar_mmc_write_reg32(dev, RCAR_MMC_INFO2, info2_reg);
 
 		for (w_off = 0; w_off < aligned_block_size; w_off += sd_buf0_size) {
 			uint64_t buf0 = 0ULL;


### PR DESCRIPTION
## Summary
- ensure RCAR_MMC_INFO2_CLEAR bit is set when clearing INFO2 flags

## Testing
- `pip install west`
- `west build -b native_sim tests/drivers/sdhc` *(fails: west not initialized)*


------
https://chatgpt.com/codex/tasks/task_e_684d6d8a2e24832196ce56c1ad6bb887