### PR TITLE
Fix CBC decrypt len, comment typo in crypto drivers

### DIFF
--- a/drivers/crypto/crypto_smartbond.c
+++ b/drivers/crypto/crypto_smartbond.c
@@ -713,10 +713,10 @@ static int crypto_smartbond_hash_handler(struct hash_ctx *ctx, struct hash_pkt *
 {
 	int ret;
 	struct crypto_smartbond_data *data = ctx->device->data;
-	/*
-	 * In case of framgemented data processing crypto status should be visible as busy for
-	 * as long as the last block is to be processed.
-	 */
+       /*
+	* In case of fragmented data processing crypto status should be visible as busy for
+	* as long as the last block is to be processed.
+	*/
 	bool is_multipart_started =
 		(AES_HASH->CRYPTO_STATUS_REG & AES_HASH_CRYPTO_STATUS_REG_CRYPTO_WAIT_FOR_IN_Msk) &&
 		!(AES_HASH->CRYPTO_STATUS_REG & AES_HASH_CRYPTO_STATUS_REG_CRYPTO_INACTIVE_Msk);

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -249,7 +249,8 @@ static int crypto_stm32_cbc_decrypt(struct cipher_ctx *ctx,
 		in_offset = 16;
 	}
 
-	ret = do_aes(ctx, hal_cbc_decrypt_op, pkt->in_buf + in_offset, pkt->in_len, pkt->out_buf);
+	ret = do_aes(ctx, hal_cbc_decrypt_op, pkt->in_buf + in_offset,
+	pkt->in_len - in_offset, pkt->out_buf);
 	if (ret == 0) {
 		pkt->out_len = pkt->in_len - in_offset;
 	}


### PR DESCRIPTION
## Summary
- fix CBC decrypt length handling for STM32 crypto driver
- fix a typo in a SmartBond crypto driver comment

## Testing
- `scripts/checkpatch.pl --no-tree -f drivers/crypto/crypto_stm32.c drivers/crypto/crypto_smartbond.c`
- `cmake ../samples/hello_world -DBOARD=native_posix` *(fails: ModuleNotFoundError: No module named 'pykwalify')*

------
https://chatgpt.com/codex/tasks/task_e_684d853489208321b5d1fbeecd9600d9