### PR TITLE
Fix GNSS driver handling

### DIFF
--- a/drivers/gnss/gnss_luatos_air530z.c
+++ b/drivers/gnss/gnss_luatos_air530z.c
@@ -277,10 +277,14 @@ static int luatos_air530z_set_fix_rate(const struct device *dev, uint32_t fix_in
 
 	luatos_air530z_lock(dev);
 
-	ret = gnss_nmea0183_snprintk(data->dynamic_request_buf, sizeof(data->dynamic_request_buf),
-				    "PCAS02,%u", fix_interval_ms);
+       ret = gnss_nmea0183_snprintk(data->dynamic_request_buf,
+                                   sizeof(data->dynamic_request_buf),
+                                   "PCAS02,%u", fix_interval_ms);
+       if (ret < 0) {
+               goto unlock_return;
+       }
 
-	data->dynamic_script_chat.request_size = ret;
+       data->dynamic_script_chat.request_size = ret;
 
 	ret = modem_chat_run_script(&data->chat, &data->dynamic_script);
 	if (ret < 0) {

--- a/drivers/gnss/gnss_quectel_lcx6g.c
+++ b/drivers/gnss/gnss_quectel_lcx6g.c
@@ -397,11 +397,11 @@ static int quectel_lcx6g_get_fix_rate(const struct device *dev, uint32_t *fix_in
 		goto unlock_return;
 	}
 
-	*fix_interval_ms = data->fix_rate_response;
+       *fix_interval_ms = data->fix_rate_response;
 
 unlock_return:
-	quectel_lcx6g_unlock(dev);
-	return 0;
+       quectel_lcx6g_unlock(dev);
+       return ret;
 }
 
 static int quectel_lcx6g_set_navigation_mode(const struct device *dev,


### PR DESCRIPTION
## Summary
- fix error handling in quectel LCx6G get_fix_rate
- validate snprintf return in luatos AIR530Z driver

## Testing
- `./scripts/twister -T tests/drivers/gnss -p native_sim -j1` *(fails: Build failure - bits/libc-header-start.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_684db13033d48321a3a64c2229024866