### PR TITLE
Fix mutex leak in ublox m8 GNSS driver

### DIFF
--- a/drivers/gnss/gnss_u_blox_m8.c
+++ b/drivers/gnss/gnss_u_blox_m8.c
@@ -124,16 +124,18 @@ static int ubx_m8_msg_get(const struct device *dev, const struct ubx_frame *req,
 	data->script.inst.request.buf = req;
 	data->script.inst.request.len = len;
 
-	err = modem_ubx_run_script(&data->ubx.inst, &data->script.inst);
-	if (err != 0 || (data->script.inst.response.buf_len < UBX_FRAME_SZ(min_rsp_size))) {
-		return -EIO;
-	}
+       err = modem_ubx_run_script(&data->ubx.inst, &data->script.inst);
+       if (err != 0 ||
+           (data->script.inst.response.buf_len < UBX_FRAME_SZ(min_rsp_size))) {
+               (void)k_mutex_unlock(&data->script.lock);
+               return -EIO;
+       }
 
-	memcpy(rsp, rsp_frame->payload_and_checksum, min_rsp_size);
+       memcpy(rsp, rsp_frame->payload_and_checksum, min_rsp_size);
 
-	(void)k_mutex_unlock(&data->script.lock);
+       (void)k_mutex_unlock(&data->script.lock);
 
-	return 0;
+       return 0;
 }
 
 static int ubx_m8_msg_send(const struct device *dev, const struct ubx_frame *req,


### PR DESCRIPTION
## Summary
- fix missing mutex unlock in `ubx_m8_msg_get`

## Testing
- `west build -b native_posix samples/hello_world` *(fails: `west: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684db13033d48321a3a64c2229024866