### PR TITLE
doc: add doxylink extension for Doxygen-to-Sphinx cross-referencing

### DIFF
--- a/doc/_extensions/zephyr/doxylink.py
+++ b/doc/_extensions/zephyr/doxylink.py
@@ -1,0 +1,332 @@
+"""
+Doxylink Sphinx Extension
+#########################
+
+Copyright (c) 2025 The Linux Foundation
+SPDX-License-Identifier: Apache-2.0
+
+Introduction
+============
+
+This Sphinx extension generates Doxygen-compatible tagfiles from Sphinx
+``objects.inv`` inventory files. This enables cross-referencing from Doxygen
+API documentation to Sphinx narrative documentation using standard Doxygen
+``@ref`` syntax.
+
+The extension runs during the ``builder-inited`` phase, before
+:py:mod:`zephyr.doxyrunner` executes Doxygen, ensuring the tagfile is
+available when Doxygen processes its input.
+
+Usage in Doxygen comments
+=========================
+
+Using ``@ref`` with labels from the Sphinx inventory::
+
+    /**
+     * See @ref getting_started for setup instructions.
+     * See also @ref bluetooth_overview "Bluetooth Overview".
+     */
+
+Using ``\\sphinxref`` alias for direct links (supports anchors)::
+
+    /**
+     * \\sphinxref{develop/getting_started/index.html,Getting Started Guide}
+     */
+
+Configuration options
+=====================
+
+- ``doxylink_inventories``: Dictionary mapping project names to config dicts.
+  Each config dict supports:
+
+  - ``url`` (str): URL to fetch ``objects.inv`` from.
+  - ``local`` (str): Local path to ``objects.inv`` (fallback).
+  - ``tagfile`` (str): Output path for the generated Doxygen tagfile.
+
+- ``doxylink_roles`` (list[str]): Sphinx inventory roles to include.
+  Default: ``["std:doc", "std:label"]``
+"""
+
+import os
+import re
+import urllib.request
+import zlib
+from typing import Any
+from xml.etree.ElementTree import Element, ElementTree, SubElement, indent
+
+from sphinx.application import Sphinx
+from sphinx.util import logging
+
+__version__ = "0.1.0"
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ROLES = ["std:doc", "std:label"]
+
+
+def parse_inventory(data: bytes) -> list[dict]:
+    """Parse a Sphinx objects.inv version 2 file.
+
+    The inventory format consists of a 4-line text header followed by
+    zlib-compressed entry lines. Each entry has the format::
+
+        name domain:role priority uri dispname
+
+    Args:
+        data: Raw bytes of the objects.inv file.
+
+    Returns:
+        List of entry dicts with keys: name, domain, role, priority, uri,
+        dispname.
+    """
+
+    # Read the 4-line header
+    pos = 0
+    header_lines = []
+    for _ in range(4):
+        nl = data.index(b"\n", pos)
+        header_lines.append(data[pos:nl].decode("utf-8"))
+        pos = nl + 1
+
+    if "Sphinx inventory version 2" not in header_lines[0]:
+        raise ValueError(f"Unsupported inventory version: {header_lines[0]}")
+
+    # Decompress the entry data
+    decompressed = zlib.decompress(data[pos:]).decode("utf-8")
+
+    entries = []
+    entry_re = re.compile(r"(.+?)\s+(\w+):(\w+)\s+(-?\d+)\s+(\S*)\s+(.*)")
+
+    for line in decompressed.splitlines():
+        m = entry_re.match(line)
+        if not m:
+            continue
+
+        name, domain, role, priority, uri, dispname = m.groups()
+
+        if dispname == "-":
+            dispname = name
+
+        # The ``$`` placeholder in URIs is replaced with the entry name
+        uri = uri.replace("$", name)
+
+        entries.append(
+            {
+                "name": name,
+                "domain": domain,
+                "role": role,
+                "priority": int(priority),
+                "uri": uri,
+                "dispname": dispname,
+            }
+        )
+
+    return entries
+
+
+def fetch_inventory_from_url(url: str) -> bytes | None:
+    """Fetch an objects.inv file from a URL.
+
+    Args:
+        url: URL to the objects.inv file.
+
+    Returns:
+        Raw bytes of the inventory, or None on failure.
+    """
+
+    try:
+        logger.info(f"[doxylink] Fetching inventory from {url}")
+        req = urllib.request.Request(url, headers={"User-Agent": "Zephyr-Doxylink/1.0"})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.read()
+    except Exception as e:
+        logger.warning(f"[doxylink] Failed to fetch inventory from {url}: {e}")
+        return None
+
+
+def read_inventory_from_file(path: str) -> bytes | None:
+    """Read an objects.inv file from the local filesystem.
+
+    Args:
+        path: Path to the objects.inv file.
+
+    Returns:
+        Raw bytes of the inventory, or None on failure.
+    """
+
+    try:
+        with open(path, "rb") as f:
+            return f.read()
+    except Exception as e:
+        logger.warning(f"[doxylink] Failed to read inventory from {path}: {e}")
+        return None
+
+
+def sanitize_doxygen_name(name: str) -> str:
+    """Sanitize a name for use as a Doxygen page reference.
+
+    Doxygen page identifiers should be valid C-like identifiers
+    (alphanumeric characters and underscores).
+
+    Args:
+        name: Original inventory entry name.
+
+    Returns:
+        Sanitized name suitable for use with Doxygen ``@ref``.
+    """
+
+    sanitized = re.sub(r"[/\-. ]", "_", name)
+    sanitized = re.sub(r"[^a-zA-Z0-9_]", "", sanitized)
+    return sanitized
+
+
+def build_tagfile(entries: list[dict], roles: list[str]) -> tuple[Element, int]:
+    """Build a Doxygen tagfile XML tree from inventory entries.
+
+    For ``std:doc`` entries, page names are prefixed with ``doc_`` to
+    distinguish them from label-based entries. For ``std:label`` entries,
+    the RST label name is used directly (after sanitization).
+
+    Each entry becomes a ``<compound kind="page">`` element. Doxygen
+    appends ``.html`` to the ``<filename>`` for page compounds, so the
+    extension stored here should not contain ``.html``.
+
+    Args:
+        entries: Parsed inventory entries.
+        roles: List of ``"domain:role"`` strings to include.
+
+    Returns:
+        Tuple of (XML root element, count of entries written).
+    """
+
+    root = Element("tagfile", attrib={"doxygen_version": "sphinx-inventory"})
+
+    seen_names = set()
+    count = 0
+
+    for entry in entries:
+        domain_role = f"{entry['domain']}:{entry['role']}"
+        if domain_role not in roles:
+            continue
+
+        # Skip hidden entries (negative priority)
+        if entry["priority"] < 0:
+            continue
+
+        # Generate the Doxygen reference name
+        if domain_role == "std:doc":
+            ref_name = "doc_" + sanitize_doxygen_name(entry["name"])
+        else:
+            ref_name = sanitize_doxygen_name(entry["name"])
+
+        if ref_name in seen_names:
+            continue
+        seen_names.add(ref_name)
+
+        # Extract the base page URI (strip fragment and .html)
+        uri = entry["uri"]
+        if "#" in uri:
+            page_uri = uri.split("#")[0]
+        else:
+            page_uri = uri
+
+        # Doxygen appends .html for page compounds, so strip it here
+        if page_uri.endswith(".html"):
+            page_uri = page_uri[:-5]
+        page_uri = page_uri.rstrip("/")
+
+        if not page_uri:
+            continue
+
+        compound = SubElement(root, "compound", kind="page")
+        SubElement(compound, "name").text = ref_name
+        SubElement(compound, "title").text = entry["dispname"]
+        SubElement(compound, "filename").text = page_uri
+        count += 1
+
+    return root, count
+
+
+def write_tagfile(root: Element, path: str) -> None:
+    """Write a Doxygen tagfile XML tree to disk.
+
+    Creates parent directories as needed.
+
+    Args:
+        root: XML root element.
+        path: Output file path.
+    """
+
+    tree = ElementTree(root)
+    indent(tree, space="  ")
+
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    tree.write(path, encoding="unicode", xml_declaration=True)
+
+
+def generate_tagfiles(app: Sphinx) -> None:
+    """Process configured inventories and generate Doxygen tagfiles.
+
+    This callback runs during ``builder-inited`` with a low priority number
+    (high priority in execution order) to ensure it completes before
+    :py:mod:`zephyr.doxyrunner` launches Doxygen.
+    """
+
+    inventories = app.config.doxylink_inventories
+    if not inventories:
+        return
+
+    roles = app.config.doxylink_roles or DEFAULT_ROLES
+
+    for name, config in inventories.items():
+        tagfile_path = config.get("tagfile")
+        if not tagfile_path:
+            logger.warning(f"[doxylink] No tagfile path for project '{name}', skipping")
+            continue
+
+        # Try to obtain inventory data from configured sources
+        data = None
+
+        url = config.get("url")
+        if url:
+            data = fetch_inventory_from_url(url)
+
+        if data is None:
+            local = config.get("local")
+            if local:
+                data = read_inventory_from_file(local)
+
+        if data is None:
+            logger.warning(
+                f"[doxylink] Could not obtain inventory for '{name}', "
+                f"writing empty tagfile at {tagfile_path}"
+            )
+            write_tagfile(Element("tagfile"), tagfile_path)
+            continue
+
+        try:
+            entries = parse_inventory(data)
+            root, count = build_tagfile(entries, roles)
+            write_tagfile(root, tagfile_path)
+            logger.info(
+                f"[doxylink] Generated tagfile for '{name}' with {count} entries "
+                f"at {tagfile_path}"
+            )
+        except Exception as e:
+            logger.warning(f"[doxylink] Failed to process inventory for '{name}': {e}")
+            # Write empty tagfile so Doxygen does not fail
+            write_tagfile(Element("tagfile"), tagfile_path)
+
+
+def setup(app: Sphinx) -> dict[str, Any]:
+    app.add_config_value("doxylink_inventories", {}, "env")
+    app.add_config_value("doxylink_roles", DEFAULT_ROLES, "env")
+
+    # Use low priority number to run before doxyrunner (default priority 500)
+    app.connect("builder-inited", generate_tagfiles, priority=100)
+
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/_extensions/zephyr/tests/test_doxylink.py
+++ b/doc/_extensions/zephyr/tests/test_doxylink.py
@@ -1,0 +1,319 @@
+# Copyright (c) 2025 The Linux Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the doxylink Sphinx extension."""
+
+import os
+import tempfile
+import zlib
+from xml.etree.ElementTree import parse as ET_parse
+
+import pytest
+
+# Ensure the extensions directory is importable
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from doxylink import (
+    build_tagfile,
+    parse_inventory,
+    sanitize_doxygen_name,
+    write_tagfile,
+)
+
+
+def _make_inventory(entries_text: str) -> bytes:
+    """Create a minimal Sphinx objects.inv v2 from entry text lines."""
+    header = (
+        b"# Sphinx inventory version 2\n"
+        b"# Project: TestProject\n"
+        b"# Version: 1.0\n"
+        b"# The remainder of this file is compressed using zlib.\n"
+    )
+    compressed = zlib.compress(entries_text.encode("utf-8"))
+    return header + compressed
+
+
+class TestParseInventory:
+    """Tests for the objects.inv parser."""
+
+    def test_basic_doc_entry(self):
+        data = _make_inventory(
+            "develop/getting_started/index std:doc 1 develop/getting_started/index.html Getting Started\n"
+        )
+        entries = parse_inventory(data)
+        assert len(entries) == 1
+        assert entries[0]["name"] == "develop/getting_started/index"
+        assert entries[0]["domain"] == "std"
+        assert entries[0]["role"] == "doc"
+        assert entries[0]["priority"] == 1
+        assert entries[0]["uri"] == "develop/getting_started/index.html"
+        assert entries[0]["dispname"] == "Getting Started"
+
+    def test_basic_label_entry(self):
+        data = _make_inventory(
+            "getting_started std:label 1 develop/getting_started/index.html#getting-started Getting Started Guide\n"
+        )
+        entries = parse_inventory(data)
+        assert len(entries) == 1
+        assert entries[0]["name"] == "getting_started"
+        assert entries[0]["uri"] == "develop/getting_started/index.html#getting-started"
+        assert entries[0]["dispname"] == "Getting Started Guide"
+
+    def test_dollar_replacement(self):
+        data = _make_inventory("mypage std:doc 1 $.html -\n")
+        entries = parse_inventory(data)
+        assert entries[0]["uri"] == "mypage.html"
+        assert entries[0]["dispname"] == "mypage"
+
+    def test_dash_dispname(self):
+        data = _make_inventory("some_label std:label 2 page.html#anchor -\n")
+        entries = parse_inventory(data)
+        assert entries[0]["dispname"] == "some_label"
+
+    def test_hidden_entry(self):
+        data = _make_inventory("hidden std:label -1 page.html#x Hidden Entry\n")
+        entries = parse_inventory(data)
+        assert len(entries) == 1
+        assert entries[0]["priority"] == -1
+
+    def test_multiple_entries(self):
+        data = _make_inventory(
+            "page1 std:doc 1 page1.html Page One\n"
+            "page2 std:doc 1 page2.html Page Two\n"
+            "label1 std:label 2 page1.html#s1 Label One\n"
+            "some_func c:function 1 api.html#c.some_func some_func\n"
+        )
+        entries = parse_inventory(data)
+        assert len(entries) == 4
+
+    def test_invalid_version(self):
+        data = b"# Sphinx inventory version 1\n# Project: X\n# Version: 1\n# zlib\n"
+        data += zlib.compress(b"")
+        with pytest.raises(ValueError, match="Unsupported inventory version"):
+            parse_inventory(data)
+
+    def test_empty_entries(self):
+        data = _make_inventory("")
+        entries = parse_inventory(data)
+        assert len(entries) == 0
+
+
+class TestSanitizeName:
+    """Tests for the name sanitization function."""
+
+    def test_simple_name(self):
+        assert sanitize_doxygen_name("getting_started") == "getting_started"
+
+    def test_hyphens(self):
+        assert sanitize_doxygen_name("my-label") == "my_label"
+
+    def test_slashes(self):
+        assert sanitize_doxygen_name("develop/getting_started/index") == "develop_getting_started_index"
+
+    def test_dots(self):
+        assert sanitize_doxygen_name("config.option") == "config_option"
+
+    def test_special_chars(self):
+        assert sanitize_doxygen_name("label@#$%") == "label"
+
+    def test_spaces(self):
+        assert sanitize_doxygen_name("some label") == "some_label"
+
+
+class TestBuildTagfile:
+    """Tests for tagfile generation."""
+
+    def test_doc_entries(self):
+        entries = [
+            {
+                "name": "develop/getting_started/index",
+                "domain": "std",
+                "role": "doc",
+                "priority": 1,
+                "uri": "develop/getting_started/index.html",
+                "dispname": "Getting Started",
+            }
+        ]
+        root, count = build_tagfile(entries, ["std:doc"])
+        assert count == 1
+
+        compounds = root.findall("compound")
+        assert len(compounds) == 1
+        assert compounds[0].get("kind") == "page"
+        assert compounds[0].find("name").text == "doc_develop_getting_started_index"
+        assert compounds[0].find("title").text == "Getting Started"
+        assert compounds[0].find("filename").text == "develop/getting_started/index"
+
+    def test_label_entries(self):
+        entries = [
+            {
+                "name": "getting_started",
+                "domain": "std",
+                "role": "label",
+                "priority": 1,
+                "uri": "develop/getting_started/index.html#getting-started",
+                "dispname": "Getting Started Guide",
+            }
+        ]
+        root, count = build_tagfile(entries, ["std:label"])
+        assert count == 1
+
+        compounds = root.findall("compound")
+        assert compounds[0].find("name").text == "getting_started"
+        assert compounds[0].find("title").text == "Getting Started Guide"
+        # Fragment is stripped, .html is stripped (Doxygen adds it back)
+        assert compounds[0].find("filename").text == "develop/getting_started/index"
+
+    def test_hidden_entries_skipped(self):
+        entries = [
+            {
+                "name": "hidden",
+                "domain": "std",
+                "role": "label",
+                "priority": -1,
+                "uri": "page.html#x",
+                "dispname": "Hidden",
+            }
+        ]
+        root, count = build_tagfile(entries, ["std:label"])
+        assert count == 0
+
+    def test_non_matching_roles_skipped(self):
+        entries = [
+            {
+                "name": "some_func",
+                "domain": "c",
+                "role": "function",
+                "priority": 1,
+                "uri": "api.html#c.some_func",
+                "dispname": "some_func",
+            }
+        ]
+        root, count = build_tagfile(entries, ["std:doc", "std:label"])
+        assert count == 0
+
+    def test_duplicate_names_deduplicated(self):
+        entries = [
+            {
+                "name": "intro",
+                "domain": "std",
+                "role": "label",
+                "priority": 1,
+                "uri": "page1.html#intro",
+                "dispname": "Introduction",
+            },
+            {
+                "name": "intro",
+                "domain": "std",
+                "role": "label",
+                "priority": 2,
+                "uri": "page2.html#intro",
+                "dispname": "Another Intro",
+            },
+        ]
+        root, count = build_tagfile(entries, ["std:label"])
+        assert count == 1
+
+    def test_mixed_roles(self):
+        entries = [
+            {
+                "name": "index",
+                "domain": "std",
+                "role": "doc",
+                "priority": 1,
+                "uri": "index.html",
+                "dispname": "Home",
+            },
+            {
+                "name": "getting_started",
+                "domain": "std",
+                "role": "label",
+                "priority": 1,
+                "uri": "start.html#getting-started",
+                "dispname": "Getting Started",
+            },
+        ]
+        root, count = build_tagfile(entries, ["std:doc", "std:label"])
+        assert count == 2
+
+
+class TestWriteTagfile:
+    """Tests for tagfile writing."""
+
+    def test_write_and_read(self):
+        entries = [
+            {
+                "name": "test_page",
+                "domain": "std",
+                "role": "label",
+                "priority": 1,
+                "uri": "test/page.html#section",
+                "dispname": "Test Page",
+            }
+        ]
+        root, count = build_tagfile(entries, ["std:label"])
+        assert count == 1
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tagfile_path = os.path.join(tmpdir, "subdir", "test.tag")
+            write_tagfile(root, tagfile_path)
+
+            assert os.path.exists(tagfile_path)
+
+            tree = ET_parse(tagfile_path)
+            tag_root = tree.getroot()
+            assert tag_root.tag == "tagfile"
+
+            compounds = tag_root.findall("compound")
+            assert len(compounds) == 1
+            assert compounds[0].find("name").text == "test_page"
+            assert compounds[0].find("filename").text == "test/page"
+
+    def test_write_empty_tagfile(self):
+        from xml.etree.ElementTree import Element
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tagfile_path = os.path.join(tmpdir, "empty.tag")
+            write_tagfile(Element("tagfile"), tagfile_path)
+
+            assert os.path.exists(tagfile_path)
+
+            tree = ET_parse(tagfile_path)
+            assert tree.getroot().tag == "tagfile"
+            assert len(tree.getroot().findall("compound")) == 0
+
+
+class TestEndToEnd:
+    """End-to-end tests combining parsing and tagfile generation."""
+
+    def test_full_pipeline(self):
+        inv_data = _make_inventory(
+            "develop/getting_started/index std:doc 1 "
+            "develop/getting_started/index.html Getting Started\n"
+            "getting_started std:label 1 "
+            "develop/getting_started/index.html#getting-started Getting Started Guide\n"
+            "bluetooth_overview std:label 1 "
+            "connectivity/bluetooth/overview.html#bluetooth-overview Bluetooth Overview\n"
+            "hidden_thing std:label -1 hidden.html#x Hidden\n"
+            "k_thread_create c:function 1 api.html#c.k_thread_create k_thread_create\n"
+        )
+
+        entries = parse_inventory(inv_data)
+        assert len(entries) == 5
+
+        root, count = build_tagfile(entries, ["std:doc", "std:label"])
+        assert count == 3  # 1 doc + 2 labels (hidden skipped, c:function skipped)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tagfile_path = os.path.join(tmpdir, "test.tag")
+            write_tagfile(root, tagfile_path)
+
+            tree = ET_parse(tagfile_path)
+            compounds = tree.getroot().findall("compound")
+            assert len(compounds) == 3
+
+            names = {c.find("name").text for c in compounds}
+            assert "doc_develop_getting_started_index" in names
+            assert "getting_started" in names
+            assert "bluetooth_overview" in names

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -84,6 +84,7 @@ extensions = [
     "zephyr.link-roles",
     "sphinx_tabs.tabs",
     "sphinx_sitemap",
+    "zephyr.doxylink",
     "zephyr.doxyrunner",
     "zephyr.doxybridge",
     "zephyr.doxytooltip",
@@ -257,6 +258,18 @@ latex_documents = [
 ]
 latex_engine = "xelatex"
 
+# -- Options for zephyr.doxylink plugin -----------------------------------
+
+_doxylink_tagfile = str(ZEPHYR_BUILD / "doxylink" / "sphinx_docs.tag")
+
+doxylink_inventories = {
+    "zephyr": {
+        "url": "https://docs.zephyrproject.org/latest/objects.inv",
+        "local": str(ZEPHYR_BUILD / "html" / "objects.inv"),
+        "tagfile": _doxylink_tagfile,
+    },
+}
+
 # -- Options for zephyr.doxyrunner plugin ---------------------------------
 
 doxyrunner_doxygen = os.environ.get("DOXYGEN_EXECUTABLE", "doxygen")
@@ -268,6 +281,7 @@ doxyrunner_projects = {
         "fmt_vars": {
             "ZEPHYR_BASE": str(ZEPHYR_BASE),
             "ZEPHYR_VERSION": version,
+            "DOXYLINK_TAGFILE": _doxylink_tagfile,
         },
         "outdir_var": "DOXY_OUT",
     },

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -300,7 +300,8 @@ ALIASES                = "kconfig{1}=\c \1" \
                          "pre_kernel_ok=\qualifier pre-kernel-ok" \
                          "async=\qualifier async" \
                          "atomic_api=As for all atomic APIs, includes a full/sequentially-consistent memory barrier (where applicable)." \
-                         "supervisor=\qualifier supervisor"
+                         "supervisor=\qualifier supervisor" \
+                         "sphinxref{2}=<a href=\"../../\1\">\2</a>"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -2613,7 +2614,7 @@ SKIP_FUNCTION_MACROS   = NO
 # the path). If a tag file is not located in the directory in which Doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               =
+TAGFILES               = @DOXYLINK_TAGFILE@=../../
 
 # When a file name is specified after GENERATE_TAGFILE, Doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to


### PR DESCRIPTION
Add a new Sphinx extension (zephyr.doxylink) that enables linking from
Doxygen API documentation to Sphinx narrative documentation pages.

The extension works by parsing Sphinx objects.inv inventory files and
generating Doxygen-compatible tagfiles. This enables two complementary
linking mechanisms:

1. Tagfile-based @ref links: The extension fetches the Sphinx inventory
   (from the published docs URL or a previous local build), parses it,
   and generates a Doxygen tagfile. This allows standard @ref syntax in
   Doxygen comments, e.g. @ref getting_started "Getting Started Guide".

2. Direct \sphinxref alias: A new Doxygen alias for direct HTML links
   to specific pages with anchor support, e.g.
   \sphinxref{develop/getting_started/index.html,Getting Started}.

The extension runs before doxyrunner in the build pipeline (priority 100
vs default 500) to ensure the tagfile is ready when Doxygen processes
its input. It gracefully degrades: if the inventory cannot be fetched,
an empty tagfile is written so the Doxygen build does not fail.

Inventory sources are tried in order:
- Remote URL (https://docs.zephyrproject.org/latest/objects.inv)
- Local file from previous build (build/html/objects.inv)
- Empty fallback

Signed-off-by: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01VtttQBLnbkifzhVnJJ3Fut