### PR TITLE
Fix dwc2 W1C register handling

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1907,8 +1907,8 @@ static int dwc2_core_soft_reset(const struct device *dev)
 	} while (sys_read32(grstctl_reg) & USB_DWC2_GRSTCTL_CSFTRST &&
 		 !(sys_read32(grstctl_reg) & USB_DWC2_GRSTCTL_CSFTRSTDONE));
 
-	/* CSFTRSTDONE is W1C so the write must have the bit set to clear it */
-	sys_clear_bits(grstctl_reg, USB_DWC2_GRSTCTL_CSFTRST);
+       /* CSFTRSTDONE is W1C so write 1 to clear it */
+       sys_write32(USB_DWC2_GRSTCTL_CSFTRSTDONE, grstctl_reg);
 
 	return 0;
 }


### PR DESCRIPTION
## Summary
- correct clearing of CSFTRSTDONE register in dwc2 driver

## Testing
- `./scripts/twister -T tests/drivers/usb/bc12 -p qemu_x86 --inline-logs --jobs 1`

------
https://chatgpt.com/codex/tasks/task_e_684d9fb834dc8321b0ffe2fbfceb4ad4