### PR TITLE
Fix littlefs lookahead buffer definition

### DIFF
--- a/include/zephyr/fs/littlefs.h
+++ b/include/zephyr/fs/littlefs.h
@@ -47,7 +47,7 @@ struct fs_littlefs {
 	/* Must be cfg.lookahead_size/4 elements, and
 	 * cfg.lookahead_size must be a multiple of 8.
 	 */
-	uint32_t *lookahead_buffer[CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE / sizeof(uint32_t)];
+       uint32_t lookahead_buffer[CONFIG_FS_LITTLEFS_LOOKAHEAD_SIZE / sizeof(uint32_t)];
 
 	/* These structures are filled automatically at mount. */
 	struct lfs lfs;


### PR DESCRIPTION
## Summary
- fix the `lookahead_buffer` definition in `fs_littlefs`

## Testing
- `scripts/twister -T tests/subsys/fs/littlefs -p native_sim -vv` *(fails: bits/libc-header-start.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684db13ce5308321bb7e1f998e5276c2