### PR TITLE
Fix watchdog driver issues

### DIFF
--- a/drivers/watchdog/wdt_andes_atcwdt200.c
+++ b/drivers/watchdog/wdt_andes_atcwdt200.c
@@ -246,12 +246,12 @@ static int wdt_atcwdt200_install_timeout(const struct device *dev,
 	}
 
 	counter_freq = counter_get_frequency(pit_counter_dev);
-	rst_period = wdt_atcwdt200_convtime(cfg->window.max, &scaler);
+       rst_period = wdt_atcwdt200_convtime(cfg->window.max, &scaler);
 
-	if (rst_period < 0 || WDOGCFG_PERIOD_MAX < rst_period) {
-		LOG_ERR("Unsupported watchdog timeout\n");
-		return -EINVAL;
-	}
+       if (rst_period == 0 || WDOGCFG_PERIOD_MAX < rst_period) {
+               LOG_ERR("Unsupported watchdog timeout\n");
+               return -EINVAL;
+       }
 
 	wdt_atcwdt200_disable(dev);
 

--- a/drivers/watchdog/wdt_dw.h
+++ b/drivers/watchdog/wdt_dw.h
@@ -403,9 +403,9 @@ static inline void dw_wdt_timeout_period_init_set(const uint32_t base,
 static inline uint32_t dw_wdt_current_counter_value_register_get(const uint32_t base,
 								 uint32_t wdt_counter_width)
 {
-	uint32_t current_counter_value = sys_read32(base + WDT_CCVR);
+       uint32_t current_counter_value = sys_read32(base + WDT_CCVR);
 
-	current_counter_value &= (1 << (wdt_counter_width - 1));
+       current_counter_value &= BIT_MASK(wdt_counter_width);
 	return current_counter_value;
 }
 


### PR DESCRIPTION
## Summary
- fix timeout check in Andes ATCWDt200 driver
- mask counter value properly in DesignWare driver

## Testing
- `west build -b native_sim samples/hello_world` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d84fa679c83218eabff8ef86aeb6f