### PR TITLE
cmake: optimize CMake module performance for faster configuration

### DIFF
--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -199,9 +199,9 @@ if(NOT "${ret_board}" STREQUAL "")
   list(GET LIST_BOARD_DIR 0 BOARD_DIR)
   set(BOARD_DIR ${BOARD_DIR} CACHE PATH "Main board directory for board (${BOARD})" FORCE)
   set(BOARD_DIRECTORIES ${LIST_BOARD_DIR} CACHE INTERNAL "List of board directories for board (${BOARD})" FORCE)
-  foreach(dir ${BOARD_DIRECTORIES})
-    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${dir}/board.yml)
-  endforeach()
+  # Batch set_property with all board.yml paths instead of per-directory calls.
+  list(TRANSFORM BOARD_DIRECTORIES APPEND "/board.yml" OUTPUT_VARIABLE board_yml_files)
+  set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${board_yml_files})
 
   # Create two CMake variables identifying the hw model.
   # CMake variable: HWM=v2

--- a/cmake/modules/zephyr_module.cmake
+++ b/cmake/modules/zephyr_module.cmake
@@ -77,11 +77,11 @@ if(WEST OR ZEPHYR_MODULES)
     file(STRINGS ${zephyr_settings_file} zephyr_settings_txt ENCODING UTF-8 REGEX "^[^#]")
     foreach(setting ${zephyr_settings_txt})
       # Match <key>:<value> for each line of file, each corresponding to
-      # a setting.  The use of quotes is required due to CMake not supporting
-      # lazy regexes (it supports greedy only).
-      string(REGEX REPLACE "\"(.*)\":\".*\"" "\\1" key ${setting})
-      string(REGEX REPLACE "\".*\":\"(.*)\"" "\\1" value ${setting})
-      list(APPEND ${key} ${value})
+      # a setting. Use [^"]* (non-quote match) instead of .* with separate
+      # REGEX REPLACE calls, extracting both groups in a single match.
+      if(setting MATCHES "\"([^\"]*)\":\"([^\"]*)\"")
+        list(APPEND ${CMAKE_MATCH_1} ${CMAKE_MATCH_2})
+      endif()
     endforeach()
   endif()
 
@@ -91,11 +91,10 @@ if(WEST OR ZEPHYR_MODULES)
 
   set(ZEPHYR_MODULE_NAMES)
   foreach(module ${zephyr_modules_txt})
-    # Match "<name>":"<path>" for each line of file, each corresponding to
-    # one module. The use of quotes is required due to CMake not supporting
-    # lazy regexes (it supports greedy only).
-    string(REGEX REPLACE "\"(.*)\":\".*\":\".*\"" "\\1" module_name ${module})
-    list(APPEND ZEPHYR_MODULE_NAMES ${module_name})
+    # Extract module name using non-quote character class for efficient matching.
+    if(module MATCHES "\"([^\"]*)\":")
+      list(APPEND ZEPHYR_MODULE_NAMES ${CMAKE_MATCH_1})
+    endif()
   endforeach()
 
   if(EXISTS ${cmake_sysbuild_file})
@@ -104,11 +103,10 @@ if(WEST OR ZEPHYR_MODULES)
 
   set(SYSBUILD_MODULE_NAMES)
   foreach(module ${sysbuild_modules_txt})
-    # Match "<name>":"<path>" for each line of file, each corresponding to
-    # one module. The use of quotes is required due to CMake not supporting
-    # lazy regexes (it supports greedy only).
-    string(REGEX REPLACE "\"(.*)\":\".*\":\".*\"" "\\1" module_name ${module})
-    list(APPEND SYSBUILD_MODULE_NAMES ${module_name})
+    # Extract module name using non-quote character class for efficient matching.
+    if(module MATCHES "\"([^\"]*)\":")
+      list(APPEND SYSBUILD_MODULE_NAMES ${CMAKE_MATCH_1})
+    endif()
   endforeach()
 
   # Prepend ZEPHYR_BASE as a default ext root at lowest priority
@@ -127,13 +125,15 @@ if(WEST OR ZEPHYR_MODULES)
   endforeach()
 
   foreach(module ${zephyr_modules_txt})
-    # Match "<name>":"<path>" for each line of file, each corresponding to
-    # one Zephyr module. The use of quotes is required due to CMake not
-    # supporting lazy regexes (it supports greedy only).
+    # Extract all three fields in a single regex match using non-quote
+    # character classes, instead of three separate REGEX REPLACE calls.
     string(CONFIGURE ${module} module)
-    string(REGEX REPLACE "\"(.*)\":\".*\":\".*\"" "\\1" module_name ${module})
-    string(REGEX REPLACE "\".*\":\"(.*)\":\".*\"" "\\1" module_path ${module})
-    string(REGEX REPLACE "\".*\":\".*\":\"(.*)\"" "\\1" cmake_path ${module})
+    if(NOT module MATCHES "\"([^\"]*)\":\"([^\"]*)\":\"([^\"]*)\"")
+      continue()
+    endif()
+    set(module_name ${CMAKE_MATCH_1})
+    set(module_path ${CMAKE_MATCH_2})
+    set(cmake_path ${CMAKE_MATCH_3})
 
     zephyr_string(SANITIZE TOUPPER MODULE_NAME_UPPER ${module_name})
     if(NOT ${MODULE_NAME_UPPER} STREQUAL CURRENT)
@@ -148,13 +148,15 @@ ${MODULE_NAME_UPPER} is a restricted name for Zephyr modules as it is used for \
   endforeach()
 
   foreach(module ${sysbuild_modules_txt})
-    # Match "<name>":"<path>" for each line of file, each corresponding to
-    # one Zephyr module. The use of quotes is required due to CMake not
-    # supporting lazy regexes (it supports greedy only).
+    # Extract all three fields in a single regex match using non-quote
+    # character classes, instead of three separate REGEX REPLACE calls.
     string(CONFIGURE ${module} module)
-    string(REGEX REPLACE "\"(.*)\":\".*\":\".*\"" "\\1" module_name ${module})
-    string(REGEX REPLACE "\".*\":\"(.*)\":\".*\"" "\\1" module_path ${module})
-    string(REGEX REPLACE "\".*\":\".*\":\"(.*)\"" "\\1" cmake_path ${module})
+    if(NOT module MATCHES "\"([^\"]*)\":\"([^\"]*)\":\"([^\"]*)\"")
+      continue()
+    endif()
+    set(module_name ${CMAKE_MATCH_1})
+    set(module_path ${CMAKE_MATCH_2})
+    set(cmake_path ${CMAKE_MATCH_3})
 
     zephyr_string(SANITIZE TOUPPER MODULE_NAME_UPPER ${module_name})
     if(NOT ${MODULE_NAME_UPPER} STREQUAL CURRENT)


### PR DESCRIPTION
Key optimizations:

1. kconfig.cmake: Skip MD5 recomputation of all Kconfig source files
   when configuration hasn't changed (CREATE_NEW_DOTCONFIG=0). The
   checksum is only needed when writing the checksum file, so move
   the expensive MD5 loop inside the conditional block. This avoids
   reading and hashing potentially hundreds of Kconfig files on every
   incremental build.

2. kconfig.cmake: Replace per-file set_property loop for
   CMAKE_CONFIGURE_DEPENDS with a single batched call, reducing
   N individual property append operations to one.

3. kconfig.cmake: Merge path normalization and file existence
   validation into a single pass instead of two separate loops.

4. extensions.cmake (import_kconfig): Replace per-iteration
   list(REMOVE_ITEM) with batch collection and single removal after
   the loop. The old code performed O(n) list scans for every "not
   set" entry in .config files, making the function O(n²) worst case.

5. zephyr_module.cmake: Replace triple string(REGEX REPLACE) calls
   per module line with single string(REGEX MATCH) using non-quote
   character classes [^"]*, extracting all capture groups at once.
   Applied to settings parsing (2→1 regex), module name extraction,
   and both Zephyr/sysbuild module processing loops (3→1 regex each).

6. boards.cmake: Replace per-directory set_property loop with
   list(TRANSFORM) + single batched set_property call.

https://claude.ai/code/session_01XEE5tYodxrrxBRAF5NyLfo