### PR TITLE
west spdx: support sysbuild via domains.yaml

### DIFF
--- a/scripts/pylib/build_helpers/domains.py
+++ b/scripts/pylib/build_helpers/domains.py
@@ -9,7 +9,9 @@ This provides parsing of domains yaml file and creation of objects of the
 Domain class.
 '''
 
+import os
 from dataclasses import dataclass
+from pathlib import Path
 
 import yaml
 import pykwalify.core
@@ -131,3 +133,29 @@ class Domain:
 
     name: str
     build_dir: str
+
+
+def zephyr_cmake_build_dir_for_spdx(build_dir_ref):
+    '''Map a west ``-d`` build directory to the Zephyr CMake build dir for SPDX.
+
+    Sysbuild writes ``domains.yaml`` at the top-level build directory. When
+    *build_dir_ref* is that directory, returns the default image's
+    ``build_dir`` from the file. Otherwise returns *build_dir_ref* unchanged.
+
+    Returns:
+        tuple: (zephyr_image_build_dir, is_sysbuild_top) where *is_sysbuild_top*
+        is True when *build_dir_ref* was the sysbuild top dir listed in
+        ``domains.yaml``.
+    '''
+    abs_ref = os.path.abspath(build_dir_ref)
+    domains_file = Path(abs_ref) / 'domains.yaml'
+    if not domains_file.is_file():
+        return abs_ref, False
+
+    domains = Domains.from_file(str(domains_file))
+    top = os.path.abspath(domains.get_top_build_dir())
+    if top != abs_ref:
+        return abs_ref, False
+
+    default = domains.get_default_domain()
+    return os.path.abspath(default.build_dir), True

--- a/scripts/west_commands/build_helpers.py
+++ b/scripts/west_commands/build_helpers.py
@@ -24,7 +24,7 @@ import zcmake
 # twister also uses the implementation
 script_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, os.path.join(script_dir, "pylib/build_helpers/"))
-from domains import Domains  # noqa: E402
+from domains import Domains, zephyr_cmake_build_dir_for_spdx  # noqa: E402
 
 DEFAULT_BUILD_DIR = 'build'
 '''Name of the default Zephyr build directory.'''

--- a/scripts/west_commands/pyproject.toml
+++ b/scripts/west_commands/pyproject.toml
@@ -3,7 +3,7 @@ ignore_missing_imports = true
 mypy_path = "."
 
 [tool.pytest.ini_options]
-pythonpath = ["."]
+pythonpath = [".", "../pylib/build_helpers"]
 
 [tool.ruff]
 extend = "../../.ruff.toml"

--- a/scripts/west_commands/spdx.py
+++ b/scripts/west_commands/spdx.py
@@ -7,6 +7,7 @@ import uuid
 
 from west.commands import WestCommand
 
+from build_helpers import zephyr_cmake_build_dir_for_spdx
 from zspdx.sbom import SBOMConfig, makeSPDX, setupCmakeQuery
 from zspdx.version import SPDX_VERSION_2_3, SUPPORTED_SPDX_VERSIONS, parse
 
@@ -18,7 +19,12 @@ Prior to the build, an empty file must be created at
 BUILDDIR/.cmake/api/v1/query/codemodel-v2 in order to enable
 the CMake file-based API, which the SPDX command relies upon.
 This can be done by calling `west spdx --init` prior to
-calling `west build`."""
+calling `west build`.
+
+For sysbuild, pass the top-level sysbuild directory (the same path you use
+with ``west build --sysbuild -d``). The command uses ``domains.yaml`` to
+find the default image's Zephyr build directory and initializes the CMake
+API there."""
 
 class ZephyrSpdx(WestCommand):
     def __init__(self):
@@ -73,10 +79,17 @@ class ZephyrSpdx(WestCommand):
         if not args.build_dir:
             self.die("Build directory not specified; call `west spdx --init --build-dir=BUILD_DIR`")
 
+        image_dir, sysbuild_top = zephyr_cmake_build_dir_for_spdx(args.build_dir)
         # initialize CMake file-based API - empty query file
-        query_ready = setupCmakeQuery(args.build_dir)
+        query_ready = setupCmakeQuery(image_dir)
         if query_ready:
-            self.inf("initialized; run `west build` then run `west spdx`")
+            if sysbuild_top:
+                self.inf(
+                    f"sysbuild: initialized CMake API under default image {image_dir}; "
+                    "run `west build --sysbuild` then `west spdx -d` with the same top-level build dir"
+                )
+            else:
+                self.inf("initialized; run `west build` then run `west spdx`")
         else:
             self.die("Couldn't create CMake file-based API query directory\n"
                      "You can manually create an empty file at "
@@ -86,9 +99,11 @@ class ZephyrSpdx(WestCommand):
         if not args.build_dir:
             self.die("Build directory not specified; call `west spdx --build-dir=BUILD_DIR`")
 
+        image_dir, _sysbuild_top = zephyr_cmake_build_dir_for_spdx(args.build_dir)
+
         # create the SPDX files
         cfg = SBOMConfig()
-        cfg.buildDir = args.build_dir
+        cfg.buildDir = image_dir
         try:
             version_obj = parse(args.spdx_version)
         except Exception:
@@ -104,7 +119,7 @@ class ZephyrSpdx(WestCommand):
         if args.spdx_dir:
             cfg.spdxDir = args.spdx_dir
         else:
-            cfg.spdxDir = os.path.join(args.build_dir, "spdx")
+            cfg.spdxDir = os.path.join(image_dir, "spdx")
         if args.analyze_includes:
             cfg.analyzeIncludes = True
         if args.include_sdk:

--- a/scripts/west_commands/tests/test_spdx_build_dir.py
+++ b/scripts/west_commands/tests/test_spdx_build_dir.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 The Zephyr Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for SPDX build directory resolution with sysbuild."""
+
+import textwrap
+
+from domains import zephyr_cmake_build_dir_for_spdx
+
+
+def test_single_image_no_domains_yaml(tmp_path):
+    b = tmp_path / "build"
+    b.mkdir()
+    image, is_top = zephyr_cmake_build_dir_for_spdx(str(b))
+    assert image == str(b.resolve())
+    assert is_top is False
+
+
+def test_sysbuild_top_remaps_to_default_image(tmp_path):
+    top = tmp_path / "build"
+    top.mkdir()
+    app = top / "my_app"
+    app.mkdir()
+    (top / "domains.yaml").write_text(
+        textwrap.dedent(
+            f"""\
+            default: my_app
+            build_dir: {top}
+            domains:
+              - name: my_app
+                build_dir: {app}
+              - name: mcuboot
+                build_dir: {top / "mcuboot"}
+            flash_order:
+              - my_app
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    image, is_top = zephyr_cmake_build_dir_for_spdx(str(top))
+    assert image == str(app.resolve())
+    assert is_top is True
+
+
+def test_explicit_image_dir_not_remapped(tmp_path):
+    top = tmp_path / "build"
+    top.mkdir()
+    app = top / "my_app"
+    app.mkdir()
+    (top / "domains.yaml").write_text(
+        textwrap.dedent(
+            f"""\
+            default: my_app
+            build_dir: {top}
+            domains:
+              - name: my_app
+                build_dir: {app}
+            flash_order:
+              - my_app
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    image, is_top = zephyr_cmake_build_dir_for_spdx(str(app))
+    assert image == str(app.resolve())
+    assert is_top is False


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`west spdx` assumed `-d` pointed at the Zephyr CMake binary directory. With **sysbuild**, that directory is the **top-level** ExternalProject tree: it has `domains.yaml` and `CMakeCache.txt`, but the real Zephyr project (and CMake file-based API replies) live under each image directory (e.g. `build/zephyr-fota-demo`).

This change detects when `-d` is the sysbuild top dir (by reading `domains.yaml` and matching `build_dir`), then uses the **default domain**'s `build_dir` for:

- `west spdx --init` (CMake API query under the image)
- `west spdx` (cache, codemodel, default SPDX output under `image/spdx/`)

Passing `-d` directly to an image directory still behaves as before.

## Testing

- `pytest scripts/west_commands/tests/test_spdx_build_dir.py`

## Usage note

For sysbuild, use the **same** top-level build directory as `west build --sysbuild -d ...`. Ensure `CONFIG_BUILD_OUTPUT_META=y` for the **application** image (meta file is read from the image's `CMakeCache.txt`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6034c598-057d-4d07-b892-cb1ca1fffc51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6034c598-057d-4d07-b892-cb1ca1fffc51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

