### PR TITLE
doc: group STM32 clock devicetree binding headers

### DIFF
--- a/include/zephyr/dt-bindings/clock/stm32_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32_clock.h
@@ -6,7 +6,15 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32_CLOCK_H_
 
-/* clock bus references */
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
+/**
+ * @name Legacy STM32 clock bus identifiers
+ * @{
+ */
 #define STM32_CLOCK_BUS_AHB1    0
 #define STM32_CLOCK_BUS_AHB2    1
 #define STM32_CLOCK_BUS_APB1    2
@@ -23,10 +31,15 @@
 #define STM32_CLOCK_BUS_AXI     13
 #define STM32_CLOCK_BUS_MLAHB   14
 #define STM32_CLOCK_BUS_APB4_2  15
+/** @} */
 
+/** @cond INTERNAL_HIDDEN */
 #define STM32_CLOCK_DIV_SHIFT	12
+/** @endcond */
 
-/** Clock divider */
+/** Clock divider value for STM32 devicetree clock specifiers. */
 #define STM32_CLOCK_DIV(div)	(((div) - 1) << STM32_CLOCK_DIV_SHIFT)
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32_common_clocks.h
+++ b/include/zephyr/dt-bindings/clock/stm32_common_clocks.h
@@ -6,21 +6,32 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32_COMMON_CLOCKS_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32_COMMON_CLOCKS_H_
 
-/** System clock */
+/**
+ * @defgroup clock_control_dt_stm32 STM32 clock control devicetree helpers
+ * @ingroup clock_control_interface
+ * @{
+ */
+
+/**
+ * @name Common STM32 clock source identifiers
+ * @{
+ */
 #define STM32_SRC_SYSCLK	0x001
-/** Fixed clocks  */
 #define STM32_SRC_LSE		0x002
 #define STM32_SRC_LSI		0x003
+/** @} */
 
-/** Dummy: Add a specifier when no selection is possible */
+/** Dummy specifier for clock configuration entries without selectable sources. */
 #define NO_SEL			0xFF
 
+/** @cond INTERNAL_HIDDEN */
 #define STM32_CLOCK_DIV_SHIFT	12
+/** @endcond */
 
-/** Clock divider */
+/** Clock divider value for STM32 devicetree clock specifiers. */
 #define STM32_CLOCK_DIV(div)	(((div) - 1) << STM32_CLOCK_DIV_SHIFT)
 
-/** Helper macros to pack RCC clock source selection register info in the DT */
+/** @cond INTERNAL_HIDDEN */
 #define STM32_DT_CLKSEL_REG_MASK	0xFFFFU
 #define STM32_DT_CLKSEL_REG_SHIFT	0U
 #define STM32_DT_CLKSEL_SHIFT_MASK	0x1FU
@@ -29,6 +40,7 @@
 #define STM32_DT_CLKSEL_WIDTH_SHIFT	21U
 #define STM32_DT_CLKSEL_VAL_MASK	0xFFU
 #define STM32_DT_CLKSEL_VAL_SHIFT	24U
+/** @endcond */
 
 /**
  * @brief Pack STM32 source clock selection RCC register bit fields for the DT
@@ -59,4 +71,6 @@
  */
 #define STM32_CLOCK(bus, bit) (STM32_CLOCK_BUS_##bus) (1 << bit)
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32_COMMON_CLOCKS_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32c0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32c0_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Bus clocks */
 #define STM32_CLOCK_BUS_IOP     0x034
 #define STM32_CLOCK_BUS_AHB1    0x038
@@ -72,4 +77,6 @@
 #define MCO_PRE_DIV_64  6
 #define MCO_PRE_DIV_128 7
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32c5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32c5_clock.h
@@ -15,6 +15,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Domain clocks */
 
 /* RM0522, Figure 24 Clock tree for STM32C5 Series */
@@ -140,4 +145,6 @@
 #define MCO2_SEL_HSIDIV3	7
 
 /** @endcond */
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32C5_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f0_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Bus gatting clocks */
 #define STM32_CLOCK_BUS_AHB1    0x014
 #define STM32_CLOCK_BUS_APB2    0x018
@@ -53,4 +58,6 @@
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR1_REG)
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 30, 28, CFGR1_REG)
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f10x_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f10x_clock.h
@@ -11,6 +11,11 @@
 /* Ensure correct order by including generic F1 definitions first. */
 #include "stm32f1_clock.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Fixed clocks  */
 /* Low speed clocks defined in stm32_common_clocks.h */
 /* Common clocks with stm32f1x defined in stm32f1_clock.h */
@@ -22,4 +27,6 @@
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR1_REG)
 /* No MCO prescaler support on STM32F1 series. */
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F10X_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f1_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f1_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Domain clocks */
 
 /** Bus clocks */
@@ -56,4 +61,6 @@
 #define ADC_PRE_DIV_6		2
 #define ADC_PRE_DIV_8		3
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F1_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f37x_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f37x_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32f3_clock.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /* On STM32F37x, the ADC prescaler is located in CFGR1 and the prescaler values are more limited */
 #undef ADC12_PRE
 #undef ADC34_PRE
@@ -35,4 +40,6 @@
 #define ADC_PRE_DIV_6		2
 #define ADC_PRE_DIV_8		3
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F37X_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f3_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f3_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Bus gatting clocks */
 #define STM32_CLOCK_BUS_AHB1    0x014
 #define STM32_CLOCK_BUS_APB2    0x018
@@ -85,4 +90,6 @@
 #define ADC_PRE_DIV_128		0x1A
 #define ADC_PRE_DIV_256		0x1B
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F3_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f410_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f410_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32f4_clock.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** @brief RCC_DCKCFGR register offset */
 #define DCKCFGR_REG		0x8C
 #define DCKCFGR2_REG		0x94
@@ -33,4 +38,6 @@
 #undef I2S_SEL
 #endif
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F410_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f427_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f427_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32f4_clock.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** @brief RCC_DCKCFGR register offset */
 #define DCKCFGR_REG		0x8C
 
@@ -21,4 +26,6 @@
 #define SDMMC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 28, 28, DCKCFGR_REG)
 #define DSI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 29, DCKCFGR_REG)
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F427_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f4_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Domain clocks */
 
 /** Bus clocks */
@@ -79,4 +84,6 @@
 #define MCO_PRE_DIV_4 6
 #define MCO_PRE_DIV_5 7
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32f7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f7_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Domain clocks */
 
 /** Bus clocks */
@@ -100,4 +105,6 @@
 #define SDMMC2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 29, 29, DCKCFGR2_REG)
 #define DSI_SEL(val)		STM32_DT_CLOCK_SELECT((val), 30, 30, DCKCFGR2_REG)
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F7_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32g0_b1x_c1x_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g0_b1x_c1x_clock.h
@@ -7,6 +7,11 @@
 #ifndef ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_B1X_C1X_CLOCK_H_
 #define ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_B1X_C1X_CLOCK_H_
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /* MCO prescaler : division factor */
 #define MCO_PRE_DIV_256  8
 #define MCO_PRE_DIV_512  9
@@ -19,4 +24,6 @@
 #define MCO_SEL_RTCCLK    10
 #define MCO_SEL_RTCWAKEUP 11
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_B1X_C1X_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32g0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g0_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Bus clocks */
 #define STM32_CLOCK_BUS_IOP     0x034
 #define STM32_CLOCK_BUS_AHB1    0x038
@@ -93,4 +98,6 @@
 #define MCO_SEL_LSI     6
 #define MCO_SEL_LSE     7
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32g4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g4_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Bus clocks */
 #define STM32_CLOCK_BUS_AHB1    0x048
 #define STM32_CLOCK_BUS_AHB2    0x04c
@@ -72,4 +77,6 @@
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32G4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32h5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h5_clock.h
@@ -9,6 +9,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Domain clocks */
 
 /* RM0481/0492, Table 47 Kernel clock distribution summary */
@@ -150,4 +155,6 @@
 #define MCO_PRE_DIV_15 15
 
 /** @endcond */
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H5_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32h7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h7_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Domain clocks */
 
 /* RM0468, Table 56 Kernel clock dictribution summary */
@@ -148,4 +153,6 @@
 #define MCO2_SEL_CSI		4
 #define MCO2_SEL_LSI		5
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H7_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32h7rs_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h7rs_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Domain clocks */
 
 /* RM0477  */
@@ -137,4 +142,6 @@
 #define MCO_PRE_DIV_14 14
 #define MCO_PRE_DIV_15 15
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32H7RS_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l0_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Bus gatting clocks */
 #define STM32_CLOCK_BUS_IOP     0x02c
 #define STM32_CLOCK_BUS_AHB1    0x030
@@ -51,4 +56,6 @@
 /** CSR devices */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CSR_REG)
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l1_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l1_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Bus gatting clocks */
 #define STM32_CLOCK_BUS_AHB1    0x01c
 #define STM32_CLOCK_BUS_APB2    0x020
@@ -34,4 +39,6 @@
 
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 17, 16, CSR_REG)
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L1_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l4_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Bus clocks */
 #define STM32_CLOCK_BUS_AHB1    0x048
 #define STM32_CLOCK_BUS_AHB2    0x04c
@@ -118,4 +123,6 @@
 #define MCO_SEL_LSE	7
 #define MCO_SEL_HSI48	8
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L4_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l4plus_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l4plus_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32l4_clock.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /*
  * On STM32L4+ series, the SAI1 / SAI2 input clock selection fields
  * are located within the CCIPR2 register instead of the CCIPR register
@@ -19,4 +24,6 @@
 #define SAI1_SEL(val)		STM32_DT_CLOCK_SELECT((val), 7, 5, CCIPR2_REG)
 #define SAI2_SEL(val)		STM32_DT_CLOCK_SELECT((val), 10, 8, CCIPR2_REG)
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L4PLUS_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32l5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l5_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Bus clocks */
 #define STM32_CLOCK_BUS_AHB1    0x048
 #define STM32_CLOCK_BUS_AHB2    0x04c
@@ -90,4 +95,6 @@
 #define MCO1_SEL(val)           STM32_DT_CLOCK_SELECT((val), 27, 24, CFGR_REG)
 #define MCO1_PRE(val)           STM32_DT_CLOCK_SELECT((val), 30, 28, CFGR_REG)
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32L5_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32mp13_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32mp13_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** System clock */
 /* defined in stm32_common_clocks.h */
 /** Fixed clocks  */
@@ -152,4 +157,6 @@
 #define DCMIPP_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, DCMIPPCKSELR_REG)
 #define SAES_SEL(val)		STM32_DT_CLOCK_SELECT((val), 1, 0, SAESCKSELR_REG)
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32MP13_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32mp2_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32mp2_clock.h
@@ -10,6 +10,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /* Undefine the common clocks macro */
 #undef STM32_CLOCK
 
@@ -90,4 +95,6 @@
 #define STM32_CLOCK_PERIPH_MAX	STM32_CLOCK_PERIPH_I3C4
 
 /** @endcond */
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32MP2_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32n6_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32n6_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Domain clocks */
 
 /* RM0486, Figures 37 and 45 on clock distribution description */
@@ -223,4 +228,6 @@
 /* ADC prescaler division factor helper */
 #define ADC_PRE_DIV(pres)	((pres - 1) & 0xFFU)
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32N6_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32u0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u0_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Bus gatting clocks */
 #define STM32_CLOCK_BUS_AHB1    0x48
 #define STM32_CLOCK_BUS_IOP     0x4C
@@ -62,4 +67,6 @@
 /** BDCR devices */
 #define RTC_SEL(val)		STM32_DT_CLOCK_SELECT((val), 9, 8, BDCR_REG)
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32u3_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u3_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Domain clocks */
 
 /* RM0487, Figure 36 Clock tree for STM32U3 Series */
@@ -115,4 +120,6 @@
 #define ADCDAC_PRE_DIV_256	0xE
 #define ADCDAC_PRE_DIV_512	0xF
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U3_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32u5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u5_clock.h
@@ -9,6 +9,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Domain clocks */
 
 /* RM0456, Figure 36 Clock tree for STM32U5 Series */
@@ -122,4 +127,6 @@
 #define MCO_PRE_DIV_8  3
 #define MCO_PRE_DIV_16 4
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32U5_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32wb0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wb0_clock.h
@@ -9,6 +9,11 @@
 /** Define system & low-speed clocks */
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Other fixed clocks.
  * - CLKSLOWMUX: used to query slow clock tree frequency
  * - CLK16MHZ: secondary clock for LPUART, SPI3/I2S and BLE
@@ -42,4 +47,6 @@
 /* `msb` is only 22 for WB06/WB07, but a single definition with msb=23 is acceptable */
 #define SPI3_I2S3_SEL(val)	STM32_DT_CLOCK_SELECT((val), 23, 22, CFGR_REG)
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WB0_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32wb_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wb_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Bus clocks */
 #define STM32_CLOCK_BUS_AHB1    0x048
 #define STM32_CLOCK_BUS_AHB2    0x04c
@@ -66,4 +71,6 @@
 /** CSR devices */
 #define RFWKP_SEL(val)		STM32_DT_CLOCK_SELECT((val), 15, 14, CSR_REG)
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WB_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32wba_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wba_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Peripheral clock sources */
 
 /* RM0493, Figure 34, clock tree */
@@ -105,4 +110,6 @@
 #define MCO_SEL_HCLK5 10
 
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WBA_CLOCK_H_ */

--- a/include/zephyr/dt-bindings/clock/stm32wl_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wl_clock.h
@@ -8,6 +8,11 @@
 
 #include "stm32_common_clocks.h"
 
+/**
+ * @addtogroup clock_control_dt_stm32
+ * @{
+ */
+
 /** Bus clocks */
 #define STM32_CLOCK_BUS_AHB1    0x048
 #define STM32_CLOCK_BUS_AHB2    0x04c
@@ -89,4 +94,6 @@
 #define MCO_SEL_PLL1PCLK  13
 #define MCO_SEL_PLL1QCLK  14
 
+
+/** @} */
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32WL_CLOCK_H_ */


### PR DESCRIPTION
### Motivation
- Provide consistent Doxygen documentation for STM32 clock devicetree bindings by introducing a shared group and avoiding repeated group text in each SoC header. 
- Surface the public DT helper macros while hiding low-level packing/divider implementation details to reduce noise in generated docs. 
- Align STM32 clock header organization with the style used for pincontrol bindings so maintainers and consumers get a predictable layout.

### Description
- Add a top-level Doxygen group `clock_control_dt_stm32` in `include/zephyr/dt-bindings/clock/stm32_common_clocks.h` and a named subsection for the common STM32 source identifiers. 
- Mark implementation-only constants (`STM32_CLOCK_DIV_SHIFT`, the `STM32_DT_CLKSEL_*` masks/shift constants, etc.) with `@cond INTERNAL_HIDDEN` so they do not appear in user-facing docs. 
- Enroll SoC-specific STM32 clock binding headers in the shared group by adding `@addtogroup clock_control_dt_stm32` / `@{` at the top and a matching `@}` before their `#endif`, removing duplicated group descriptions from each file. 
- Update wording for several macro comments to clarify public semantics (e.g. describe `STM32_CLOCK_DIV(div)` as the clock divider value for DT specifiers) and keep changes limited to documentation/grouping only.

### Testing
- Ran `git diff --check` which reported no whitespace/patch issues and succeeded. 
- Attempted `python3 scripts/ci/check_compliance.py --changed-files` which failed due to the missing `magic` Python module in the environment. 
- Verified programmatically that added Doxygen group markers are balanced across modified headers (no unmatched `@{` / `@}` occurrences).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b60af56483219e7f95b06a8cc3d5)