### PR TITLE
Fix hwinfo driver typos

### DIFF
--- a/drivers/hwinfo/hwinfo_litex.c
+++ b/drivers/hwinfo/hwinfo_litex.c
@@ -15,8 +15,8 @@
 ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
 	uint32_t addr = DT_INST_REG_ADDR(0);
-	ssize_t end = MIN(length, DT_INST_REG_ADDR(0) / 4 *
-			CONFIG_LITEX_CSR_DATA_WIDTH / 8);
+	ssize_t end = MIN(length, DT_INST_REG_SIZE(0) / 4 *
+		CONFIG_LITEX_CSR_DATA_WIDTH / 8);
 	for (int i = 0; i < end; i++) {
 #if CONFIG_LITEX_CSR_DATA_WIDTH == 8
 		buffer[i] = litex_read8(addr);

--- a/drivers/hwinfo/hwinfo_sam.c
+++ b/drivers/hwinfo/hwinfo_sam.c
@@ -28,7 +28,7 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
  * the code, the unique identifier or the user signature area at the flash
  * location. Therefore the function reading the device id must be executed
  * from RAM with the interrupts disabled. To avoid executing this complex
- * code each time the device id is requested, we do this at boot time at save
+ * code each time the device id is requested, we do this at boot time and save
  * the 128-bit value into RAM.
  */
 __ramfunc static void hwinfo_sam_read_device_id(void)

--- a/drivers/hwinfo/hwinfo_smartbond.c
+++ b/drivers/hwinfo/hwinfo_smartbond.c
@@ -10,8 +10,8 @@
 #include <soc.h>
 #include <da1469x_trimv.h>
 
-#define PRODUCT_INFO_GPOUP	(12U)
-#define CHIP_ID_GPOUP		(13U)
+#define PRODUCT_INFO_GROUP	(12U)
+#define CHIP_ID_GROUP		(13U)
 
 #define PRODUCT_INFO_LENGTH	(3U)
 #define CHIP_ID_LENGTH		(1U)
@@ -23,9 +23,9 @@ ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 	uint8_t product_info_len;
 	uint8_t chip_id_len;
 
-	product_info_len = da1469x_trimv_group_read(PRODUCT_INFO_GPOUP, &unique_id[0],
+	product_info_len = da1469x_trimv_group_read(PRODUCT_INFO_GROUP, &unique_id[0],
 						    PRODUCT_INFO_LENGTH);
-	chip_id_len = da1469x_trimv_group_read(CHIP_ID_GPOUP, &unique_id[3],
+	chip_id_len = da1469x_trimv_group_read(CHIP_ID_GROUP, &unique_id[3],
 					       CHIP_ID_LENGTH);
 
 	if ((product_info_len != PRODUCT_INFO_LENGTH) || (chip_id_len != CHIP_ID_LENGTH)) {


### PR DESCRIPTION
## Summary
- correct register size calculation in Litex hwinfo driver
- fix comment in SAM hwinfo driver
- fix group macro typos in Smartbond hwinfo driver

## Testing
- `./scripts/checkpatch.pl -q /tmp/patch.diff`


------
https://chatgpt.com/codex/tasks/task_e_684d6d46c9c48321aa6c96c50b0f9879