### PR TITLE
Fix SDHC driver typos

### DIFF
--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -171,7 +171,7 @@ static void card_detect_gpio_cb(const struct device *port, struct gpio_callback 
 static void imx_usdhc_select_1_8v(USDHC_Type *base, bool enable_1_8v)
 {
 #if !(defined(FSL_FEATURE_USDHC_HAS_NO_VOLTAGE_SELECT) && (FSL_FEATURE_USDHC_HAS_NO_VOLTAGE_SELECT))
-	UDSHC_SelectVoltage(base, enable_1_8v);
+	USDHC_SelectVoltage(base, enable_1_8v);
 #endif
 }
 

--- a/drivers/sdhc/sam_hsmci.c
+++ b/drivers/sdhc/sam_hsmci.c
@@ -405,7 +405,7 @@ static inline int wait_read_transfer_done(Hsmci *hsmci)
 	int sr;
 
 	do {
-		sr = HSMCI->HSMCI_SR;
+		sr = hsmci->HSMCI_SR;
 		if (sr & (HSMCI_SR_UNRE | HSMCI_SR_OVRE | HSMCI_SR_DTOE | HSMCI_SR_DCRCE)) {
 			return -EIO;
 		}


### PR DESCRIPTION
## Summary
- fix mis-typed USDHC function name in imx_usdhc driver
- use correct variable in sam_hsmci wait_read_transfer_done()

## Testing
- `scripts/checkpatch.pl -f drivers/sdhc/sam_hsmci.c drivers/sdhc/imx_usdhc.c`

------
https://chatgpt.com/codex/tasks/task_e_684d6d8a2e24832196ce56c1ad6bb887