### PR TITLE
Fix watchdog driver bugs

### DIFF
--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -75,7 +75,7 @@ static void (*user_cb)(const struct device *dev, int channel_id);
 
 static void wdog_cmsdk_apb_unlock(const struct device *dev)
 {
-	volatile struct wdog_cmsdk_apb *wdog = WDOG_STRUCT;
+volatile struct wdog_cmsdk_apb *wdog = WDOG_STRUCT;
 
 	ARG_UNUSED(dev);
 
@@ -111,8 +111,8 @@ static int wdog_cmsdk_apb_disable(const struct device *dev)
 
 	ARG_UNUSED(dev);
 
-	/* Stop the watchdog counter with INTEN bit */
-	wdog->ctrl = ~(CMSDK_APB_WDOG_CTRL_RESEN | CMSDK_APB_WDOG_CTRL_INTEN);
+	/* Stop the watchdog counter by clearing RESEN and INTEN */
+	wdog->ctrl &= ~(CMSDK_APB_WDOG_CTRL_RESEN | CMSDK_APB_WDOG_CTRL_INTEN);
 
 	enabled = false;
 	assigned_channels = 0;

--- a/drivers/watchdog/wdt_rts5912.c
+++ b/drivers/watchdog/wdt_rts5912.c
@@ -121,7 +121,7 @@ static int wdt_rts5912_install_timeout(const struct device *dev,
 	uint32_t timeout;
 	uint32_t max, min;
 
-	LOG_DBG("WDT intstall timeout");
+	LOG_DBG("WDT install timeout");
 
 	if (wdt_reg->CTRL & WDT_CTRL_EN) {
 		LOG_ERR("WDT is already running");


### PR DESCRIPTION
## Summary
- fix wdt_cmsdk_apb disable logic by clearing RESEN and INTEN bits
- fix typo in wdt_rts5912 debug message

## Testing
- `./scripts/checkpatch.pl -f drivers/watchdog/wdt_cmsdk_apb.c drivers/watchdog/wdt_rts5912.c | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684d84fa679c83218eabff8ef86aeb6f