### PR TITLE
Fix comparator driver issues

### DIFF
--- a/drivers/comparator/comparator_nrf_lpcomp.c
+++ b/drivers/comparator/comparator_nrf_lpcomp.c
@@ -103,9 +103,7 @@ static void shim_nrf_lpcomp_stop(void)
 
 static int shim_nrf_lpcomp_pm_callback(const struct device *dev, enum pm_device_action action)
 {
-	ARG_UNUSED(dev);
-
-	ARG_UNUSED(dev);
+       ARG_UNUSED(dev);
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:

--- a/drivers/comparator/comparator_renesas_ra.c
+++ b/drivers/comparator/comparator_renesas_ra.c
@@ -171,11 +171,11 @@ static int acmphs_renesas_ra_init(const struct device *dev)
 		return -EIO;
 	}
 
-	/*
-	 * Once the analog comparator is configurate, the program must wait
-	 * for the ACMPHS stabilization time (300ns enabling + 200ns input switching)
-	 * before using the comparator.
-	 */
+       /*
+        * Once the analog comparator is configured, the program must wait
+         * for the ACMPHS stabilization time (300ns enabling + 200ns input switching)
+         * before using the comparator.
+         */
 	k_usleep(5);
 
 	fsp_err = R_ACMPHS_OutputEnable(&data->acmphs);

--- a/drivers/comparator/comparator_silabs_acmp.c
+++ b/drivers/comparator/comparator_silabs_acmp.c
@@ -125,8 +125,8 @@ static int acmp_set_trigger(const struct device *dev, enum comparator_trigger tr
 	/* Disable ACMP trigger interrupts */
 	ACMP_IntDisable(config->base, ACMP_IEN_RISE | ACMP_IEN_FALL);
 
-	/* Clear ACMP trigger interrupt flags */
-	ACMP_IntClear(config->base, ACMP_IEN_RISE | ACMP_IEN_FALL);
+       /* Clear ACMP trigger interrupt flags */
+       ACMP_IntClear(config->base, ACMP_IF_RISE | ACMP_IF_FALL);
 
 	switch (trigger) {
 	case COMPARATOR_TRIGGER_BOTH_EDGES:
@@ -184,8 +184,8 @@ static int acmp_trigger_is_pending(const struct device *dev)
 	const struct acmp_config *config = dev->config;
 	const struct acmp_data *data = dev->data;
 
-	if (ACMP_IntGet(config->base) & data->interrupt_mask) {
-		ACMP_IntClear(config->base, data->interrupt_mask);
+       if (ACMP_IntGet(config->base) & data->interrupt_mask) {
+               ACMP_IntClear(config->base, data->interrupt_mask);
 		return 1;
 	}
 


### PR DESCRIPTION
## Summary
- use correct interrupt flag bits in Silicon Labs ACMP driver
- remove duplicate `ARG_UNUSED` call in Nordic LPCOMP driver
- fix typo in Renesas RA comparator driver documentation

## Testing
- `./scripts/checkpatch.pl --no-tree -q drivers/comparator/comparator_silabs_acmp.c drivers/comparator/comparator_nrf_lpcomp.c drivers/comparator/comparator_renesas_ra.c | head`

------
https://chatgpt.com/codex/tasks/task_e_684da001eed4832192ec8c9614c8ed78