### PR TITLE
Fix bugs in haptics drivers

### DIFF
--- a/drivers/haptics/drv2605.c
+++ b/drivers/haptics/drv2605.c
@@ -16,7 +16,6 @@
 #include <zephyr/drivers/haptics/drv2605.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/drivers/haptics.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/util.h>

--- a/drivers/haptics/haptics_handlers.c
+++ b/drivers/haptics/haptics_handlers.c
@@ -20,7 +20,7 @@ static inline int z_vrfy_haptics_stop_output(const struct device *dev)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_HAPTICS(dev, stop_output));
 
-	z_impl_haptics_stop_output(dev);
+        return z_impl_haptics_stop_output(dev);
 }
 
 #include <syscalls/haptics_stop_output_mrsh.c>


### PR DESCRIPTION
## Summary
- remove duplicate haptics include in DRV2605 driver
- fix missing return value in syscall verification handler

## Testing
- `cmake --version`
- ❌ `west build -b native_posix samples/drivers/haptics/drv2605` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6d74d4148321a40540c4133f1520