### PR TITLE
Fix CMSDK watchdog disable register write

### DIFF
--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -107,17 +107,17 @@ static int wdog_cmsdk_apb_setup(const struct device *dev, uint8_t options)
 
 static int wdog_cmsdk_apb_disable(const struct device *dev)
 {
-	volatile struct wdog_cmsdk_apb *wdog = WDOG_STRUCT;
+       volatile struct wdog_cmsdk_apb *wdog = WDOG_STRUCT;
 
-	ARG_UNUSED(dev);
+       ARG_UNUSED(dev);
 
-	/* Stop the watchdog counter with INTEN bit */
-	wdog->ctrl = ~(CMSDK_APB_WDOG_CTRL_RESEN | CMSDK_APB_WDOG_CTRL_INTEN);
+       /* Stop the watchdog counter by clearing RESEN and INTEN bits */
+       wdog->ctrl &= ~(CMSDK_APB_WDOG_CTRL_RESEN | CMSDK_APB_WDOG_CTRL_INTEN);
 
-	enabled = false;
-	assigned_channels = 0;
+       enabled = false;
+       assigned_channels = 0;
 
-	return 0;
+       return 0;
 }
 
 static int wdog_cmsdk_apb_install_timeout(const struct device *dev,


### PR DESCRIPTION
## Summary
- fix clearing RESEN and INTEN bits when disabling CMSDK APB watchdog

## Testing
- `./scripts/checkpatch.pl -q --git HEAD~1..HEAD`

------
https://chatgpt.com/codex/tasks/task_e_684d84fa679c83218eabff8ef86aeb6f