### PR TITLE
serial: add SERIAL_HAS_POST_KERNEL_INIT

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -18,6 +18,18 @@
 @{
 @}
 
+@defgroup posix POSIX APIs
+@brief POSIX APIs
+@ingroup os_services
+@{
+@}
+
+@defgroup posix_extensions POSIX compatibility APIs
+@brief Compatibility APIs provided from the POSIX include tree.
+@ingroup os_services
+@{
+@}
+
 @defgroup io_interfaces Device Drivers
 @brief Interfaces to interact with various hardware peripherals.
 @details A collection of hardware-agnostic interfaces used to implement and interact with device

--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -319,6 +319,12 @@ ALIASES               += "driver_ops{1}=\brief \htmlonly <span class=\"mlabel\">
 ALIASES               += "driver_ops_mandatory=\htmlonly<span class=\"op-badge op-req\" title=\"This operation MUST be implemented by the driver.\">REQ</span>\endhtmlonly"
 ALIASES               += "driver_ops_optional=\htmlonly<span class=\"op-badge op-opt\" title=\"This operation MAY optionally be implemented by the driver.\">OPT</span>\endhtmlonly"
 
+# Aliases to reference POSIX and POSIX-adjacent compatibility API documentation.
+ALIASES               += "posix_func{1}=\see \htmlonly<a href=\"https://pubs.opengroup.org/onlinepubs/9699919799/functions/\1.html\">\1()</a>\endhtmlonly in The Open Group Base Specifications Issue 7, 2018 edition."
+ALIASES               += "posix_header{1}=\see \htmlonly<a href=\"https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/\1.html\">\1</a>\endhtmlonly in The Open Group Base Specifications Issue 7, 2018 edition."
+ALIASES               += "opengroup{3}=\see \htmlonly<a href=\"https://pubs.opengroup.org/onlinepubs/\1/\2\">\3</a>\endhtmlonly in The Open Group Base Specifications."
+ALIASES               += "compat_api{1}=\note \1 is a compatibility interface, not a POSIX API."
+
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
 # instance, some of the names that are used will be different. The list of all

--- a/include/zephyr/posix/aio.h
+++ b/include/zephyr/posix/aio.h
@@ -4,6 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Asynchronous input and output.
+ * @ingroup posix
+ *
+ * Provides the aiocb control block and the asynchronous I/O functions that
+ * allow read, write, and fsync operations to proceed in the background.
+ *
+ * @posix_header{aio.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_AIO_H_
 #define ZEPHYR_INCLUDE_POSIX_AIO_H_
 
@@ -17,25 +28,138 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Asynchronous I/O control block.
+ */
 struct aiocb {
+	/**
+	 * @brief File descriptor.
+	 */
 	int aio_fildes;
+	/**
+	 * @brief File offset.
+	 */
 	off_t aio_offset;
+	/**
+	 * @brief Location of buffer.
+	 */
 	volatile void *aio_buf;
+	/**
+	 * @brief Length of transfer.
+	 */
 	size_t aio_nbytes;
+	/**
+	 * @brief Request priority offset.
+	 */
 	int aio_reqprio;
+	/**
+	 * @brief Signal number and value.
+	 */
 	struct sigevent aio_sigevent;
+	/**
+	 * @brief Operation to be performed.
+	 */
 	int aio_lio_opcode;
 };
 
 #if _POSIX_C_SOURCE >= 200112L
 
+/**
+ * @brief Cancel an asynchronous I/O request.
+ *
+ * @param fildes File descriptor.
+ * @param aiocbp Control block to cancel, or NULL to cancel all requests for @p fildes.
+ *
+ * @return @c AIO_CANCELED, @c AIO_NOTCANCELED, or @c AIO_ALLDONE on success, -1 on error.
+ *
+ * @posix_func{aio_cancel}
+ */
 int aio_cancel(int fildes, struct aiocb *aiocbp);
+
+/**
+ * @brief Retrieve error status for an asynchronous I/O operation.
+ *
+ * @param aiocbp Asynchronous I/O control block.
+ *
+ * @return @c EINPROGRESS if still running, 0 on success, or a positive error number.
+ *
+ * @posix_func{aio_error}
+ */
 int aio_error(const struct aiocb *aiocbp);
+
+/**
+ * @brief Asynchronously synchronize a file's data and metadata to storage.
+ *
+ * @param filedes File descriptor (ignored; the file descriptor is taken from @p aiocbp).
+ * @param aiocbp  Control block specifying the file descriptor.
+ *
+ * @return 0 if the request was successfully queued, or -1 on failure.
+ *
+ * @posix_func{aio_fsync}
+ */
 int aio_fsync(int filedes, struct aiocb *aiocbp);
+
+/**
+ * @brief Enqueue an asynchronous read operation.
+ *
+ * @param aiocbp Control block specifying the file, offset, buffer, and size.
+ *
+ * @return 0 if the request was successfully queued, or -1 on failure.
+ *
+ * @posix_func{aio_read}
+ */
 int aio_read(struct aiocb *aiocbp);
+
+/**
+ * @brief Retrieve the return status of a completed asynchronous I/O operation.
+ *
+ * Must be called exactly once after aio_error() returns a value other than
+ * @c EINPROGRESS. Calling it a second time yields undefined behavior.
+ *
+ * @param aiocbp Asynchronous I/O control block.
+ *
+ * @return Number of bytes transferred on success, or -1 on error.
+ *
+ * @posix_func{aio_return}
+ */
 ssize_t aio_return(struct aiocb *aiocbp);
+
+/**
+ * @brief Wait for one or more asynchronous I/O requests to complete.
+ *
+ * @param list    Array of pointers to control blocks to wait on.
+ * @param nent    Number of entries in @p list.
+ * @param timeout Maximum wait time, or NULL to block indefinitely.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{aio_suspend}
+ */
 int aio_suspend(const struct aiocb *const list[], int nent, const struct timespec *timeout);
+
+/**
+ * @brief Enqueue an asynchronous write operation.
+ *
+ * @param aiocbp Control block specifying the file, offset, buffer, and size.
+ *
+ * @return 0 if the request was successfully queued, or -1 on failure.
+ *
+ * @posix_func{aio_write}
+ */
 int aio_write(struct aiocb *aiocbp);
+
+/**
+ * @brief Initiate a list of asynchronous I/O requests.
+ *
+ * @param mode @c LIO_WAIT (block until all complete) or @c LIO_NOWAIT (return immediately).
+ * @param list Array of control block pointers (@c LIO_NOP entries are skipped).
+ * @param nent Number of entries in @p list.
+ * @param sig  Notification on completion (only for @c LIO_NOWAIT), or NULL.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{lio_listio}
+ */
 int lio_listio(int mode, struct aiocb *const ZRESTRICT list[], int nent,
 	       struct sigevent *ZRESTRICT sig);
 

--- a/include/zephyr/posix/arpa/inet.h
+++ b/include/zephyr/posix/arpa/inet.h
@@ -3,6 +3,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Definitions for internet operations.
+ * @ingroup posix
+ *
+ * Provides conversion between the binary and text forms of IPv4 and IPv6
+ * addresses, and macros to convert values between host and network byte order.
+ *
+ * @posix_header{arpa_inet.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_ARPA_INET_H_
 #define ZEPHYR_INCLUDE_POSIX_ARPA_INET_H_
 
@@ -17,18 +29,93 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Unsigned 32-bit IPv4 address.
+ */
 typedef uint32_t in_addr_t;
 
+/**
+ * @brief Convert an IPv4 address from dotted-decimal text to binary.
+ *
+ * @note Deprecated; use inet_pton() for new code.
+ *
+ * @param cp Dotted-decimal IPv4 address string (e.g. "192.0.2.1").
+ *
+ * @return IPv4 address in network byte order, or @c INADDR_NONE on failure.
+ *
+ * @posix_func{inet_addr}
+ */
 in_addr_t inet_addr(const char *cp);
+
+/**
+ * @brief Convert an IPv4 address from binary to dotted-decimal text.
+ *
+ * @note Deprecated; use inet_ntop() for new code. The returned pointer is to
+ *       a static buffer that may be overwritten by subsequent calls.
+ *
+ * @param in IPv4 address in network byte order.
+ *
+ * @return Pointer to a dotted-decimal string, or NULL on failure.
+ *
+ * @posix_func{inet_ntoa}
+ */
 char *inet_ntoa(struct in_addr in);
+
+/**
+ * @brief Convert an IPv4 or IPv6 address from binary to text form.
+ *
+ * @param family Address family: @c AF_INET or @c AF_INET6.
+ * @param src    Source address in network byte order.
+ * @param dst    Output buffer for the text form.
+ * @param size   Size of @p dst in bytes (@c INET_ADDRSTRLEN / @c INET6_ADDRSTRLEN).
+ *
+ * @return @p dst on success, or NULL with errno set on failure.
+ *
+ * @posix_func{inet_ntop}
+ */
 char *inet_ntop(sa_family_t family, const void *src, char *dst, size_t size);
+
+/**
+ * @brief Convert an IPv4 or IPv6 address from text form to binary.
+ *
+ * @param family Address family: @c AF_INET or @c AF_INET6.
+ * @param src    Text form of the address.
+ * @param dst    Output buffer for the binary address.
+ *
+ * @return 1 on success, 0 if @p src is not a valid address, -1 on error.
+ *
+ * @posix_func{inet_pton}
+ */
 int inet_pton(sa_family_t family, const char *src, void *dst);
 
+/**
+ * @brief Convert a 16-bit value from network to host byte order.
+ */
 #define ntohs(x)  net_ntohs(x)
+
+/**
+ * @brief Convert a 32-bit value from network to host byte order.
+ */
 #define ntohl(x)  net_ntohl(x)
+
+/**
+ * @brief Convert a 64-bit value from network to host byte order.
+ */
 #define ntohll(x) net_ntohll(x)
+
+/**
+ * @brief Convert a 16-bit value from host to network byte order.
+ */
 #define htons(x)  net_htons(x)
+
+/**
+ * @brief Convert a 32-bit value from host to network byte order.
+ */
 #define htonl(x)  net_htonl(x)
+
+/**
+ * @brief Convert a 64-bit value from host to network byte order.
+ */
 #define htonll(x) net_htonll(x)
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/dirent.h
+++ b/include/zephyr/posix/dirent.h
@@ -5,6 +5,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Format of directory entries.
+ * @ingroup posix
+ *
+ * Provides the DIR directory stream type together with the functions used to open,
+ * read, rewind, and close directories.
+ *
+ * @posix_header{dirent.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_DIRENT_H_
 #define ZEPHYR_INCLUDE_POSIX_DIRENT_H_
 
@@ -16,26 +27,138 @@ extern "C" {
 #endif
 
 #if (_POSIX_C_SOURCE >= 200809L) || (_XOPEN_SOURCE >= 700)
+/**
+ * @brief Compare two directory entries alphabetically (for use with scandir()).
+ *
+ * @param d1 First directory entry.
+ * @param d2 Second directory entry.
+ *
+ * @return Negative, zero, or positive value per strcmp() semantics.
+ *
+ * @posix_func{alphasort}
+ */
 int alphasort(const struct dirent **d1, const struct dirent **d2);
 #endif
+
+/**
+ * @brief Close a directory stream.
+ *
+ * @param dirp Directory stream to close.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{closedir}
+ */
 int closedir(DIR *dirp);
+
 #if (_POSIX_C_SOURCE >= 200809L) || (_XOPEN_SOURCE >= 700)
+/**
+ * @brief Extract the file descriptor used by a DIR stream.
+ *
+ * @param dirp Directory stream.
+ *
+ * @return File descriptor on success, or -1 with errno set on failure.
+ *
+ * @posix_func{dirfd}
+ */
 int dirfd(DIR *dirp);
 #endif
+
+/**
+ * @brief Open a directory stream for a directory identified by a file descriptor.
+ *
+ * @param fd File descriptor for the directory.
+ *
+ * @return Directory stream on success, or NULL with errno set on failure.
+ *
+ * @posix_func{fdopendir}
+ */
 DIR *fdopendir(int fd);
+
+/**
+ * @brief Open a directory stream for a named directory.
+ *
+ * @param dirname Path to the directory.
+ *
+ * @return Directory stream on success, or NULL with errno set on failure.
+ *
+ * @posix_func{opendir}
+ */
 DIR *opendir(const char *dirname);
+
+/**
+ * @brief Read the next entry from a directory stream.
+ *
+ * @param dirp Directory stream.
+ *
+ * @return Pointer to a @c struct dirent on success, or NULL at end-of-directory or on error.
+ *
+ * @posix_func{readdir}
+ */
 struct dirent *readdir(DIR *dirp);
+
 #if (_POSIX_C_SOURCE >= 199506L) || (_XOPEN_SOURCE >= 500)
+/**
+ * @brief Read a directory entry into a caller-supplied buffer (thread-safe).
+ *
+ * @param dirp   Directory stream.
+ * @param entry  Caller-supplied buffer for the entry.
+ * @param result Output: pointer to @p entry, or NULL at end-of-directory.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{readdir_r}
+ */
 int readdir_r(DIR *ZRESTRICT dirp, struct dirent *ZRESTRICT entry,
 	      struct dirent **ZRESTRICT result);
 #endif
+
+/**
+ * @brief Reset the position of a directory stream to the beginning of a directory.
+ *
+ * @param dirp Directory stream to rewind.
+ *
+ * @posix_func{rewinddir}
+ */
 void rewinddir(DIR *dirp);
+
 #if (_POSIX_C_SOURCE >= 200809L) || (_XOPEN_SOURCE >= 700)
+/**
+ * @brief Scan a directory, optionally filtering and sorting the entries.
+ *
+ * @param dir      Path to the directory.
+ * @param namelist Output: allocated array of directory entry pointers.
+ * @param sel      Filter function, or NULL to include all entries.
+ * @param compar   Comparison function for sorting, or NULL for no sorting.
+ *
+ * @return Number of entries in @p namelist on success, or -1 on failure.
+ *
+ * @posix_func{scandir}
+ */
 int scandir(const char *dir, struct dirent ***namelist, int (*sel)(const struct dirent *),
 	    int (*compar)(const struct dirent **, const struct dirent **));
 #endif
+
 #if defined(_XOPEN_SOURCE)
+/**
+ * @brief Set the position of a directory stream.
+ *
+ * @param dirp Directory stream.
+ * @param loc  Position value previously returned by telldir().
+ *
+ * @posix_func{seekdir}
+ */
 void seekdir(DIR *dirp, long loc);
+
+/**
+ * @brief Get the current position of a directory stream.
+ *
+ * @param dirp Directory stream.
+ *
+ * @return Current position value, or -1 with errno set on failure.
+ *
+ * @posix_func{telldir}
+ */
 long telldir(DIR *dirp);
 #endif
 

--- a/include/zephyr/posix/fcntl.h
+++ b/include/zephyr/posix/fcntl.h
@@ -4,32 +4,111 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief File control options.
+ * @ingroup posix
+ *
+ * Defines the file-control commands, file access mode flags, and file status flags
+ * used with open() and fcntl().
+ *
+ * @posix_header{fcntl.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_FCNTL_H_
 #define ZEPHYR_INCLUDE_POSIX_FCNTL_H_
 
 #include <zephyr/sys/fdtable.h>
 
+/**
+ * @brief Write operations append to the end of the file.
+ */
 #define O_APPEND   ZVFS_O_APPEND
+
+/**
+ * @brief Create file if it does not exist.
+ */
 #define O_CREAT    ZVFS_O_CREAT
+
+/**
+ * @brief Exclusive creation: fail if the file already exists (used with @c O_CREAT).
+ */
 #define O_EXCL     ZVFS_O_EXCL
+
+/**
+ * @brief Non-blocking I/O mode.
+ */
 #define O_NONBLOCK ZVFS_O_NONBLOCK
+
+/**
+ * @brief Truncate the file to zero length on open.
+ */
 #define O_TRUNC    ZVFS_O_TRUNC
 
+/**
+ * @brief Mask to extract the file access mode from open flags.
+ */
 #define O_ACCMODE (ZVFS_O_RDONLY | ZVFS_O_RDWR | ZVFS_O_WRONLY)
 
+/**
+ * @brief Open for reading only.
+ */
 #define O_RDONLY ZVFS_O_RDONLY
+
+/**
+ * @brief Open for reading and writing.
+ */
 #define O_RDWR   ZVFS_O_RDWR
+
+/**
+ * @brief Open for writing only.
+ */
 #define O_WRONLY ZVFS_O_WRONLY
 
+/**
+ * @brief Duplicate a file descriptor to the lowest available number >= the argument.
+ */
 #define F_DUPFD ZVFS_F_DUPFD
+
+/**
+ * @brief Get file status flags and file access modes.
+ */
 #define F_GETFL ZVFS_F_GETFL
+
+/**
+ * @brief Set file status flags.
+ */
 #define F_SETFL ZVFS_F_SETFL
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/**
+ * @brief Open or create a file.
+ *
+ * @param name  Pathname of the file.
+ * @param flags Access mode and creation flags (@c O_RDONLY, @c O_WRONLY, @c O_RDWR,
+ *              @c O_CREAT, ...).
+ * @param ...   Permission bits of type @c mode_t (required when @c O_CREAT is given).
+ *
+ * @return New file descriptor on success, or -1 with errno set on failure.
+ *
+ * @posix_func{open}
+ */
 int open(const char *name, int flags, ...);
+
+/**
+ * @brief Perform file control operations on an open file descriptor.
+ *
+ * @param fildes File descriptor.
+ * @param cmd    Control command (@c F_DUPFD, @c F_GETFL, @c F_SETFL, ...).
+ * @param ...    Optional argument whose type depends on @p cmd.
+ *
+ * @return Command-specific value on success, or -1 with errno set on failure.
+ *
+ * @posix_func{fcntl}
+ */
 int fcntl(int fildes, int cmd, ...);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/fnmatch.h
+++ b/include/zephyr/posix/fnmatch.h
@@ -30,26 +30,78 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- *    @(#)fnmatch.h    8.1 (Berkeley) 6/2/93
+ */
+
+/**
+ * @file
+ * @brief Filename-matching types.
+ * @ingroup posix
+ *
+ * Provides fnmatch() for matching strings against shell-style wildcard
+ * patterns as used in filename globbing.
+ *
+ * @posix_header{fnmatch.h}
  */
 
 #ifndef ZEPHYR_INCLUDE_POSIX_FNMATCH_H_
 #define ZEPHYR_INCLUDE_POSIX_FNMATCH_H_
 
+/**
+ * @brief The string does not match the specified pattern.
+ */
 #define FNM_NOMATCH 1 /* Match failed. */
+
+/**
+ * @brief Function not implemented.
+ */
 #define FNM_NOSYS   2 /* Function not implemented. */
+
+/**
+ * @brief Out of resources.
+ */
 #define FNM_NORES   3 /* Out of resources */
 
+/**
+ * @brief Treat backslash as an ordinary character rather than an escape character.
+ */
 #define FNM_NOESCAPE	0x01 /* Disable backslash escaping. */
+
+/**
+ * @brief Slash in string only matches slash in pattern.
+ */
 #define FNM_PATHNAME	0x02 /* Slash must be matched by slash. */
+
+/**
+ * @brief Leading period in string must be exactly matched by period in pattern.
+ */
 #define FNM_PERIOD	0x04 /* Period must be matched by period. */
+
+/**
+ * @brief Match the pattern case-insensitively.
+ */
 #define FNM_CASEFOLD	0x08 /* Pattern is matched case-insensitive */
+
+/**
+ * @brief Ignore a trailing slash and following characters after a match.
+ */
 #define FNM_LEADING_DIR 0x10 /* Ignore /<tail> after Imatch. */
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/**
+ * @brief Match a filename or path against a shell-style pattern.
+ *
+ * The first argument is the shell pattern (which may use '?', '*', and
+ * bracket expressions), the second is the string to test against it, and
+ * the third is a combination of @c FNM_* flags (or 0 for default matching).
+ *
+ * @return 0 if the string matches the pattern, @c FNM_NOMATCH if it does not,
+ *         or another non-zero value on error.
+ *
+ * @posix_func{fnmatch}
+ */
 int fnmatch(const char *, const char *, int);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/grp.h
+++ b/include/zephyr/posix/grp.h
@@ -3,6 +3,17 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+/**
+ * @file
+ * @brief Group database access.
+ * @ingroup posix
+ *
+ * Defines the group structure and the thread-safe functions used to search
+ * the system group database by group name or numeric group ID.
+ *
+ * @posix_header{grp.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_GRP_H_
 #define ZEPHYR_INCLUDE_POSIX_GRP_H_
 
@@ -16,16 +27,49 @@ extern "C" {
  * @brief Group structure
  */
 struct group {
-	/**< the name of the group */
+	/**
+	 * @brief Group name.
+	 */
 	char *gr_name;
-	/**< numerical group ID */
+	/**
+	 * @brief Numeric group ID.
+	 */
 	gid_t gr_gid;
-	/**< pointer to a null-terminated array of character pointers to member names */
+	/**
+	 * @brief NULL-terminated array of member login names.
+	 */
 	char **gr_mem;
 };
 
+/**
+ * @brief Look up a group entry by name (thread-safe).
+ *
+ * @param name    Group name to search for.
+ * @param grp     Caller-supplied structure to fill in.
+ * @param buffer  Caller-supplied buffer for string fields.
+ * @param bufsize Size of @p buffer.
+ * @param result  Output: pointer to @p grp on success, or NULL if not found.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{getgrnam_r}
+ */
 int getgrnam_r(const char *name, struct group *grp, char *buffer, size_t bufsize,
 	       struct group **result);
+
+/**
+ * @brief Look up a group entry by group ID (thread-safe).
+ *
+ * @param gid     Numerical group ID to search for.
+ * @param grp     Caller-supplied structure to fill in.
+ * @param buffer  Caller-supplied buffer for string fields.
+ * @param bufsize Size of @p buffer.
+ * @param result  Output: pointer to @p grp on success, or NULL if not found.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{getgrgid_r}
+ */
 int getgrgid_r(gid_t gid, struct group *grp, char *buffer, size_t bufsize, struct group **result);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/mqueue.h
+++ b/include/zephyr/posix/mqueue.h
@@ -4,6 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Message queues.
+ * @ingroup posix
+ *
+ * Provides the POSIX message queue API for inter-process (or inter-thread)
+ * communication via named, persistent, prioritized message queues.
+ *
+ * @posix_header{mqueue.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_MQUEUE_H_
 #define ZEPHYR_INCLUDE_POSIX_MQUEUE_H_
 
@@ -19,29 +30,167 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Opaque message queue descriptor returned by mq_open().
+ */
 typedef void *mqd_t;
 
+/**
+ * @brief Message queue attributes used with mq_getattr() and mq_setattr().
+ */
 struct mq_attr {
+	/**
+	 * @brief Message queue flags (@c O_NONBLOCK).
+	 */
 	long mq_flags;
+	/**
+	 * @brief Maximum number of messages.
+	 */
 	long mq_maxmsg;
+	/**
+	 * @brief Maximum message size in bytes.
+	 */
 	long mq_msgsize;
-	long mq_curmsgs;	/* Number of messages currently queued. */
+	/**
+	 * @brief Number of messages currently queued.
+	 */
+	long mq_curmsgs;
 };
 
+/**
+ * @brief Open or create a message queue.
+ *
+ * @param name   Queue name (must start with '/').
+ * @param oflags Open flags (@c O_RDONLY, @c O_WRONLY, @c O_RDWR, @c O_CREAT, @c O_EXCL,
+ *               @c O_NONBLOCK).
+ * @param ...    If @c O_CREAT is set: mode_t mode, struct mq_attr *attr.
+ *
+ * @return Message queue descriptor on success, or @c (mqd_t)-1 on failure.
+ *
+ * @posix_func{mq_open}
+ */
 mqd_t mq_open(const char *name, int oflags, ...);
+
+/**
+ * @brief Close a message queue descriptor.
+ *
+ * @param mqdes Message queue descriptor.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mq_close}
+ */
 int mq_close(mqd_t mqdes);
+
+/**
+ * @brief Remove a named message queue.
+ *
+ * @param name Queue name.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mq_unlink}
+ */
 int mq_unlink(const char *name);
+
+/**
+ * @brief Get the attributes of a message queue.
+ *
+ * @param mqdes  Message queue descriptor.
+ * @param mqstat Output: current attributes.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mq_getattr}
+ */
 int mq_getattr(mqd_t mqdes, struct mq_attr *mqstat);
+
+/**
+ * @brief Receive the oldest highest-priority message from a queue.
+ *
+ * @param mqdes    Message queue descriptor (opened with @c O_RDONLY or @c O_RDWR).
+ * @param msg_ptr  Buffer to receive the message.
+ * @param msg_len  Size of @p msg_ptr (must be >= mq_msgsize).
+ * @param msg_prio Output: priority of the received message, or NULL.
+ *
+ * @return Number of bytes in the received message on success, or -1 on failure.
+ *
+ * @posix_func{mq_receive}
+ */
 int mq_receive(mqd_t mqdes, char *msg_ptr, size_t msg_len,
 		   unsigned int *msg_prio);
+
+/**
+ * @brief Add a message to a queue.
+ *
+ * @param mqdes    Message queue descriptor (opened with @c O_WRONLY or @c O_RDWR).
+ * @param msg_ptr  Message to send.
+ * @param msg_len  Size of the message in bytes.
+ * @param msg_prio Priority of the message (higher value = higher priority).
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mq_send}
+ */
 int mq_send(mqd_t mqdes, const char *msg_ptr, size_t msg_len,
 	    unsigned int msg_prio);
+
+/**
+ * @brief Set the attributes of a message queue.
+ *
+ * @param mqdes   Message queue descriptor.
+ * @param mqstat  New attributes (only mq_flags is used).
+ * @param omqstat Output: previous attributes, or NULL.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mq_setattr}
+ */
 int mq_setattr(mqd_t mqdes, const struct mq_attr *mqstat,
 	       struct mq_attr *omqstat);
+
+/**
+ * @brief Receive a message from a queue with an absolute timeout.
+ *
+ * @param mqdes    Message queue descriptor.
+ * @param msg_ptr  Buffer to receive the message.
+ * @param msg_len  Size of @p msg_ptr.
+ * @param msg_prio Output: message priority, or NULL.
+ * @param abstime  Absolute timeout (@c CLOCK_REALTIME).
+ *
+ * @return Number of bytes in the message on success, or -1 on failure.
+ *
+ * @posix_func{mq_timedreceive}
+ */
 int mq_timedreceive(mqd_t mqdes, char *msg_ptr, size_t msg_len,
 			unsigned int *msg_prio, const struct timespec *abstime);
+
+/**
+ * @brief Send a message to a queue with an absolute timeout.
+ *
+ * @param mqdes    Message queue descriptor.
+ * @param msg_ptr  Message to send.
+ * @param msg_len  Size of the message in bytes.
+ * @param msg_prio Priority of the message.
+ * @param abstime  Absolute timeout (@c CLOCK_REALTIME).
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mq_timedsend}
+ */
 int mq_timedsend(mqd_t mqdes, const char *msg_ptr, size_t msg_len,
 		 unsigned int msg_prio, const struct timespec *abstime);
+
+/**
+ * @brief Register for notification when a message arrives on an empty queue.
+ *
+ * @param mqdes        Message queue descriptor.
+ * @param notification Notification specification, or NULL to cancel.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mq_notify}
+ */
 int mq_notify(mqd_t mqdes, const struct sigevent *notification);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/net/if.h
+++ b/include/zephyr/posix/net/if.h
@@ -3,16 +3,37 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Network interface names and indices.
+ * @ingroup posix
+ *
+ * Provides functions for mapping between network interface names and
+ * their numeric indices.
+ *
+ * @posix_header{net_if.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_NET_IF_H_
 #define ZEPHYR_INCLUDE_POSIX_NET_IF_H_
 
 #ifdef CONFIG_NET_INTERFACE_NAME_LEN
+/**
+ * @brief Maximum length of a network interface name including the NUL terminator.
+ */
 #define IF_NAMESIZE CONFIG_NET_INTERFACE_NAME_LEN
 #else
+/**
+ * @brief Maximum length of a network interface name including the NUL terminator.
+ */
 #define IF_NAMESIZE 1
 #endif
 
 #if !defined(IFNAMSIZ)
+/**
+ * @brief Legacy alias for @c IF_NAMESIZE.
+ */
 #define IFNAMSIZ IF_NAMESIZE
 #endif
 
@@ -20,14 +41,62 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Network interface name-to-index mapping.
+ */
 struct if_nameindex {
+	/**
+	 * @brief Numeric index of the interface.
+	 */
 	unsigned int if_index;
+	/**
+	 * @brief Null-terminated name of the interface.
+	 */
 	char *if_name;
 };
 
+/**
+ * @brief Map a network interface index to its corresponding name.
+ *
+ * @param ifindex Numeric interface index.
+ * @param ifname  Output buffer of at least @c IF_NAMESIZE bytes.
+ *
+ * @return @p ifname on success, or NULL with errno set on failure.
+ *
+ * @posix_func{if_indextoname}
+ */
 char *if_indextoname(unsigned int ifindex, char *ifname);
+
+/**
+ * @brief Free memory allocated by if_nameindex.
+ *
+ * @param ptr List to free (must have been returned by if_nameindex()).
+ *
+ * @posix_func{if_freenameindex}
+ */
 void if_freenameindex(struct if_nameindex *ptr);
+
+/**
+ * @brief Return all network interface names and indexes.
+ *
+ * The returned array is terminated by an entry with @c if_index == 0 and
+ * @c if_name == NULL. Free with if_freenameindex().
+ *
+ * @return Allocated array on success, or NULL with errno set on failure.
+ *
+ * @posix_func{if_nameindex}
+ */
 struct if_nameindex *if_nameindex(void);
+
+/**
+ * @brief Map a network interface name to its corresponding index.
+ *
+ * @param ifname Interface name string.
+ *
+ * @return Interface index on success, or 0 with errno set on failure.
+ *
+ * @posix_func{if_nametoindex}
+ */
 unsigned int if_nametoindex(const char *ifname);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/net/if_arp.h
+++ b/include/zephyr/posix/net/if_arp.h
@@ -3,6 +3,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Linux-compatible ARP hardware type definitions.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{This header provides non-POSIX compatibility interfaces.}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_NET_IF_ARP_H_
 #define ZEPHYR_INCLUDE_POSIX_NET_IF_ARP_H_
 
@@ -14,69 +23,495 @@ extern "C" {
  * for the ARP hardware address type values.
  */
 /* ARP protocol HARDWARE identifiers. */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_NETROM.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_NETROM}
+ */
 #define ARPHRD_NETROM     0            /* From KA9Q: NET/ROM pseudo. */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_ETHER.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_ETHER}
+ */
 #define ARPHRD_ETHER      1            /* Ethernet 10/100Mbps.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_EETHER.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_EETHER}
+ */
 #define ARPHRD_EETHER     2            /* Experimental Ethernet.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_AX25.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_AX25}
+ */
 #define ARPHRD_AX25       3            /* AX.25 Level 2.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_PRONET.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_PRONET}
+ */
 #define ARPHRD_PRONET     4            /* PROnet token ring.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_CHAOS.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_CHAOS}
+ */
 #define ARPHRD_CHAOS      5            /* Chaosnet.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_IEEE802.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_IEEE802}
+ */
 #define ARPHRD_IEEE802    6            /* IEEE 802.2 Ethernet/TR/TB.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_ARCNET.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_ARCNET}
+ */
 #define ARPHRD_ARCNET     7            /* ARCnet.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_APPLETLK.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_APPLETLK}
+ */
 #define ARPHRD_APPLETLK   8            /* APPLEtalk.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_DLCI.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_DLCI}
+ */
 #define ARPHRD_DLCI       15           /* Frame Relay DLCI.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_ATM.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_ATM}
+ */
 #define ARPHRD_ATM        19           /* ATM.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_METRICOM.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_METRICOM}
+ */
 #define ARPHRD_METRICOM   23           /* Metricom STRIP (new IANA id).  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_IEEE1394.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_IEEE1394}
+ */
 #define ARPHRD_IEEE1394   24           /* IEEE 1394 IPv4 - RFC 2734.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_EUI64.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_EUI64}
+ */
 #define ARPHRD_EUI64      27           /* EUI-64.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_INFINIBAND.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_INFINIBAND}
+ */
 #define ARPHRD_INFINIBAND 32           /* InfiniBand.  */
 
 /* Dummy types for non ARP hardware */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_SLIP.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_SLIP}
+ */
 #define ARPHRD_SLIP       256
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_CSLIP.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_CSLIP}
+ */
 #define ARPHRD_CSLIP      257
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_SLIP6.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_SLIP6}
+ */
 #define ARPHRD_SLIP6      258
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_CSLIP6.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_CSLIP6}
+ */
 #define ARPHRD_CSLIP6     259
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_RSRVD.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_RSRVD}
+ */
 #define ARPHRD_RSRVD      260          /* Notional KISS type.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_ADAPT.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_ADAPT}
+ */
 #define ARPHRD_ADAPT      264
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_ROSE.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_ROSE}
+ */
 #define ARPHRD_ROSE       270
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_X25.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_X25}
+ */
 #define ARPHRD_X25        271          /* CCITT X.25.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_HWX25.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_HWX25}
+ */
 #define ARPHRD_HWX25      272          /* Boards with X.25 in firmware.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_CAN.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_CAN}
+ */
 #define ARPHRD_CAN        280          /* Controller Area Network.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_MCTP.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_MCTP}
+ */
 #define ARPHRD_MCTP       290
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_PPP.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_PPP}
+ */
 #define ARPHRD_PPP        512
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_CISCO.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_CISCO}
+ */
 #define ARPHRD_CISCO      513          /* Cisco HDLC.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_HDLC.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_HDLC}
+ */
 #define ARPHRD_HDLC       ARPHRD_CISCO
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_LAPB.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_LAPB}
+ */
 #define ARPHRD_LAPB       516          /* LAPB.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_DDCMP.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_DDCMP}
+ */
 #define ARPHRD_DDCMP      517          /* Digital's DDCMP.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_RAWHDLC.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_RAWHDLC}
+ */
 #define ARPHRD_RAWHDLC    518          /* Raw HDLC.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_RAWIP.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_RAWIP}
+ */
 #define ARPHRD_RAWIP      519          /* Raw IP.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_TUNNEL.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_TUNNEL}
+ */
 #define ARPHRD_TUNNEL     768          /* IPIP tunnel.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_TUNNEL6.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_TUNNEL6}
+ */
 #define ARPHRD_TUNNEL6    769          /* IPIP6 tunnel.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_FRAD.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_FRAD}
+ */
 #define ARPHRD_FRAD       770          /* Frame Relay Access Device.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_SKIP.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_SKIP}
+ */
 #define ARPHRD_SKIP       771          /* SKIP vif.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_LOOPBACK.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_LOOPBACK}
+ */
 #define ARPHRD_LOOPBACK   772          /* Loopback device.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_LOCALTLK.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_LOCALTLK}
+ */
 #define ARPHRD_LOCALTLK   773          /* Localtalk device.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_FDDI.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_FDDI}
+ */
 #define ARPHRD_FDDI       774          /* Fiber Distributed Data Interface. */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_BIF.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_BIF}
+ */
 #define ARPHRD_BIF        775          /* AP1000 BIF.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_SIT.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_SIT}
+ */
 #define ARPHRD_SIT        776          /* sit0 device - IPv6-in-IPv4.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_IPDDP.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_IPDDP}
+ */
 #define ARPHRD_IPDDP      777          /* IP-in-DDP tunnel.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_IPGRE.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_IPGRE}
+ */
 #define ARPHRD_IPGRE      778          /* GRE over IP.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_PIMREG.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_PIMREG}
+ */
 #define ARPHRD_PIMREG     779          /* PIMSM register interface.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_HIPPI.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_HIPPI}
+ */
 #define ARPHRD_HIPPI      780          /* High Performance Parallel I'face. */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_ASH.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_ASH}
+ */
 #define ARPHRD_ASH        781          /* (Nexus Electronics) Ash.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_ECONET.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_ECONET}
+ */
 #define ARPHRD_ECONET     782          /* Acorn Econet.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_IRDA.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_IRDA}
+ */
 #define ARPHRD_IRDA       783          /* Linux-IrDA.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_FCPP.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_FCPP}
+ */
 #define ARPHRD_FCPP       784          /* Point to point fibrechanel.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_FCAL.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_FCAL}
+ */
 #define ARPHRD_FCAL       785          /* Fibrechanel arbitrated loop.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_FCPL.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_FCPL}
+ */
 #define ARPHRD_FCPL       786          /* Fibrechanel public loop.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_FCFABRIC.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_FCFABRIC}
+ */
 #define ARPHRD_FCFABRIC   787          /* Fibrechanel fabric.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_IEEE802_TR.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_IEEE802_TR}
+ */
 #define ARPHRD_IEEE802_TR 800          /* Magic type ident for TR.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_IEEE80211.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_IEEE80211}
+ */
 #define ARPHRD_IEEE80211  801          /* IEEE 802.11.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_IEEE80211_PRISM.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_IEEE80211_PRISM}
+ */
 #define ARPHRD_IEEE80211_PRISM    802  /* IEEE 802.11 + Prism2 header.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_IEEE80211_RADIOTAP.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_IEEE80211_RADIOTAP}
+ */
 #define ARPHRD_IEEE80211_RADIOTAP 803  /* IEEE 802.11 + radiotap header.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_IEEE802154.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_IEEE802154}
+ */
 #define ARPHRD_IEEE802154         804  /* IEEE 802.15.4 header.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_IEEE802154_PHY.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_IEEE802154_PHY}
+ */
 #define ARPHRD_IEEE802154_PHY     805  /* IEEE 802.15.4 PHY header.  */
 
+/**
+ * @brief Linux ARP hardware type ARPHRD_VOID.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_VOID}
+ */
 #define ARPHRD_VOID       0xFFFF       /* Void type, nothing is known.  */
+
+/**
+ * @brief Linux ARP hardware type ARPHRD_NONE.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{ARPHRD_NONE}
+ */
 #define ARPHRD_NONE       0xFFFE       /* Zero header length.  */
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/netdb.h
+++ b/include/zephyr/posix/netdb.h
@@ -3,6 +3,17 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+/**
+ * @file
+ * @brief Definitions for network database operations.
+ * @ingroup posix
+ *
+ * Provides hostname and service resolution (getaddrinfo() and getnameinfo())
+ * and the legacy host, network, protocol, and service database functions.
+ *
+ * @posix_header{netdb.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_NETDB_H_
 #define ZEPHYR_INCLUDE_POSIX_NETDB_H_
 
@@ -10,78 +21,386 @@
 
 #ifndef NI_MAXSERV
 /** Provide a reasonable size for apps using getnameinfo */
+/**
+ * @brief Reasonable buffer size for getnameinfo() service names.
+ */
 #define NI_MAXSERV 32
 #endif
 
+/**
+ * @brief The flags argument to getaddrinfo() contained an invalid value.
+ */
 #define EAI_BADFLAGS DNS_EAI_BADFLAGS
+
+/**
+ * @brief The name does not resolve for the supplied parameters.
+ */
 #define EAI_NONAME DNS_EAI_NONAME
+
+/**
+ * @brief The name could not be resolved at this time.
+ */
 #define EAI_AGAIN DNS_EAI_AGAIN
+
+/**
+ * @brief A non-recoverable error occurred.
+ */
 #define EAI_FAIL DNS_EAI_FAIL
+
+/**
+ * @brief No address is associated with the name.
+ */
 #define EAI_NODATA DNS_EAI_NODATA
+
+/**
+ * @brief There was a memory allocation failure.
+ */
 #define EAI_MEMORY DNS_EAI_MEMORY
+
+/**
+ * @brief A system error occurred; the error code can be found in errno.
+ */
 #define EAI_SYSTEM DNS_EAI_SYSTEM
+
+/**
+ * @brief The service passed was not recognized for the specified socket type.
+ */
 #define EAI_SERVICE DNS_EAI_SERVICE
+
+/**
+ * @brief The intended socket type was not recognized.
+ */
 #define EAI_SOCKTYPE DNS_EAI_SOCKTYPE
+
+/**
+ * @brief The address family was not recognized or the address length was invalid for the
+ * specified family.
+ */
 #define EAI_FAMILY DNS_EAI_FAMILY
+
+/**
+ * @brief An argument buffer overflowed.
+ */
 #define EAI_OVERFLOW DNS_EAI_OVERFLOW
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/**
+ * @brief Host database entry.
+ */
 struct hostent {
+	/**
+	 * @brief Official name of the host.
+	 */
 	char *h_name;
+	/**
+	 * @brief A pointer to an array of pointers to alternative host names.
+	 */
 	char **h_aliases;
+	/**
+	 * @brief Address type.
+	 */
 	int h_addrtype;
+	/**
+	 * @brief The length, in bytes, of the address.
+	 */
 	int h_length;
+	/**
+	 * @brief A pointer to an array of pointers to network addresses.
+	 */
 	char **h_addr_list;
 };
 
+/**
+ * @brief Network database entry.
+ */
 struct netent {
+	/**
+	 * @brief Official, fully-qualified name of the host.
+	 */
 	char *n_name;
+	/**
+	 * @brief A pointer to an array of pointers to alternative network names.
+	 */
 	char **n_aliases;
+	/**
+	 * @brief The address type of the network.
+	 */
 	int n_addrtype;
+	/**
+	 * @brief The network number, in host byte order.
+	 */
 	uint32_t n_net;
 };
 
+/**
+ * @brief Protocol database entry.
+ */
 struct protoent {
+	/**
+	 * @brief Official name of the protocol.
+	 */
 	char *p_name;
+	/**
+	 * @brief A pointer to an array of pointers to alternative protocol names.
+	 */
 	char **p_aliases;
+	/**
+	 * @brief The protocol number.
+	 */
 	int p_proto;
 };
 
+/**
+ * @brief Service database entry.
+ */
 struct servent {
+	/**
+	 * @brief Official name of the service.
+	 */
 	char *s_name;
+	/**
+	 * @brief A pointer to an array of pointers to alternative service names.
+	 */
 	char **s_aliases;
+	/**
+	 * @brief A value that yields the port number in network byte order when converted to
+	 * uint16_t.
+	 */
 	int s_port;
+	/**
+	 * @brief The name of the protocol to use when contacting the service.
+	 */
 	char *s_proto;
 };
 
+/**
+ * @brief Address information structure.
+ */
 #define addrinfo zsock_addrinfo
 
+/**
+ * @brief Close the hosts database (no-op on Zephyr).
+ *
+ * @posix_func{endhostent}
+ */
 void endhostent(void);
+
+/**
+ * @brief Close the networks database (no-op on Zephyr).
+ *
+ * @posix_func{endnetent}
+ */
 void endnetent(void);
+
+/**
+ * @brief Close the protocols database (no-op on Zephyr).
+ *
+ * @posix_func{endprotoent}
+ */
 void endprotoent(void);
+
+/**
+ * @brief Close the services database (no-op on Zephyr).
+ *
+ * @posix_func{endservent}
+ */
 void endservent(void);
+
+/**
+ * @brief Free the address information list returned by getaddrinfo().
+ *
+ * @param ai Linked list of address information structures to free.
+ *
+ * @posix_func{freeaddrinfo}
+ */
 void freeaddrinfo(struct addrinfo *ai);
+
+/**
+ * @brief Return a string describing a getaddrinfo() or getnameinfo() error code.
+ *
+ * @param errcode Error code returned by getaddrinfo() or getnameinfo().
+ *
+ * @return Pointer to a string describing the error.
+ *
+ * @posix_func{gai_strerror}
+ */
 const char *gai_strerror(int errcode);
+
+/**
+ * @brief Translate a hostname and service to a list of socket addresses.
+ *
+ * @param host    Hostname or numeric address string, or NULL.
+ * @param service Service name or numeric port string, or NULL.
+ * @param hints   Criteria for address selection, or NULL for defaults.
+ * @param res     Output: linked list of matching addresses.
+ *
+ * @return 0 on success, or a non-zero @c EAI_* error code on failure.
+ *
+ * @posix_func{getaddrinfo}
+ */
 int getaddrinfo(const char *host, const char *service, const struct addrinfo *hints,
 		struct addrinfo **res);
+
+/**
+ * @brief Get the next sequential entry from the hosts database.
+ *
+ * @return Pointer to a static hostent on success, or NULL at end of database or on error.
+ *
+ * @posix_func{gethostent}
+ */
 struct hostent *gethostent(void);
+
+/**
+ * @brief Translate a socket address to a hostname and service name.
+ *
+ * @param addr    Socket address to look up.
+ * @param addrlen Size of @p addr, in bytes.
+ * @param host    Output buffer for the hostname, or NULL.
+ * @param hostlen Size of @p host, in bytes.
+ * @param serv    Output buffer for the service name, or NULL.
+ * @param servlen Size of @p serv, in bytes.
+ * @param flags   @c NI_* flags controlling the conversion.
+ *
+ * @return 0 on success, or a non-zero @c EAI_* error code on failure.
+ *
+ * @posix_func{getnameinfo}
+ */
 int getnameinfo(const struct sockaddr *addr, socklen_t addrlen, char *host, socklen_t hostlen,
 		char *serv, socklen_t servlen, int flags);
+
+/**
+ * @brief Look up a network by address.
+ *
+ * @param net  Network number, in host byte order.
+ * @param type Address type of the network (@c AF_INET).
+ *
+ * @return Pointer to a static netent on success, or NULL on failure.
+ *
+ * @posix_func{getnetbyaddr}
+ */
 struct netent *getnetbyaddr(uint32_t net, int type);
+
+/**
+ * @brief Look up a network by name.
+ *
+ * @param name Network name.
+ *
+ * @return Pointer to a static netent on success, or NULL on failure.
+ *
+ * @posix_func{getnetbyname}
+ */
 struct netent *getnetbyname(const char *name);
+
+/**
+ * @brief Get the next sequential entry from the networks database.
+ *
+ * @return Pointer to a static netent on success, or NULL at end of database or on error.
+ *
+ * @posix_func{getnetent}
+ */
 struct netent *getnetent(void);
+
+/**
+ * @brief Look up a protocol by name.
+ *
+ * @param name Protocol name (e.g. "tcp").
+ *
+ * @return Pointer to a static protoent on success, or NULL on failure.
+ *
+ * @posix_func{getprotobyname}
+ */
 struct protoent *getprotobyname(const char *name);
+
+/**
+ * @brief Look up a protocol by number.
+ *
+ * @param proto Protocol number.
+ *
+ * @return Pointer to a static protoent on success, or NULL on failure.
+ *
+ * @posix_func{getprotobynumber}
+ */
 struct protoent *getprotobynumber(int proto);
+
+/**
+ * @brief Get the next sequential entry from the protocols database.
+ *
+ * @return Pointer to a static protoent on success, or NULL at end of database or on error.
+ *
+ * @posix_func{getprotoent}
+ */
 struct protoent *getprotoent(void);
+
+/**
+ * @brief Look up a service by name and protocol.
+ *
+ * @param name  Service name (e.g. "http").
+ * @param proto Protocol name ("tcp" or "udp"), or NULL for any protocol.
+ *
+ * @return Pointer to a static servent on success, or NULL on failure.
+ *
+ * @posix_func{getservbyname}
+ */
 struct servent *getservbyname(const char *name, const char *proto);
+
+/**
+ * @brief Look up a service by port number and protocol.
+ *
+ * @param port  Port number, in network byte order.
+ * @param proto Protocol name ("tcp" or "udp"), or NULL for any protocol.
+ *
+ * @return Pointer to a static servent on success, or NULL on failure.
+ *
+ * @posix_func{getservbyport}
+ */
 struct servent *getservbyport(int port, const char *proto);
+
+/**
+ * @brief Get the next sequential entry from the services database.
+ *
+ * @return Pointer to a static servent on success, or NULL at end of database or on error.
+ *
+ * @posix_func{getservent}
+ */
 struct servent *getservent(void);
+
+/**
+ * @brief Open the hosts database and reset its sequential position.
+ *
+ * @param stayopen Non-zero to keep the database open between queries.
+ *
+ * @posix_func{sethostent}
+ */
 void sethostent(int stayopen);
+
+/**
+ * @brief Open the networks database and reset its sequential position.
+ *
+ * @param stayopen Non-zero to keep the database open between queries.
+ *
+ * @posix_func{setnetent}
+ */
 void setnetent(int stayopen);
+
+/**
+ * @brief Open the protocols database and reset its sequential position.
+ *
+ * @param stayopen Non-zero to keep the database open between queries.
+ *
+ * @posix_func{setprotoent}
+ */
 void setprotoent(int stayopen);
+
+/**
+ * @brief Open the services database and reset its sequential position.
+ *
+ * @param stayopen Non-zero to keep the database open between queries.
+ *
+ * @posix_func{setservent}
+ */
 void setservent(int stayopen);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/netinet/in.h
+++ b/include/zephyr/posix/netinet/in.h
@@ -3,6 +3,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Internet address family.
+ * @ingroup posix
+ *
+ * Provides the fundamental Internet address and port types used across the
+ * BSD socket API and the IP protocol family headers.
+ *
+ * @posix_header{netinet_in.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_NETINET_IN_H_
 #define ZEPHYR_INCLUDE_POSIX_NETINET_IN_H_
 
@@ -14,13 +26,34 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Unsigned 16-bit Internet port number.
+ */
 typedef uint16_t in_port_t;
+
+/**
+ * @brief Unsigned 32-bit IPv4 address.
+ */
 typedef uint32_t in_addr_t;
 
+/**
+ * @brief IPv4 address structure.
+ */
 #define in_addr  net_in_addr
+
+/**
+ * @brief IPv6 address structure.
+ */
 #define in6_addr net_in6_addr
 
+/**
+ * @brief Buffer length sufficient to hold the text form of an IPv4 address.
+ */
 #define INET_ADDRSTRLEN  NET_INET_ADDRSTRLEN
+
+/**
+ * @brief Buffer length sufficient to hold the text form of an IPv6 address.
+ */
 #define INET6_ADDRSTRLEN NET_INET6_ADDRSTRLEN
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/netinet/tcp.h
+++ b/include/zephyr/posix/netinet/tcp.h
@@ -3,6 +3,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Definitions for the Internet Transmission Control Protocol.
+ * @ingroup posix
+ *
+ * TCP socket options and constants are defined by the underlying Zephyr
+ * networking stack. This header pulls them in via @c <zephyr/net/socket.h>.
+ *
+ * @posix_header{netinet_tcp.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_NETINET_TCP_H_
 #define ZEPHYR_INCLUDE_POSIX_NETINET_TCP_H_
 

--- a/include/zephyr/posix/poll.h
+++ b/include/zephyr/posix/poll.h
@@ -3,6 +3,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Definitions for the poll() function.
+ * @ingroup posix
+ *
+ * Provides the poll() function and associated poll event flags for
+ * multiplexed I/O on multiple file descriptors.
+ *
+ * @posix_header{poll.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_POLL_H_
 #define ZEPHYR_INCLUDE_POSIX_POLL_H_
 
@@ -12,17 +24,62 @@
 extern "C" {
 #endif
 
+/**
+ * @brief An unsigned integer type used for the number of file descriptors.
+ */
 typedef	unsigned int nfds_t;
 
+/**
+ * @brief File descriptor poll structure.
+ */
 #define pollfd zsock_pollfd
 
+/**
+ * @brief Data other than high-priority data may be read without blocking.
+ */
 #define POLLIN ZSOCK_POLLIN
+
+/**
+ * @brief High priority data may be read without blocking.
+ */
 #define POLLPRI ZSOCK_POLLPRI
+
+/**
+ * @brief Normal data may be written without blocking.
+ */
 #define POLLOUT ZSOCK_POLLOUT
+
+/**
+ * @brief An error has occurred (revents only).
+ */
 #define POLLERR ZSOCK_POLLERR
+
+/**
+ * @brief Device has been disconnected (revents only).
+ */
 #define POLLHUP ZSOCK_POLLHUP
+
+/**
+ * @brief Invalid fd member (revents only).
+ */
 #define POLLNVAL ZSOCK_POLLNVAL
 
+/**
+ * @brief Wait for events on a set of file descriptors.
+ *
+ * Examines each file descriptor in @p fds for the events specified in its
+ * @c events field. Blocks until at least one descriptor is ready, the
+ * timeout expires, or a signal is caught.
+ *
+ * @param fds     Array of @c struct pollfd descriptors to monitor.
+ * @param nfds    Number of entries in @p fds.
+ * @param timeout Timeout in milliseconds; -1 to block indefinitely, 0 to return immediately.
+ *
+ * @return Number of file descriptors with non-zero @c revents on success,
+ *         0 on timeout, or -1 with errno set on failure.
+ *
+ * @posix_func{poll}
+ */
 int poll(struct pollfd *fds, int nfds, int timeout);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/posix_features.h
+++ b/include/zephyr/posix/posix_features.h
@@ -5,6 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Standard symbolic constants and types.
+ * @ingroup posix
+ *
+ * Defines the @c _POSIX_* and @c _XOPEN_* symbolic constants for options and
+ * option groups that indicate which POSIX features the implementation
+ * supports.
+ *
+ * @posix_header{unistd.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_POSIX_FEATURES_H_
 #define ZEPHYR_INCLUDE_POSIX_POSIX_FEATURES_H_
 
@@ -16,19 +28,32 @@
  */
 
 #ifdef CONFIG_POSIX_AEP_REALTIME_MINIMAL
+/**
+ * @brief The implementation supports the Minimal Realtime System Profile (PSE51).
+ */
 #define _POSIX_AEP_REALTIME_MINIMAL 200312L
 #endif
 
 #ifdef CONFIG_POSIX_AEP_REALTIME_CONTROLLER
+/**
+ * @brief The implementation supports the Realtime Controller System Profile (PSE52).
+ */
 #define _POSIX_AEP_REALTIME_CONTROLLER 200312L
 #endif
 
 #ifdef CONFIG_POSIX_AEP_REALTIME_DEDICATED
+/**
+ * @brief The implementation supports the Dedicated Realtime System Profile (PSE53).
+ */
 #define _POSIX_AEP_REALTIME_DEDICATED 200312L
 #endif
 
 /*
  * Subprofiling Considerations
+ */
+
+/**
+ * @brief The implementation is a subprofile and need not provide all POSIX interfaces.
  */
 #define _POSIX_SUBPROFILE 1
 
@@ -36,63 +61,113 @@
  * POSIX System Interfaces
  */
 
+/**
+ * @brief The version of POSIX.1 to which the implementation conforms (POSIX.1-2008).
+ */
 #define _POSIX_VERSION 200809L
 
+/**
+ * @brief Use of chown() is restricted to a process with appropriate privileges.
+ */
 #define _POSIX_CHOWN_RESTRICTED (0)
+
+/**
+ * @brief Pathname components longer than @c NAME_MAX generate an error.
+ */
 #define _POSIX_NO_TRUNC         (0)
+
+/**
+ * @brief Character value that disables terminal special character handling.
+ */
 #define _POSIX_VDISABLE         ('\0')
 
 /* #define _POSIX_ADVISORY_INFO (-1L) */
 
 #ifdef CONFIG_POSIX_ASYNCHRONOUS_IO
+/**
+ * @brief The implementation supports asynchronous input and output.
+ */
 #define _POSIX_ASYNCHRONOUS_IO _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_POSIX_BARRIERS
+/**
+ * @brief The implementation supports barriers.
+ */
 #define _POSIX_BARRIERS _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_POSIX_FSYNC
+/**
+ * @brief The implementation supports the File Synchronization option.
+ */
 #define _POSIX_FSYNC _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_NET_IPV6
+/**
+ * @brief The implementation supports the IPv6 option.
+ */
 #define _POSIX_IPV6 _POSIX_VERSION
 #endif
 
 /* #define _POSIX_JOB_CONTROL (-1L) */
 
 #ifdef CONFIG_POSIX_MAPPED_FILES
+/**
+ * @brief The implementation supports memory mapped files.
+ */
 #define _POSIX_MAPPED_FILES _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_POSIX_MEMLOCK
+/**
+ * @brief The implementation supports the Process Memory Locking option.
+ */
 #define _POSIX_MEMLOCK _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_POSIX_MEMLOCK_RANGE
+/**
+ * @brief The implementation supports the Range Memory Locking option.
+ */
 #define _POSIX_MEMLOCK_RANGE _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_POSIX_MEMORY_PROTECTION
+/**
+ * @brief The implementation supports memory protection.
+ */
 #define _POSIX_MEMORY_PROTECTION _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_POSIX_MESSAGE_PASSING
+/**
+ * @brief The implementation supports the Message Passing option.
+ */
 #define _POSIX_MESSAGE_PASSING _POSIX_VERSION
 #endif
 
 /* #define _POSIX_PRIORITIZED_IO (-1L) */
 
 #ifdef CONFIG_POSIX_PRIORITY_SCHEDULING
+/**
+ * @brief The implementation supports the Process Scheduling option.
+ */
 #define _POSIX_PRIORITY_SCHEDULING _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_NET_SOCKETS_PACKET
+/**
+ * @brief The implementation supports the Raw Sockets option.
+ */
 #define _POSIX_RAW_SOCKETS _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_POSIX_RW_LOCKS
+/**
+ * @brief The implementation supports read-write locks.
+ */
 #define _POSIX_READER_WRITER_LOCKS _POSIX_VERSION
 #endif
 
@@ -100,10 +175,16 @@
 /* #define _POSIX_SAVED_IDS (-1L) */
 
 #ifdef CONFIG_POSIX_SEMAPHORES
+/**
+ * @brief The implementation supports semaphores.
+ */
 #define _POSIX_SEMAPHORES _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_POSIX_SHARED_MEMORY_OBJECTS
+/**
+ * @brief The implementation supports the Shared Memory Objects option.
+ */
 #define _POSIX_SHARED_MEMORY_OBJECTS _POSIX_VERSION
 #endif
 
@@ -111,36 +192,60 @@
 /* #define _POSIX_SPAWN (-1L) */
 
 #ifdef CONFIG_POSIX_SPIN_LOCKS
+/**
+ * @brief The implementation supports spin locks.
+ */
 #define _POSIX_SPIN_LOCKS _POSIX_VERSION
 #endif
 
 /* #define _POSIX_SPORADIC_SERVER (-1L) */
 
 #ifdef CONFIG_POSIX_SYNCHRONIZED_IO
+/**
+ * @brief The implementation supports the Synchronized Input and Output option.
+ */
 #define _POSIX_SYNCHRONIZED_IO _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_POSIX_THREAD_ATTR_STACKADDR
+/**
+ * @brief The implementation supports the Thread Stack Address Attribute option.
+ */
 #define _POSIX_THREAD_ATTR_STACKADDR _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_POSIX_THREAD_ATTR_STACKSIZE
+/**
+ * @brief The implementation supports the Thread Stack Size Attribute option.
+ */
 #define _POSIX_THREAD_ATTR_STACKSIZE _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_POSIX_THREAD_CPUTIME
+/**
+ * @brief The implementation supports the Thread CPU-Time Clocks option.
+ */
 #define _POSIX_THREAD_CPUTIME _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_POSIX_THREAD_PRIO_INHERIT
+/**
+ * @brief The implementation supports the Non-Robust Mutex Priority Inheritance option.
+ */
 #define _POSIX_THREAD_PRIO_INHERIT _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_POSIX_THREAD_PRIO_PROTECT
+/**
+ * @brief The implementation supports the Non-Robust Mutex Priority Protection option.
+ */
 #define _POSIX_THREAD_PRIO_PROTECT _POSIX_VERSION
 #endif
 
 #ifdef CONFIG_POSIX_THREAD_PRIORITY_SCHEDULING
+/**
+ * @brief The implementation supports the Thread Execution Scheduling option.
+ */
 #define _POSIX_THREAD_PRIORITY_SCHEDULING _POSIX_VERSION
 #endif
 
@@ -152,11 +257,17 @@
 
 #ifdef CONFIG_POSIX_THREADS
 #ifndef _POSIX_THREADS
+/**
+ * @brief The implementation supports threads.
+ */
 #define _POSIX_THREADS _POSIX_VERSION
 #endif
 #endif
 
 #ifdef CONFIG_POSIX_TIMEOUTS
+/**
+ * @brief The implementation supports timeouts.
+ */
 #define _POSIX_TIMEOUTS _POSIX_VERSION
 #endif
 
@@ -186,6 +297,10 @@
  * POSIX2 Options
  */
 /* #define _POSIX2_VERSION (-1) */
+
+/**
+ * @brief The implementation supports the C-Language Binding option.
+ */
 #define _POSIX2_C_BIND _POSIX_VERSION
 /* #define _POSIX2_C_DEV (-1) */
 /* #define _POSIX2_CHAR_TERM (-1L) */
@@ -204,6 +319,10 @@
 /*
  * X/Open System Interfaces
  */
+
+/**
+ * @brief The version of the X/Open Portability Guide to which the implementation conforms.
+ */
 #define _XOPEN_VERSION 700
 /* #define _XOPEN_CRYPT (-1L) */
 /* #define _XOPEN_ENH_I18N (-1L) */
@@ -212,12 +331,19 @@
 	 defined(CONFIG_POSIX_MEMLOCK_RANGE) && defined(CONFIG_POSIX_MESSAGE_PASSING) &&           \
 	 defined(CONFIG_POSIX_PRIORITY_SCHEDULING) &&                                              \
 	 defined(CONFIG_POSIX_SHARED_MEMORY_OBJECTS) && defined(CONFIG_POSIX_SYNCHRONIZED_IO))
+
+/**
+ * @brief The implementation supports the X/Open Realtime Option Group.
+ */
 #define _XOPEN_REALTIME _XOPEN_VERSION
 #endif
 /* #define _XOPEN_REALTIME_THREADS (-1L) */
 /* #define _XOPEN_SHM (-1L) */
 
 #ifdef CONFIG_XOPEN_STREAMS
+/**
+ * @brief The implementation supports the XSI STREAMS Option Group.
+ */
 #define _XOPEN_STREAMS _XOPEN_VERSION
 #endif
 

--- a/include/zephyr/posix/posix_limits.h
+++ b/include/zephyr/posix/posix_limits.h
@@ -4,6 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Implementation-defined constants.
+ * @ingroup posix
+ *
+ * Defines minimum, maximum, and runtime-invariant POSIX limits that complement
+ * the C standard limits.h header and the runtime sysconf() and pathconf()
+ * interfaces.
+ *
+ * @posix_header{limits.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_POSIX_LIMITS_H_
 #define ZEPHYR_INCLUDE_POSIX_POSIX_LIMITS_H_
 
@@ -17,109 +29,467 @@
 /* clang-format off */
 
 /* Maximum values */
+
+/**
+ * @brief Maximum nanoseconds between clock ticks (20 ms).
+ */
 #define _POSIX_CLOCKRES_MIN (20000000L)
 
 /* Minimum values */
+
+/**
+ * @brief Minimum number of I/O operations in a single list I/O call.
+ */
 #define _POSIX_AIO_LISTIO_MAX               (2)
+
+/**
+ * @brief Minimum number of outstanding asynchronous I/O operations.
+ */
 #define _POSIX_AIO_MAX                      (1)
+
+/**
+ * @brief Minimum length of arguments to the exec functions, including environment data.
+ */
 #define _POSIX_ARG_MAX                      (4096)
+
+/**
+ * @brief Minimum number of simultaneous processes per real user ID.
+ */
 #define _POSIX_CHILD_MAX                    (25)
+
+/**
+ * @brief Minimum number of timer expiration overruns.
+ */
 #define _POSIX_DELAYTIMER_MAX               (32)
+
+/**
+ * @brief Minimum length of a host name, not including the terminating null.
+ */
 #define _POSIX_HOST_NAME_MAX                (255)
+
+/**
+ * @brief Minimum number of links to a single file.
+ */
 #define _POSIX_LINK_MAX                     (8)
+
+/**
+ * @brief Minimum length of a login name.
+ */
 #define _POSIX_LOGIN_NAME_MAX               (9)
+
+/**
+ * @brief Minimum number of bytes in a terminal canonical input queue.
+ */
 #define _POSIX_MAX_CANON                    (255)
+
+/**
+ * @brief Minimum number of bytes in a terminal input queue.
+ */
 #define _POSIX_MAX_INPUT                    (255)
+
+/**
+ * @brief Minimum number of message queues that a process may hold open at one time.
+ */
 #define _POSIX_MQ_OPEN_MAX                  (8)
+
+/**
+ * @brief Minimum number of supported message priorities.
+ */
 #define _POSIX_MQ_PRIO_MAX                  (32)
+
+/**
+ * @brief Minimum number of bytes in a filename, not including the terminating null.
+ */
 #define _POSIX_NAME_MAX                     (14)
+
+/**
+ * @brief Minimum number of supplementary group IDs per process.
+ */
 #define _POSIX_NGROUPS_MAX                  (8)
+
+/**
+ * @brief Minimum number of files that a process may have open at one time.
+ */
 #define _POSIX_OPEN_MAX                     (20)
+
+/**
+ * @brief Minimum number of bytes in a pathname, including the terminating null.
+ */
 #define _POSIX_PATH_MAX                     (256)
+
+/**
+ * @brief Minimum number of bytes that can be written atomically to a pipe.
+ */
 #define _POSIX_PIPE_BUF                     (512)
+
+/**
+ * @brief Minimum number of repeated occurrences of a regular expression in an interval expression.
+ */
 #define _POSIX_RE_DUP_MAX                   (255)
+
+/**
+ * @brief Minimum number of realtime signals reserved for application use.
+ */
 #define _POSIX_RTSIG_MAX                    (8)
+
+/**
+ * @brief Minimum number of semaphores that a process may have.
+ */
 #define _POSIX_SEM_NSEMS_MAX                (256)
+
+/**
+ * @brief Minimum value that the maximum value of a semaphore may have.
+ */
 #define _POSIX_SEM_VALUE_MAX                (32767)
+
+/**
+ * @brief Minimum number of queued signals that a process may send and have pending.
+ */
 #define _POSIX_SIGQUEUE_MAX                 (32)
+
+/**
+ * @brief Value guaranteed to be storable in an object of type ssize_t.
+ */
 #define _POSIX_SSIZE_MAX                    (32767)
+
+/**
+ * @brief Minimum number of simultaneously pending replenishment operations for a sporadic server.
+ */
 #define _POSIX_SS_REPL_MAX                  (4)
+
+/**
+ * @brief Minimum number of streams that a process may have open at one time.
+ */
 #define _POSIX_STREAM_MAX                   (8)
+
+/**
+ * @brief Minimum number of bytes in a symbolic link.
+ */
 #define _POSIX_SYMLINK_MAX                  (255)
+
+/**
+ * @brief Minimum number of symbolic links traversable during pathname resolution.
+ */
 #define _POSIX_SYMLOOP_MAX                  (8)
+
+/**
+ * @brief Minimum number of attempts made to destroy thread-specific data on thread exit.
+ */
 #define _POSIX_THREAD_DESTRUCTOR_ITERATIONS (4)
+
+/**
+ * @brief Minimum number of thread-specific data keys per process.
+ */
 #define _POSIX_THREAD_KEYS_MAX              (128)
+
+/**
+ * @brief Minimum number of threads per process.
+ */
 #define _POSIX_THREAD_THREADS_MAX           (64)
+
+/**
+ * @brief Minimum number of per-process timers.
+ */
 #define _POSIX_TIMER_MAX                    (32)
+
+/**
+ * @brief Minimum length of a trace event name.
+ */
 #define _POSIX_TRACE_EVENT_NAME_MAX         (30)
+
+/**
+ * @brief Minimum length of a trace generation version string or stream name.
+ */
 #define _POSIX_TRACE_NAME_MAX               (8)
+
+/**
+ * @brief Minimum number of trace streams that may simultaneously exist in the system.
+ */
 #define _POSIX_TRACE_SYS_MAX                (8)
+
+/**
+ * @brief Minimum number of user trace event type identifiers per process.
+ */
 #define _POSIX_TRACE_USER_EVENT_MAX         (32)
+
+/**
+ * @brief Minimum length of a terminal device name.
+ */
 #define _POSIX_TTY_NAME_MAX                 (9)
+
+/**
+ * @brief Minimum number of bytes supported for the name of a timezone.
+ */
 #define _POSIX_TZNAME_MAX                   (6)
+
+/**
+ * @brief Minimum maximum obase value allowed by the bc utility.
+ */
 #define _POSIX2_BC_BASE_MAX                 (99)
+
+/**
+ * @brief Minimum maximum number of elements permitted in a bc array.
+ */
 #define _POSIX2_BC_DIM_MAX                  (2048)
+
+/**
+ * @brief Minimum maximum scale value allowed by the bc utility.
+ */
 #define _POSIX2_BC_SCALE_MAX                (99)
+
+/**
+ * @brief Minimum maximum length of a string constant accepted by the bc utility.
+ */
 #define _POSIX2_BC_STRING_MAX               (1000)
+
+/**
+ * @brief Minimum number of bytes in a character class name.
+ */
 #define _POSIX2_CHARCLASS_NAME_MAX          (14)
+
+/**
+ * @brief Minimum number of weights assignable to a locale collating entry.
+ */
 #define _POSIX2_COLL_WEIGHTS_MAX            (2)
+
+/**
+ * @brief Minimum number of expressions nestable within parentheses by the expr utility.
+ */
 #define _POSIX2_EXPR_NEST_MAX               (32)
+
+/**
+ * @brief Minimum length, in bytes, of a utility's input line.
+ */
 #define _POSIX2_LINE_MAX                    (2048)
+
+/**
+ * @brief Minimum number of iovec structures that a process may use with readv() or writev().
+ */
 #define _XOPEN_IOV_MAX                      (16)
+
+/**
+ * @brief Minimum number of bytes in a filename on XSI-conformant systems.
+ */
 #define _XOPEN_NAME_MAX                     (255)
+
+/**
+ * @brief Minimum number of bytes in a pathname on XSI-conformant systems.
+ */
 #define _XOPEN_PATH_MAX                     (1024)
 
 /* Other invariant values */
+
+/**
+ * @brief Maximum number of bytes in a LANG name.
+ */
 #define NL_LANGMAX (14)
+
+/**
+ * @brief Maximum message number.
+ */
 #define NL_MSGMAX  (32767)
+
+/**
+ * @brief Maximum set number.
+ */
 #define NL_SETMAX  (255)
+
+/**
+ * @brief Maximum number of bytes in a message string.
+ */
 #define NL_TEXTMAX (_POSIX2_LINE_MAX)
+
+/**
+ * @brief Default process priority.
+ */
 #define NZERO      (20)
 
 /* Runtime invariant values */
+
+/**
+ * @brief Maximum number of I/O operations in a single list I/O call supported by the
+ * implementation.
+ */
 #define AIO_LISTIO_MAX                _POSIX_AIO_LISTIO_MAX
+
+/**
+ * @brief Maximum number of outstanding asynchronous I/O operations supported by the implementation.
+ */
 #define AIO_MAX                       _POSIX_AIO_MAX
+
+/**
+ * @brief The maximum amount by which a process can decrease its asynchronous I/O priority level
+ * from its own scheduling priority.
+ */
 #define AIO_PRIO_DELTA_MAX            (0)
+
+/**
+ * @brief Maximum length of argument to the exec functions including environment data.
+ */
 #define ARG_MAX                       _POSIX_ARG_MAX
+
+/**
+ * @brief Maximum number of functions that may be registered with atexit().
+ */
 #define ATEXIT_MAX                    (32)
+
+/**
+ * @brief Maximum number of timer expiration overruns.
+ */
 #define DELAYTIMER_MAX \
 	COND_CODE_1(CONFIG_POSIX_TIMERS, (CONFIG_POSIX_DELAYTIMER_MAX), (0))
+
+/**
+ * @brief Maximum length of a host name (not including the terminating null) as returned from the
+ * gethostname() function.
+ */
 #define HOST_NAME_MAX \
 	COND_CODE_1(CONFIG_POSIX_NETWORKING, (CONFIG_POSIX_HOST_NAME_MAX), (0))
+
+/**
+ * @brief Maximum length of a login name.
+ */
 #define LOGIN_NAME_MAX                _POSIX_LOGIN_NAME_MAX
+
+/**
+ * @brief The maximum number of open message queue descriptors a process may hold.
+ */
 #define MQ_OPEN_MAX \
 	COND_CODE_1(CONFIG_POSIX_MESSAGE_PASSING, (CONFIG_POSIX_MQ_OPEN_MAX), (0))
+
+/**
+ * @brief The maximum number of message priorities supported by the implementation.
+ */
 #define MQ_PRIO_MAX                   _POSIX_MQ_PRIO_MAX
+
+/**
+ * @brief A value one greater than the maximum value that the system may assign to a newly-created
+ * file descriptor.
+ */
 #define OPEN_MAX                      CONFIG_POSIX_OPEN_MAX
+
+/**
+ * @brief Equivalent to {PAGESIZE}.
+ */
 #define PAGE_SIZE                     CONFIG_POSIX_PAGE_SIZE
+
+/**
+ * @brief Size in bytes of a page.
+ */
 #define PAGESIZE                      CONFIG_POSIX_PAGE_SIZE
+
+/**
+ * @brief Maximum number of bytes the implementation will store as a pathname in a user-supplied
+ * buffer of unspecified size, including the terminating null character.
+ */
 #define PATH_MAX                      _POSIX_PATH_MAX
+
+/**
+ * @brief Maximum number of attempts made to destroy a thread's thread-specific data values on
+ * thread exit.
+ */
 #define PTHREAD_DESTRUCTOR_ITERATIONS _POSIX_THREAD_DESTRUCTOR_ITERATIONS
+
+/**
+ * @brief Maximum number of data keys that can be created by a process.
+ */
 #define PTHREAD_KEYS_MAX \
 	COND_CODE_1(CONFIG_POSIX_THREADS, (CONFIG_POSIX_THREAD_KEYS_MAX), (0))
+
+/**
+ * @brief Maximum number of threads that can be created per process.
+ */
 #define PTHREAD_THREADS_MAX \
 	COND_CODE_1(CONFIG_POSIX_THREADS, (CONFIG_POSIX_THREAD_THREADS_MAX), (0))
+
+/**
+ * @brief Maximum number of realtime signals reserved for application use in this implementation.
+ */
 #define RTSIG_MAX \
 	COND_CODE_1(CONFIG_POSIX_REALTIME_SIGNALS, (CONFIG_POSIX_RTSIG_MAX), (0))
+
+/**
+ * @brief Maximum number of semaphores that a process may have.
+ */
 #define SEM_NSEMS_MAX \
 	COND_CODE_1(CONFIG_POSIX_SEMAPHORES, (CONFIG_POSIX_SEM_NSEMS_MAX), (0))
+
+/**
+ * @brief The maximum value a semaphore may have.
+ */
 #define SEM_VALUE_MAX \
 	COND_CODE_1(CONFIG_POSIX_SEMAPHORES, (CONFIG_POSIX_SEM_VALUE_MAX), (0))
+
+/**
+ * @brief Maximum number of queued signals that a process may send and have pending at the
+ * receiver(s) at any time.
+ */
 #define SIGQUEUE_MAX                  _POSIX_SIGQUEUE_MAX
+
+/**
+ * @brief Maximum number of streams that one process can have open at one time.
+ */
 #define STREAM_MAX                    _POSIX_STREAM_MAX
+
+/**
+ * @brief Maximum number of symbolic links that can be reliably traversed in the resolution of a
+ * pathname in the absence of a loop.
+ */
 #define SYMLOOP_MAX                   _POSIX_SYMLOOP_MAX
+
+/**
+ * @brief Maximum number of timers per process supported by the implementation.
+ */
 #define TIMER_MAX \
 	COND_CODE_1(CONFIG_POSIX_TIMERS, (CONFIG_POSIX_TIMER_MAX), (0))
+
+/**
+ * @brief Maximum length of terminal device name.
+ */
 #define TTY_NAME_MAX                  _POSIX_TTY_NAME_MAX
+
+/**
+ * @brief Maximum number of bytes supported for the name of a timezone (not of the TZ variable).
+ */
 #define TZNAME_MAX                    _POSIX_TZNAME_MAX
 
 /* Pathname variable values */
+
+/**
+ * @brief Minimum number of bits needed to represent, as a signed integer value, the maximum size of
+ * a regular file allowed in the specified directory.
+ */
 #define FILESIZEBITS             (32)
+
+/**
+ * @brief Minimum number of bytes of storage actually allocated for any portion of a file.
+ */
 #define POSIX_ALLOC_SIZE_MIN     (256)
+
+/**
+ * @brief Recommended increment for file transfer sizes between the {POSIX_REC_MIN_XFER_SIZE} and
+ * {POSIX_REC_MAX_XFER_SIZE} values.
+ */
 #define POSIX_REC_INCR_XFER_SIZE (1024)
+
+/**
+ * @brief Maximum recommended file transfer size.
+ */
 #define POSIX_REC_MAX_XFER_SIZE  (32767)
+
+/**
+ * @brief Minimum recommended file transfer size.
+ */
 #define POSIX_REC_MIN_XFER_SIZE  (1)
+
+/**
+ * @brief Recommended file transfer buffer alignment.
+ */
 #define POSIX_REC_XFER_ALIGN     (4)
+
+/**
+ * @brief Maximum number of bytes in a symbolic link.
+ */
 #define SYMLINK_MAX              _POSIX_SYMLINK_MAX
 
 /* clang-format on */

--- a/include/zephyr/posix/posix_signal.h
+++ b/include/zephyr/posix/posix_signal.h
@@ -3,6 +3,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Signals.
+ * @ingroup posix
+ *
+ * Provides signal numbers, signal sets, signal actions, real-time signal
+ * extensions, and the POSIX signal-management functions.
+ *
+ * @posix_header{signal.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_POSIX_SIGNAL_H_
 #define ZEPHYR_INCLUDE_POSIX_POSIX_SIGNAL_H_
 
@@ -19,6 +31,9 @@ extern "C" {
 /* SIG_ERR must be defined by the libc signal.h */
 
 #if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
+/**
+ * @brief Signal disposition to hold the signal (XSI extension, used with sigset()).
+ */
 #define SIG_HOLD ((void *)-2)
 #endif
 
@@ -27,9 +42,16 @@ extern "C" {
 #if defined(_POSIX_THREADS) || defined(__DOXYGEN__)
 
 #if !defined(_PTHREAD_T_DECLARED) && !defined(__pthread_t_defined)
+/**
+ * @brief POSIX type pthread_t.
+ */
 typedef unsigned int pthread_t;
+/** @cond INTERNAL_HIDDEN */
 #define _PTHREAD_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __pthread_t_defined
+/** @endcond */
 #endif
 
 #endif /* defined(_POSIX_THREADS) || defined(__DOXYGEN__) */
@@ -38,9 +60,16 @@ typedef unsigned int pthread_t;
 #include <stddef.h>
 
 #if !defined(_UID_T_DECLARED) && !defined(__uid_t_defined)
+/**
+ * @brief POSIX type uid_t.
+ */
 typedef int uid_t;
+/** @cond INTERNAL_HIDDEN */
 #define _UID_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __uid_t_defined
+/** @endcond */
 #endif
 
 /* time_t must be defined by the libc time.h */
@@ -50,48 +79,101 @@ typedef int uid_t;
 /* struct timespec must be defined in the libc time.h */
 #else
 #if !defined(_TIMESPEC_DECLARED) && !defined(__timespec_defined)
+/**
+ * @brief Time interval in seconds and nanoseconds.
+ */
 struct timespec {
+	/**
+	 * @brief Seconds component.
+	 */
 	time_t tv_sec;
+	/**
+	 * @brief Nanoseconds component.
+	 */
 	long tv_nsec;
 };
+/** @cond INTERNAL_HIDDEN */
 #define _TIMESPEC_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __timespec_defined
+/** @endcond */
 #endif
 #endif
 
 /* sig_atomic_t must be defined by the libc signal.h */
 
+/**
+ * @brief Minimum realtime signal number.
+ */
 #define SIGRTMIN 32
 #if defined(_POSIX_REALTIME_SIGNALS) || defined(__DOXYGEN__)
 BUILD_ASSERT(CONFIG_POSIX_RTSIG_MAX >= 0);
+
+/**
+ * @brief Maximum realtime signal number.
+ */
 #define SIGRTMAX (SIGRTMIN + CONFIG_POSIX_RTSIG_MAX)
 #else
+/**
+ * @brief Maximum realtime signal number.
+ */
 #define SIGRTMAX SIGRTMIN
 #endif
 
 #if !defined(_SIGSET_T_DECLARED) && !defined(__sigset_t_defined)
+/**
+ * @brief Set of signals.
+ */
 typedef struct {
+	/**
+	 * @brief Signal bit mask storage.
+	 */
 	unsigned long sig[DIV_ROUND_UP(SIGRTMAX + 1, BITS_PER_LONG)];
 } sigset_t;
+/** @cond INTERNAL_HIDDEN */
 #define _SIGSET_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __sigset_t_defined
+/** @endcond */
 #endif
 
 #if !defined(_PID_T_DECLARED) && !defined(__pid_t_defined)
+/**
+ * @brief POSIX type pid_t.
+ */
 typedef long pid_t;
+/** @cond INTERNAL_HIDDEN */
 #define _PID_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __pid_t_defined
+/** @endcond */
 #endif
 
 #if defined(_POSIX_THREADS) || defined(__DOXYGEN__)
 
 #if !defined(_PTHREAD_ATTR_T_DECLARED) && !defined(__pthread_attr_t_defined)
+/**
+ * @brief Thread creation attributes.
+ */
 typedef struct {
+	/**
+	 * @brief Thread stack address.
+	 */
 	void *stack;
+	/**
+	 * @brief Implementation-defined thread attributes.
+	 */
 	unsigned int details[2];
 } pthread_attr_t;
+/** @cond INTERNAL_HIDDEN */
 #define _PTHREAD_ATTR_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __pthread_attr_t_defined
+/** @endcond */
 #endif
 
 #endif
@@ -100,30 +182,77 @@ typedef struct {
 
 /* slightly out of order w.r.t. the specification */
 #if !defined(_SIGVAL_DECLARED) && !defined(__sigval_defined)
+/**
+ * @brief Value passed to a signal handler or retrieved via siginfo_t.
+ */
 union sigval {
+	/**
+	 * @brief Integer signal value.
+	 */
 	int sival_int;
+	/**
+	 * @brief Pointer signal value.
+	 */
 	void *sival_ptr;
 };
+/** @cond INTERNAL_HIDDEN */
 #define _SIGVAL_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __sigval_defined
+/** @endcond */
 #endif
 
 #if !defined(_SIGEVENT_DECLARED) && !defined(__sigevent_defined)
+/**
+ * @brief Signal event notification settings.
+ */
 struct sigevent {
 #if defined(_POSIX_THREADS) || defined(__DOXYGEN__)
+	/**
+	 * @brief Notification attributes.
+	 */
 	pthread_attr_t *sigev_notify_attributes;
+	/**
+	 * @brief Signal notification callback.
+	 */
 	void (*sigev_notify_function)(union sigval value);
 #endif
+	/**
+	 * @brief Signal value.
+	 */
 	union sigval sigev_value;
+	/**
+	 * @brief Notification type.
+	 */
 	int sigev_notify;
+	/**
+	 * @brief Signal number.
+	 */
 	int sigev_signo;
 };
+/** @cond INTERNAL_HIDDEN */
 #define _SIGEVENT_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __sigevent_defined
+/** @endcond */
 #endif
 
+/**
+ * @brief No asynchronous notification is delivered when the event of interest occurs.
+ */
 #define SIGEV_NONE   1
+
+/**
+ * @brief A queued signal, with an application-defined value, is generated when the event of
+ * interest occurs.
+ */
 #define SIGEV_SIGNAL 2
+
+/**
+ * @brief A notification function is called to perform notification.
+ */
 #define SIGEV_THREAD 3
 
 /* Signal constants are defined below */
@@ -133,89 +262,250 @@ struct sigevent {
 /* SIGRTMIN and SIGRTMAX defined above */
 
 #if !defined(_SIGINFO_T_DECLARED) && !defined(__siginfo_t_defined)
+/**
+ * @brief Signal information.
+ */
 typedef struct {
+	/**
+	 * @brief Address associated with the signal.
+	 */
 	void *si_addr;
 #if defined(_XOPEN_STREAMS) || defined(__DOXYGEN__)
+	/**
+	 * @brief Band event for stream-related signals.
+	 */
 	long si_band;
 #endif
+	/**
+	 * @brief Signal value.
+	 */
 	union sigval si_value;
+	/**
+	 * @brief Sending process ID.
+	 */
 	pid_t si_pid;
+	/**
+	 * @brief Real user ID of the sending process.
+	 */
 	uid_t si_uid;
+	/**
+	 * @brief Signal number.
+	 */
 	int si_signo;
+	/**
+	 * @brief Signal code.
+	 */
 	int si_code;
 #if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
+	/**
+	 * @brief Error number associated with the signal.
+	 */
 	int si_errno;
 #endif
+	/**
+	 * @brief Exit status or signal value.
+	 */
 	int si_status;
 } siginfo_t;
+/** @cond INTERNAL_HIDDEN */
 #define _SIGINFO_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __siginfo_t_defined
+/** @endcond */
 #endif
 
 #if defined(_POSIX_REALTIME_SIGNALS) || defined(__DOXYGEN__)
 
 #if !defined(_SIGACTION_DECLARED) && !defined(__sigaction_defined)
+/**
+ * @brief Signal action settings.
+ */
 struct sigaction {
+	/**
+	 * @brief Signal action callback storage.
+	 */
 	union {
+		/**
+		 * @brief Signal handler callback.
+		 */
 		void (*sa_handler)(int sig);
+		/**
+		 * @brief Queued signal action callback.
+		 */
 		void (*sa_sigaction)(int sig, siginfo_t *info, void *context);
 	};
+	/**
+	 * @brief Set of signals to be blocked during execution.
+	 */
 	sigset_t sa_mask;
+	/**
+	 * @brief Special flags.
+	 */
 	int sa_flags;
 };
+/** @cond INTERNAL_HIDDEN */
 #define _SIGACTION_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __sigaction_defined
+/** @endcond */
 #endif
 
+/**
+ * @brief The resulting set is the union of the current set and the signal set pointed to by the
+ * argument set.
+ */
 #define SIG_BLOCK   1
+
+/**
+ * @brief The resulting set is the intersection of the current set and the complement of the signal
+ * set pointed to by the argument set.
+ */
 #define SIG_UNBLOCK 2
+
+/**
+ * @brief The resulting set is the signal set pointed to by the argument set.
+ */
 #define SIG_SETMASK 0
 
 #if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
+/**
+ * @brief Do not generate @c SIGCHLD when child processes stop.
+ */
 #define SA_NOCLDSTOP 0x00000001
+
+/**
+ * @brief Causes signal delivery to occur on an alternate stack.
+ */
 #define SA_ONSTACK   0x00000002
 #endif
+
+/**
+ * @brief Causes signal dispositions to be set to SIG_DFL on entry to signal handlers.
+ */
 #define SA_RESETHAND 0x00000004
+
+/**
+ * @brief Causes certain functions to become restartable.
+ */
 #define SA_RESTART   0x00000008
+
+/**
+ * @brief Causes extra information to be passed to signal handlers at the time of receipt of a
+ * signal.
+ */
 #define SA_SIGINFO   0x00000010
 #if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
+/**
+ * @brief Causes implementations not to create zombie processes or status information on child
+ * termination.
+ */
 #define SA_NOCLDWAIT 0x00000020
 #endif
+
+/**
+ * @brief Causes signal not to be automatically blocked on entry to signal handler.
+ */
 #define SA_NODEFER  0x00000040
+
+/**
+ * @brief Process is executing on an alternate signal stack.
+ */
 #define SS_ONSTACK  0x00000001
+
+/**
+ * @brief Alternate signal stack is disabled.
+ */
 #define SS_DISABLE  0x00000002
+
+/**
+ * @brief Minimum stack size for a signal handler.
+ */
 #define MINSIGSTKSZ 4096
+
+/**
+ * @brief Default size in bytes for the alternate signal stack.
+ */
 #define SIGSTKSZ    4096
 
 #if !defined(_MCONTEXT_T_DECLARED) && !defined(__mcontext_t_defined)
+/**
+ * @brief Machine-specific context saved when a signal is delivered.
+ */
 typedef struct {
 	/* FIXME: there should be a much better Zephyr-specific structure that can be used here */
+	/**
+	 * @brief General register storage.
+	 */
 	unsigned long gregs[32];
+	/**
+	 * @brief Machine context flags.
+	 */
 	unsigned long flags;
 } mcontext_t;
+/** @cond INTERNAL_HIDDEN */
 #define _MCONTEXT_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __mcontext_defined
+/** @endcond */
 #endif
 
 #if !defined(_STACK_T_DECLARED) && !defined(__stack_t_defined)
+/**
+ * @brief Alternate signal stack descriptor.
+ */
 typedef struct {
+	/**
+	 * @brief Stack base address.
+	 */
 	void *ss_sp;
+	/**
+	 * @brief Stack size in bytes.
+	 */
 	size_t ss_size;
+	/**
+	 * @brief Stack flags.
+	 */
 	int ss_flags;
 } stack_t;
+/** @cond INTERNAL_HIDDEN */
 #define _STACK_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __stack_t_defined
+/** @endcond */
 #endif
 
 #if !defined(_UCONTEXT_T_DECLARED) && !defined(__ucontext_t_defined)
+/**
+ * @brief User-space context saved and restored by getcontext()/setcontext().
+ */
 typedef struct {
+	/**
+	 * @brief Linked user context.
+	 */
 	struct ucontext *uc_link;
+	/**
+	 * @brief Blocked signal mask.
+	 */
 	sigset_t uc_sigmask;
+	/**
+	 * @brief Signal stack for this context.
+	 */
 	stack_t uc_stack;
+	/**
+	 * @brief Machine context for this context.
+	 */
 	mcontext_t uc_mcontext;
 } ucontext_t;
+/** @cond INTERNAL_HIDDEN */
 #define _UCONTEXT_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __ucontext_defined
+/** @endcond */
 #endif
 
 #endif /* defined(_POSIX_REALTIME_SIGNALS) || defined(__DOXYGEN__) */
@@ -223,169 +513,726 @@ typedef struct {
 /* Siginfo codes are defined below */
 
 #if !defined(_SIGHANDLER_T_DECLARED) && !defined(__sighandler_t_defined)
+/**
+ * @brief Signal handler function pointer.
+ */
 typedef void (*sighandler_t)(int sig);
+/** @cond INTERNAL_HIDDEN */
 #define _SIGHANDLER_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __sighandler_t_defined
+/** @endcond */
 #endif
 
+/**
+ * @brief Send a signal to a process or a group of processes.
+ *
+ * @param pid Target process ID (positive), process group (negative), or 0.
+ * @param sig Signal number, or 0 to check process existence.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{kill}
+ */
 int kill(pid_t pid, int sig);
 #if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
+/**
+ * @brief Send a signal to a process group.
+ *
+ * @param pgrp Process group ID, or 0 for the calling process's process group.
+ * @param sig  Signal number.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{killpg}
+ */
 int killpg(pid_t pgrp, int sig);
 #endif
+
+/**
+ * @brief Print a signal description with additional siginfo_t context.
+ *
+ * @param info    Signal information.
+ * @param message Prefix string.
+ *
+ * @posix_func{psiginfo}
+ */
 void psiginfo(const siginfo_t *info, const char *message);
+
+/**
+ * @brief Print a signal description to stderr.
+ *
+ * @param sig     Signal number.
+ * @param message Prefix string.
+ *
+ * @posix_func{psignal}
+ */
 void psignal(int sig, const char *message);
 #if defined(_POSIX_THREADS) || defined(__DOXYGEN__)
+/**
+ * @brief Send a signal to a thread.
+ *
+ * @param thread Target thread.
+ * @param sig    Signal number, or 0 to check thread existence.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_kill}
+ */
 int pthread_kill(pthread_t thread, int sig);
+
+/**
+ * @brief Examine and change blocked signals for the calling thread.
+ *
+ * @param how  @c SIG_BLOCK, @c SIG_UNBLOCK, or @c SIG_SETMASK.
+ * @param set  Signal set to apply, or NULL.
+ * @param oset Output: previous signal mask, or NULL.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_sigmask}
+ */
 int pthread_sigmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT oset);
 #endif
+
+/**
+ * @brief Send a signal to the executing process.
+ *
+ * @posix_func{raise}
+ */
 /* raise() must be defined by the libc signal.h */
 #if defined(_POSIX_REALTIME_SIGNALS) || defined(__DOXYGEN__)
+/** @cond INTERNAL_HIDDEN */
 TOOLCHAIN_DISABLE_WARNING(TOOLCHAIN_WARNING_SHADOW);
+/** @endcond */
+
+/**
+ * @brief Examine and change a signal action.
+ *
+ * @param sig  Signal number.
+ * @param act  New action, or NULL to query.
+ * @param oact Output: previous action, or NULL.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sigaction}
+ */
 int sigaction(int sig, const struct sigaction *ZRESTRICT act, struct sigaction *ZRESTRICT oact);
+/** @cond INTERNAL_HIDDEN */
 TOOLCHAIN_ENABLE_WARNING(TOOLCHAIN_WARNING_SHADOW);
+/** @endcond */
 #endif
+
+/**
+ * @brief Add a signal to a signal set.
+ *
+ * @param set Signal set.
+ * @param sig Signal number to add.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sigaddset}
+ */
 int sigaddset(sigset_t *set, int sig);
 #if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
+/**
+ * @brief Set or get the alternate signal stack.
+ *
+ * @param ss  New alternate stack descriptor, or NULL.
+ * @param oss Output: previous descriptor, or NULL.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sigaltstack}
+ */
 int sigaltstack(const stack_t *ZRESTRICT ss, stack_t *ZRESTRICT oss);
 #endif
+
+/**
+ * @brief Delete a signal from a signal set.
+ *
+ * @param set Signal set.
+ * @param sig Signal number to remove.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sigdelset}
+ */
 int sigdelset(sigset_t *set, int sig);
+
+/**
+ * @brief Initialize a signal set to the empty set.
+ *
+ * @param set Signal set to clear.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sigemptyset}
+ */
 int sigemptyset(sigset_t *set);
+
+/**
+ * @brief Initialize a signal set to the full set (all signals).
+ *
+ * @param set Signal set to fill.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sigfillset}
+ */
 int sigfillset(sigset_t *set);
 #if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
+/**
+ * @brief Add a signal to the calling process's signal mask (XSI, obsolescent).
+ *
+ * @param sig Signal to block.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sighold}
+ */
 int sighold(int sig);
+
+/**
+ * @brief Set a signal's disposition to @c SIG_IGN (XSI, obsolescent).
+ *
+ * @param sig Signal to ignore.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sigignore}
+ */
 int sigignore(int sig);
+
+/**
+ * @brief Control whether a signal restarts or interrupts system calls (XSI, obsolescent).
+ *
+ * @param sig  Signal number.
+ * @param flag Non-zero to interrupt; 0 to restart.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{siginterrupt}
+ */
 int siginterrupt(int sig, int flag);
 #endif
+
+/**
+ * @brief Test whether a signal is a member of a signal set.
+ *
+ * @param set Signal set to query.
+ * @param sig Signal number to test.
+ *
+ * @return 1 if the signal is a member, 0 if not, or -1 with errno set on failure.
+ *
+ * @posix_func{sigismember}
+ */
 int sigismember(const sigset_t *set, int sig);
+
+/**
+ * @brief Set the disposition of a signal.
+ *
+ * @posix_func{signal}
+ */
 /* signal() must be defined by the libc signal.h */
 #if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
+/**
+ * @brief Suspend execution until a signal is delivered (XSI, obsolescent).
+ *
+ * @param sig Signal whose blocking is temporarily removed.
+ *
+ * @return Always returns -1 with @c errno set to @c EINTR.
+ *
+ * @posix_func{sigpause}
+ */
 int sigpause(int sig);
 #endif
+
+/**
+ * @brief Retrieve the set of pending signals.
+ *
+ * @param set Output: set of signals pending delivery to the calling process.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sigpending}
+ */
 int sigpending(sigset_t *set);
+
+/**
+ * @brief Examine and change the calling process's signal mask.
+ *
+ * @param how  @c SIG_BLOCK, @c SIG_UNBLOCK, or @c SIG_SETMASK.
+ * @param set  Signal set to apply, or NULL.
+ * @param oset Output: previous mask, or NULL.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sigprocmask}
+ */
 int sigprocmask(int how, const sigset_t *ZRESTRICT set, sigset_t *ZRESTRICT oset);
 #if defined(_POSIX_REALTIME_SIGNALS) || defined(__DOXYGEN__)
+/**
+ * @brief Queue a signal and data to a process.
+ *
+ * @param pid   Target process ID.
+ * @param sig   Signal number.
+ * @param value Value to deliver along with the signal.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sigqueue}
+ */
 int sigqueue(pid_t pid, int sig, union sigval value);
 #endif
 #if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
+/**
+ * @brief Remove a signal from the process signal mask (XSI, obsolescent).
+ *
+ * @param sig Signal to unblock.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sigrelse}
+ */
 int sigrelse(int sig);
+
+/**
+ * @brief Set the disposition of a signal, optionally blocking it first (XSI, obsolescent).
+ *
+ * @param sig  Signal number.
+ * @param disp New disposition (@c SIG_DFL, @c SIG_IGN, @c SIG_HOLD, or a handler).
+ *
+ * @return Previous disposition on success, or @c SIG_ERR on failure.
+ *
+ * @posix_func{sigset}
+ */
 sighandler_t sigset(int sig, sighandler_t disp);
 #endif
+
+/**
+ * @brief Wait for a signal, atomically replacing the process signal mask.
+ *
+ * @param set New signal mask to apply while waiting.
+ *
+ * @return Always returns -1 with @c errno set to @c EINTR.
+ *
+ * @posix_func{sigsuspend}
+ */
 int sigsuspend(const sigset_t *set);
 #if defined(_POSIX_REALTIME_SIGNALS) || defined(__DOXYGEN__)
+/**
+ * @brief Wait for a queued signal with a timeout.
+ *
+ * @param set     Set of signals to wait for.
+ * @param info    Output: information about the accepted signal, or NULL.
+ * @param timeout Maximum time to wait.
+ *
+ * @return Signal number on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sigtimedwait}
+ */
 int sigtimedwait(const sigset_t *ZRESTRICT set, siginfo_t *ZRESTRICT info,
 		 const struct timespec *ZRESTRICT timeout);
 #endif
+
+/**
+ * @brief Wait for a signal from a set.
+ *
+ * @param set Set of signals to wait for.
+ * @param sig Output: number of the accepted signal.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{sigwait}
+ */
 int sigwait(const sigset_t *ZRESTRICT set, int *ZRESTRICT sig);
 #if defined(_POSIX_REALTIME_SIGNALS) || defined(__DOXYGEN__)
+/**
+ * @brief Wait for a queued signal (no timeout).
+ *
+ * @param set  Set of signals to wait for.
+ * @param info Output: information about the accepted signal, or NULL.
+ *
+ * @return Signal number on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sigwaitinfo}
+ */
 int sigwaitinfo(const sigset_t *ZRESTRICT set, siginfo_t *ZRESTRICT info);
 #endif
 
 /* Note: only ANSI / ISO C signals are guarded below */
 
+/**
+ * @brief Hangup.
+ */
 #define SIGHUP 1 /**< Hangup */
 #if !defined(SIGINT) || defined(__DOXYGEN__)
+/**
+ * @brief Terminal interrupt signal.
+ */
 #define SIGINT 2 /**< Interrupt */
 #endif
+
+/**
+ * @brief Terminal quit signal.
+ */
 #define SIGQUIT 3 /**< Quit */
 #if !defined(SIGILL) || defined(__DOXYGEN__)
+/**
+ * @brief Illegal instruction.
+ */
 #define SIGILL 4 /**< Illegal instruction */
 #endif
+
+/**
+ * @brief Trace/breakpoint trap.
+ */
 #define SIGTRAP 5 /**< Trace/breakpoint trap */
 #if !defined(SIGABRT) || defined(__DOXYGEN__)
+/**
+ * @brief Process abort signal.
+ */
 #define SIGABRT 6 /**< Aborted */
 #endif
+
+/**
+ * @brief Access to an undefined portion of a memory object.
+ */
 #define SIGBUS 7 /**< Bus error */
 #if !defined(SIGFPE) || defined(__DOXYGEN__)
+/**
+ * @brief Erroneous arithmetic operation.
+ */
 #define SIGFPE 8 /**< Arithmetic exception */
 #endif
+
+/**
+ * @brief Kill (cannot be caught or ignored).
+ */
 #define SIGKILL 9  /**< Killed */
+
+/**
+ * @brief User-defined signal 1.
+ */
 #define SIGUSR1 10 /**< User-defined signal 1 */
 #if !defined(SIGSEGV) || defined(__DOXYGEN__)
+/**
+ * @brief Invalid memory reference.
+ */
 #define SIGSEGV 11 /**< Invalid memory reference */
 #endif
+
+/**
+ * @brief User-defined signal 2.
+ */
 #define SIGUSR2 12 /**< User-defined signal 2 */
+
+/**
+ * @brief Write on a pipe with no one to read it.
+ */
 #define SIGPIPE 13 /**< Broken pipe */
+
+/**
+ * @brief Alarm clock.
+ */
 #define SIGALRM 14 /**< Alarm clock */
 #if !defined(SIGTERM) || defined(__DOXYGEN__)
+/**
+ * @brief Termination signal.
+ */
 #define SIGTERM 15 /**< Terminated */
 #endif
 /* 16 not used */
+
+/**
+ * @brief Child process terminated, stopped, or continued.
+ */
 #define SIGCHLD   17 /**< Child status changed */
+
+/**
+ * @brief Continue executing, if stopped.
+ */
 #define SIGCONT   18 /**< Continued */
+
+/**
+ * @brief Stop executing (cannot be caught or ignored).
+ */
 #define SIGSTOP   19 /**< Stop executing */
+
+/**
+ * @brief Terminal stop signal.
+ */
 #define SIGTSTP   20 /**< Stopped */
+
+/**
+ * @brief Background process attempting read.
+ */
 #define SIGTTIN   21 /**< Stopped (read) */
+
+/**
+ * @brief Background process attempting write.
+ */
 #define SIGTTOU   22 /**< Stopped (write) */
+
+/**
+ * @brief High bandwidth data is available at a socket.
+ */
 #define SIGURG    23 /**< Urgent I/O condition */
+
+/**
+ * @brief CPU time limit exceeded.
+ */
 #define SIGXCPU   24 /**< CPU time limit exceeded */
+
+/**
+ * @brief File size limit exceeded.
+ */
 #define SIGXFSZ   25 /**< File size limit exceeded */
+
+/**
+ * @brief Virtual timer expired.
+ */
 #define SIGVTALRM 26 /**< Virtual timer expired */
+
+/**
+ * @brief Profiling timer expired.
+ */
 #define SIGPROF   27 /**< Profiling timer expired */
 /* 28 not used */
+
+/**
+ * @brief Pollable event.
+ */
 #define SIGPOLL   29 /**< Pollable event occurred */
 /* 30 not used */
+
+/**
+ * @brief Bad system call.
+ */
 #define SIGSYS    31 /**< Bad system call */
 
 #if defined(_POSIX_REALTIME_SIGNALS) || defined(__DOXYGEN__)
 
 /* SIGILL */
+
+/**
+ * @brief Illegal opcode.
+ */
 #define ILL_ILLOPC 1 /**< Illegal opcode */
+
+/**
+ * @brief Illegal operand.
+ */
 #define ILL_ILLOPN 2 /**< Illegal operand */
+
+/**
+ * @brief Illegal addressing mode.
+ */
 #define ILL_ILLADR 3 /**< Illegal addressing mode */
+
+/**
+ * @brief Illegal trap.
+ */
 #define ILL_ILLTRP 4 /**< Illegal trap */
+
+/**
+ * @brief Privileged opcode.
+ */
 #define ILL_PRVOPC 5 /**< Privileged opcode */
+
+/**
+ * @brief Privileged register.
+ */
 #define ILL_PRVREG 6 /**< Privileged register */
+
+/**
+ * @brief Coprocessor error.
+ */
 #define ILL_COPROC 7 /**< Coprocessor error */
+
+/**
+ * @brief Internal stack error.
+ */
 #define ILL_BADSTK 8 /**< Internal stack error */
 
 /* SIGFPE */
+
+/**
+ * @brief Integer divide by zero.
+ */
 #define FPE_INTDIV 9  /**< Integer divide by zero */
+
+/**
+ * @brief Integer overflow.
+ */
 #define FPE_INTOVF 10 /**< Integer overflow */
+
+/**
+ * @brief Floating-point divide by zero.
+ */
 #define FPE_FLTDIV 11 /**< Floating-point divide by zero */
+
+/**
+ * @brief Floating-point overflow.
+ */
 #define FPE_FLTOVF 12 /**< Floating-point overflow */
+
+/**
+ * @brief Floating-point underflow.
+ */
 #define FPE_FLTUND 13 /**< Floating-point underflow */
+
+/**
+ * @brief Floating-point inexact result.
+ */
 #define FPE_FLTRES 15 /**< Floating-point inexact result */
+
+/**
+ * @brief Invalid floating-point operation.
+ */
 #define FPE_FLTINV 16 /**< Invalid floating-point operation */
+
+/**
+ * @brief Subscript out of range.
+ */
 #define FPE_FLTSUB 17 /**< Subscript out of range */
 
 /* SIGSEGV */
+
+/**
+ * @brief Address not mapped to object.
+ */
 #define SEGV_MAPERR 18 /**< Address not mapped to object */
+
+/**
+ * @brief Invalid permissions for mapped object.
+ */
 #define SEGV_ACCERR 19 /**< Invalid permissions for mapped object */
 
 /* SIGBUS */
+
+/**
+ * @brief Invalid address alignment.
+ */
 #define BUS_ADRALN 20 /**< Invalid address alignment */
+
+/**
+ * @brief Nonexistent physical address.
+ */
 #define BUS_ADRERR 21 /**< Nonexistent physical address */
+
+/**
+ * @brief Object-specific hardware error.
+ */
 #define BUS_OBJERR 22 /**< Object-specific hardware error */
 
 #if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
 /* SIGTRAP */
+
+/**
+ * @brief Process breakpoint.
+ */
 #define TRAP_BRKPT 23 /**< Process breakpoint */
+
+/**
+ * @brief Process trace trap.
+ */
 #define TRAP_TRACE 24 /**< Process trace trap */
 #endif
 
 /* SIGCHLD */
+
+/**
+ * @brief Child has exited.
+ */
 #define CLD_EXITED    25 /**< Child has exited */
+
+/**
+ * @brief Child has terminated abnormally and did not create a core file.
+ */
 #define CLD_KILLED    26 /**< Child has terminated abnormally and did not create a core file */
+
+/**
+ * @brief Child has terminated abnormally and created a core file.
+ */
 #define CLD_DUMPED    27 /**< Child has terminated abnormally and created a core file */
+
+/**
+ * @brief Traced child has trapped.
+ */
 #define CLD_TRAPPED   28 /**< Traced child has trapped */
+
+/**
+ * @brief Child has stopped.
+ */
 #define CLD_STOPPED   29 /**< Child has stopped */
+
+/**
+ * @brief Stopped child has continued.
+ */
 #define CLD_CONTINUED 30 /**< Stopped child has continued */
 
 #if defined(_XOPEN_STREAMS) || defined(__DOXYGEN__)
 /* SIGPOLL */
+
+/**
+ * @brief Data input available.
+ */
 #define POLL_IN  31 /**< Data input available */
+
+/**
+ * @brief Output buffers available.
+ */
 #define POLL_OUT 32 /**< Output buffers available */
+
+/**
+ * @brief Input message available.
+ */
 #define POLL_MSG 33 /**< Input message available */
+
+/**
+ * @brief I/O error.
+ */
 #define POLL_ERR 34 /**< I/O error */
+
+/**
+ * @brief High priority input available.
+ */
 #define POLL_PRI 35 /**< High priority input available */
+
+/**
+ * @brief Device disconnected.
+ */
 #define POLL_HUP 36 /**< Device disconnected */
 #endif
 
 /* Any */
+
+/**
+ * @brief Signal sent by kill().
+ */
 #define SI_USER    37 /**< Signal sent by kill() */
+
+/**
+ * @brief Signal sent by sigqueue().
+ */
 #define SI_QUEUE   38 /**< Signal sent by sigqueue() */
+
+/**
+ * @brief Signal generated by expiration of a timer set by timer_settime().
+ */
 #define SI_TIMER   39 /**< Signal generated by expiration of a timer set by timer_settime() */
+
+/**
+ * @brief Signal generated by completion of an asynchronous I/O.
+ */
 #define SI_ASYNCIO 40 /**< Signal generated by completion of an asynchronous I/O request */
+
+/**
+ * @brief Signal generated by arrival of a message on an empty message queue.
+ */
 #define SI_MESGQ   41 /**< Signal generated by arrival of a message on an empty message queue */
 
 #endif

--- a/include/zephyr/posix/posix_time.h
+++ b/include/zephyr/posix/posix_time.h
@@ -4,6 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Time types.
+ * @ingroup posix
+ *
+ * Provides clock identifiers, the POSIX timer API, thread-safe time conversion
+ * helpers, and locale-aware time formatting that extend the C standard time.h
+ * interface.
+ *
+ * @posix_header{time.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_POSIX_TIME_H_
 #define ZEPHYR_INCLUDE_POSIX_POSIX_TIME_H_
 
@@ -23,32 +35,64 @@ extern "C" {
 /* time_t must be defined in the libc time.h */
 
 #if !defined(_CLOCKID_T_DECLARED) && !defined(__clockid_t_defined)
+/**
+ * @brief Identifies a clock (e.g. @c CLOCK_REALTIME, @c CLOCK_MONOTONIC).
+ */
 typedef unsigned long clockid_t;
+/** @cond INTERNAL_HIDDEN */
 #define _CLOCKID_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __clockid_t_defined
+/** @endcond */
 #endif
 
 #if !defined(_TIMER_T_DECLARED) && !defined(__timer_t_defined)
+/**
+ * @brief Opaque handle for a POSIX interval timer created with timer_create().
+ */
 typedef unsigned long timer_t;
+/** @cond INTERNAL_HIDDEN */
 #define _TIMER_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __timer_t_defined
+/** @endcond */
 #endif
 
 #if !defined(_LOCALE_T_DECLARED) && !defined(__locale_t_defined)
 #ifdef CONFIG_NEWLIB_LIBC
 struct __locale_t;
+
+/**
+ * @brief Opaque locale object.
+ */
 typedef struct __locale_t *locale_t;
 #else
+/**
+ * @brief Opaque locale object.
+ */
 typedef void *locale_t;
 #endif
+/** @cond INTERNAL_HIDDEN */
 #define _LOCALE_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __locale_t_defined
+/** @endcond */
 #endif
 
 #if !defined(_PID_T_DECLARED) && !defined(__pid_t_defined)
+/**
+ * @brief Process ID type.
+ */
 typedef int pid_t;
+/** @cond INTERNAL_HIDDEN */
 #define _PID_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __pid_t_defined
+/** @endcond */
 #endif
 
 #if defined(_POSIX_REALTIME_SIGNALS)
@@ -61,128 +105,444 @@ struct sigevent;
 /* struct timespec must be defined in the libc time.h */
 #else
 #if !defined(_TIMESPEC_DECLARED) && !defined(__timespec_defined)
+/**
+ * @brief Time interval in seconds and nanoseconds.
+ */
 struct timespec {
+	/**
+	 * @brief Seconds component.
+	 */
 	time_t tv_sec;
+	/**
+	 * @brief Nanoseconds component.
+	 */
 	long tv_nsec;
 };
+/** @cond INTERNAL_HIDDEN */
 #define _TIMESPEC_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __timespec_defined
+/** @endcond */
 #endif
 #endif
 
 #if !defined(_ITIMERSPEC_DECLARED) && !defined(__itimerspec_defined)
+/**
+ * @brief Interval timer specification.
+ */
 struct itimerspec {
+	/**
+	 * @brief Timer period.
+	 */
 	struct timespec it_interval;
+	/**
+	 * @brief Timer expiration.
+	 */
 	struct timespec it_value;
 };
+/** @cond INTERNAL_HIDDEN */
 #define _ITIMERSPEC_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __itimerspec_defined
+/** @endcond */
 #endif
 
 /* NULL must be defined in the libc stddef.h */
 
 #ifndef CLOCK_REALTIME
+/**
+ * @brief The identifier of the system-wide clock measuring real time.
+ */
 #define CLOCK_REALTIME ((clockid_t)SYS_CLOCK_REALTIME)
 #endif
 
 #ifndef CLOCKS_PER_SEC
 #if defined(_XOPEN_SOURCE)
+/**
+ * @brief A number used to convert the value returned by the clock() function into seconds.
+ */
 #define CLOCKS_PER_SEC 1000000
 #else
+/**
+ * @brief A number used to convert the value returned by the clock() function into seconds.
+ */
 #define CLOCKS_PER_SEC CONFIG_SYS_CLOCK_TICKS_PER_SEC
 #endif
 #endif
 
 #if defined(_POSIX_CPUTIME) || defined(__DOXYGEN__)
 #ifndef CLOCK_PROCESS_CPUTIME_ID
+/**
+ * @brief The identifier of the CPU-time clock associated with the process making a clock() or
+ * timer*() function call.
+ */
 #define CLOCK_PROCESS_CPUTIME_ID ((clockid_t)2)
 #endif
 #endif
 
 #if defined(_POSIX_THREAD_CPUTIME) || defined(__DOXYGEN__)
 #ifndef CLOCK_THREAD_CPUTIME_ID
+/**
+ * @brief The identifier of the CPU-time clock associated with the thread making a clock() or
+ * timer*() function call.
+ */
 #define CLOCK_THREAD_CPUTIME_ID ((clockid_t)3)
 #endif
 #endif
 
 #if defined(_POSIX_MONOTONIC_CLOCK) || defined(__DOXYGEN__)
 #ifndef CLOCK_MONOTONIC
+/**
+ * @brief The identifier for the system-wide monotonic clock, which is defined as a clock measuring
+ * real time, whose value cannot be set via clock_settime() and which cannot have negative clock
+ * jumps.
+ */
 #define CLOCK_MONOTONIC ((clockid_t)SYS_CLOCK_MONOTONIC)
 #endif
 #endif
 
 #ifndef TIMER_ABSTIME
+/**
+ * @brief Flag indicating time is absolute.
+ */
 #define TIMER_ABSTIME SYS_TIMER_ABSTIME
 #endif
 
+/**
+ * @brief Convert date and time to a string.
+ *
+ * @posix_func{asctime}
+ */
 /* asctime() must be declared in the libc time.h */
 #if defined(_POSIX_THREAD_SAFE_FUNCTIONS) || defined(__DOXYGEN__)
+/**
+ * @brief Convert broken-down time to a string (thread-safe version of asctime()).
+ *
+ * @param tm  Broken-down time to convert.
+ * @param buf Caller-supplied buffer of at least 26 bytes.
+ *
+ * @return @p buf on success, or NULL on failure.
+ *
+ * @posix_func{asctime_r}
+ */
 char *asctime_r(const struct tm *ZRESTRICT tm, char *ZRESTRICT buf);
 #endif
+
+/**
+ * @brief Report CPU time used.
+ *
+ * @posix_func{clock}
+ */
 /* clock() must be declared in the libc time.h */
 #if defined(_POSIX_CPUTIME) || defined(__DOXYGEN__)
+/**
+ * @brief Access a process CPU-time clock.
+ *
+ * @param pid      Process ID (0 means the calling process).
+ * @param clock_id Output: CPU-time clock ID of the process.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{clock_getcpuclockid}
+ */
 int clock_getcpuclockid(pid_t pid, clockid_t *clock_id);
 #endif
 #if defined(_POSIX_TIMERS) || defined(__DOXYGEN__)
+/**
+ * @brief Get the resolution of a clock.
+ *
+ * @param clock_id Clock to query.
+ * @param ts       Output: resolution (smallest representable interval) of the clock.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{clock_getres}
+ */
 int clock_getres(clockid_t clock_id, struct timespec *ts);
+
+/**
+ * @brief Get the current time of a clock.
+ *
+ * @param clock_id Clock to read.
+ * @param ts       Output: current time of the clock.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{clock_gettime}
+ */
 int clock_gettime(clockid_t clock_id, struct timespec *ts);
 #endif
 #if defined(_POSIX_CLOCK_SELECTION) || defined(__DOXYGEN__)
+/**
+ * @brief High resolution sleep with specifiable clock.
+ *
+ * @param clock_id Clock to measure the sleep against.
+ * @param flags    0 for a relative sleep, @c TIMER_ABSTIME for an absolute wakeup time.
+ * @param rqtp     Requested sleep duration or absolute wakeup time.
+ * @param rmtp     Output: remaining time if interrupted (only for relative sleeps), or NULL.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{clock_nanosleep}
+ */
 int clock_nanosleep(clockid_t clock_id, int flags, const struct timespec *rqtp,
 		    struct timespec *rmtp);
 #endif
 #if defined(_POSIX_TIMERS) || defined(__DOXYGEN__)
+/**
+ * @brief Set the time of a clock.
+ *
+ * @param clock_id Clock to set.
+ * @param ts       New time value.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{clock_settime}
+ */
 int clock_settime(clockid_t clock_id, const struct timespec *ts);
 #endif
+
+/**
+ * @brief Convert a time value to a date and time string.
+ *
+ * @posix_func{ctime}
+ */
 /* ctime() must be declared in the libc time.h */
 #if defined(_POSIX_THREAD_SAFE_FUNCTIONS) || defined(__DOXYGEN__)
+/**
+ * @brief Convert a time value to a date and time string (thread-safe version of ctime()).
+ *
+ * @param clock Pointer to the time value to convert.
+ * @param buf   Caller-supplied buffer of at least 26 bytes.
+ *
+ * @return @p buf on success, or NULL on failure.
+ *
+ * @posix_func{ctime_r}
+ */
 char *ctime_r(const time_t *clock, char *buf);
 #endif
+
+/**
+ * @brief Compute the difference between two calendar time values.
+ *
+ * @posix_func{difftime}
+ */
 /* difftime() must be declared in the libc time.h */
 #if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
+/**
+ * @brief Convert user format date and time.
+ *
+ * @param string Date and time string; the format is given by the DATEMSK environment variable.
+ *
+ * @return Pointer to a broken-down time on success, or NULL on failure.
+ *
+ * @posix_func{getdate}
+ */
 struct tm *getdate(const char *string);
 #endif
+
+/**
+ * @brief Convert a time value to a broken-down UTC time.
+ *
+ * @posix_func{gmtime}
+ */
 /* gmtime() must be declared in the libc time.h */
 #if __STDC_VERSION__ >= 202311L
+/**
+ * @brief Convert a time value to a broken-down UTC time.
+ *
+ * @posix_func{gmtime_r}
+ */
 /* gmtime_r() must be declared in the libc time.h */
 #else
 #if defined(_POSIX_THREAD_SAFE_FUNCTIONS) || defined(__DOXYGEN__)
+/**
+ * @brief Convert a time value to a broken-down UTC time.
+ *
+ * @param timer  Pointer to the time value to convert.
+ * @param result Caller-supplied storage for the broken-down time.
+ *
+ * @return @p result on success, or NULL on failure.
+ *
+ * @posix_func{gmtime_r}
+ */
 struct tm *gmtime_r(const time_t *ZRESTRICT timer, struct tm *ZRESTRICT result);
 #endif
 #endif
+
+/**
+ * @brief Convert a time value to a broken-down local time.
+ *
+ * @posix_func{localtime}
+ */
 /* localtime() must be declared in the libc time.h */
 #if __STDC_VERSION__ >= 202311L
+/**
+ * @brief Convert a time value to a broken-down local time.
+ *
+ * @posix_func{localtime_r}
+ */
 /* localtime_r() must be declared in the libc time.h */
 #else
 #if defined(_POSIX_THREAD_SAFE_FUNCTIONS) || defined(__DOXYGEN__)
+/**
+ * @brief Convert a time value to a broken-down local time.
+ *
+ * @param timer  Pointer to the time value to convert.
+ * @param result Caller-supplied storage for the broken-down time.
+ *
+ * @return @p result on success, or NULL on failure.
+ *
+ * @posix_func{localtime_r}
+ */
 struct tm *localtime_r(const time_t *ZRESTRICT timer, struct tm *ZRESTRICT result);
 #endif
 #endif
+
+/**
+ * @brief Convert broken-down time into time since the Epoch.
+ *
+ * @posix_func{mktime}
+ */
 /* mktime() must be declared in the libc time.h */
 #if defined(_POSIX_TIMERS) || defined(__DOXYGEN__)
+/**
+ * @brief High resolution sleep.
+ *
+ * @param rqtp Requested sleep duration.
+ * @param rmtp Output: remaining time if the call was interrupted, or NULL.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{nanosleep}
+ */
 int nanosleep(const struct timespec *rqtp, struct timespec *rmtp);
 #endif
+
+/**
+ * @brief Convert date and time to a string.
+ *
+ * @posix_func{strftime}
+ */
 /* strftime() must be declared in the libc time.h */
+/**
+ * @brief Format broken-down time into a string using the specified locale.
+ *
+ * @param s       Output buffer.
+ * @param maxsize Maximum number of bytes to write, including the terminating null byte.
+ * @param format  Format string (same syntax as strftime()).
+ * @param timeptr Broken-down time to format.
+ * @param locale  Locale to use for formatting.
+ *
+ * @return Number of bytes written, not including the terminating null byte, or 0 if @p maxsize
+ *         would have been exceeded.
+ *
+ * @posix_func{strftime_l}
+ */
 size_t strftime_l(char *ZRESTRICT s, size_t maxsize, const char *ZRESTRICT format,
 		  const struct tm *ZRESTRICT timeptr, locale_t locale);
 #if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
+/**
+ * @brief Parse a date and time string according to a format.
+ *
+ * @param s      Input string to parse.
+ * @param format Format string describing the date and time fields to parse.
+ * @param tm     Output: broken-down time filled in from the parsed fields.
+ *
+ * @return Pointer to the first character in @p s not consumed by parsing, or NULL on failure.
+ *
+ * @posix_func{strptime}
+ */
 char *strptime(const char *ZRESTRICT s, const char *ZRESTRICT format, struct tm *ZRESTRICT tm);
 #endif
+
+/**
+ * @brief Get time.
+ *
+ * @posix_func{time}
+ */
 /* time() must be declared in the libc time.h */
 #if defined(_POSIX_TIMERS) || defined(__DOXYGEN__)
+/**
+ * @brief Create a per-process timer.
+ *
+ * @param clockId Clock to base the timer on.
+ * @param evp     Notification specification, or NULL for @c SIGALRM delivery.
+ * @param timerid Output: ID of the new timer.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{timer_create}
+ */
 int timer_create(clockid_t clockId, struct sigevent *ZRESTRICT evp, timer_t *ZRESTRICT timerid);
+
+/**
+ * @brief Delete a per-process timer.
+ *
+ * @param timerid Timer to delete.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{timer_delete}
+ */
 int timer_delete(timer_t timerid);
+
+/**
+ * @brief Get the number of timer overruns since the last timer expiration notification.
+ *
+ * @param timerid Timer to query.
+ *
+ * @return Overrun count on success, or -1 with errno set on failure.
+ *
+ * @posix_func{timer_getoverrun}
+ */
 int timer_getoverrun(timer_t timerid);
+
+/**
+ * @brief Get the time remaining until the next timer expiration.
+ *
+ * @param timerid Timer to query.
+ * @param its     Output: current timer value and interval.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{timer_gettime}
+ */
 int timer_gettime(timer_t timerid, struct itimerspec *its);
+
+/**
+ * @brief Arm or disarm a per-process timer.
+ *
+ * @param timerid Timer to set.
+ * @param flags   0 for a relative time, @c TIMER_ABSTIME for an absolute time.
+ * @param value   New expiration time and interval; set it_value to zero to disarm.
+ * @param ovalue  Output: previous timer value, or NULL.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{timer_settime}
+ */
 int timer_settime(timer_t timerid, int flags, const struct itimerspec *value,
 		  struct itimerspec *ovalue);
 #endif
 
 #if defined(_XOPEN_SOURCE) || defined(__DOXYGEN__)
+/**
+ * @brief Daylight saving time flag.
+ */
 extern int daylight;
+
+/**
+ * @brief Seconds west of UTC.
+ */
 extern long timezone;
 #endif
 
+/**
+ * @brief Timezone name strings.
+ */
 extern char *tzname[];
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/posix_types.h
+++ b/include/zephyr/posix/posix_types.h
@@ -4,6 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Data types.
+ * @ingroup posix
+ *
+ * Provides POSIX data types such as clock, user/group ID, and pthread object
+ * types for toolchains whose C library does not already define them.
+ *
+ * @posix_header{sys_types.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_POSIX_TYPES_H_
 #define ZEPHYR_INCLUDE_POSIX_POSIX_TYPES_H_
 
@@ -12,15 +23,29 @@
 #endif
 
 #if !defined(_CLOCK_T_DECLARED) && !defined(__clock_t_defined)
+/**
+ * @brief Used for system times in clock ticks or CLOCKS_PER_SEC; see <time.h>.
+ */
 typedef unsigned long clock_t;
+/** @cond INTERNAL_HIDDEN */
 #define _CLOCK_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __clock_t_defined
+/** @endcond */
 #endif
 
 #if !defined(_CLOCKID_T_DECLARED) && !defined(__clockid_t_defined)
+/**
+ * @brief Used for clock ID type in the clock and timer functions.
+ */
 typedef unsigned long clockid_t;
+/** @cond INTERNAL_HIDDEN */
 #define _CLOCKID_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __clockid_t_defined
+/** @endcond */
 #endif
 
 #ifdef CONFIG_NEWLIB_LIBC
@@ -34,57 +59,115 @@ extern "C" {
 #endif
 
 #if !defined(_DEV_T_DECLARED) && !defined(__dev_t_defined)
+/**
+ * @brief Used for device IDs.
+ */
 typedef int dev_t;
+/** @cond INTERNAL_HIDDEN */
 #define _DEV_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __dev_t_defined
+/** @endcond */
 #endif
 
 #if !defined(_INO_T_DECLARED) && !defined(__ino_t_defined)
+/**
+ * @brief Used for file serial numbers.
+ */
 typedef int ino_t;
+/** @cond INTERNAL_HIDDEN */
 #define _INO_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __ino_t_defined
+/** @endcond */
 #endif
 
 #if !defined(_NLINK_T_DECLARED) && !defined(__nlink_t_defined)
+/**
+ * @brief Used for link counts.
+ */
 typedef unsigned short nlink_t;
+/** @cond INTERNAL_HIDDEN */
 #define _NLINK_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __nlink_t_defined
+/** @endcond */
 #endif
 
 #if !defined(_UID_T_DECLARED) && !defined(__uid_t_defined)
+/**
+ * @brief Used for user IDs.
+ */
 typedef unsigned short uid_t;
+/** @cond INTERNAL_HIDDEN */
 #define _UID_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __uid_t_defined
+/** @endcond */
 #endif
 
 #if !defined(_GID_T_DECLARED) && !defined(__gid_t_defined)
+/**
+ * @brief Used for group IDs.
+ */
 typedef unsigned short gid_t;
+/** @cond INTERNAL_HIDDEN */
 #define _GID_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __gid_t_defined
+/** @endcond */
 #endif
 
 #if !defined(_BLKSIZE_T_DECLARED) && !defined(__blksize_t_defined)
+/**
+ * @brief Used for block sizes.
+ */
 typedef unsigned long blksize_t;
+/** @cond INTERNAL_HIDDEN */
 #define _BLKSIZE_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __blksize_t_defined
+/** @endcond */
 #endif
 
 #if !defined(_BLKCNT_T_DECLARED) && !defined(__blkcnt_t_defined)
+/**
+ * @brief Used for file block counts.
+ */
 typedef unsigned long blkcnt_t;
+/** @cond INTERNAL_HIDDEN */
 #define _BLKCNT_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __blkcnt_t_defined
+/** @endcond */
 #endif
 
 #if !defined(CONFIG_ARCMWDT_LIBC)
+/**
+ * @brief Used for process IDs and process group IDs.
+ */
 typedef int pid_t;
 #endif
 
 #if !defined(_USECONDS_T_DECLARED) && !defined(__useconds_t_defined)
+/**
+ * @brief Used for time in microseconds.
+ */
 typedef unsigned long useconds_t;
 #endif
 
 /* time related attributes */
 #if !defined(__timer_t_defined) && !defined(_TIMER_T_DECLARED)
+/**
+ * @brief Used for timer ID returned by timer_create().
+ */
 typedef unsigned long timer_t;
 #endif
 
@@ -95,58 +178,131 @@ typedef struct {
 	void *stack;
 	unsigned int details[2];
 } pthread_attr_t;
+/** @cond INTERNAL_HIDDEN */
 #define _PTHREAD_ATTR_T_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __pthread_attr_t_defined
+/** @endcond */
 #endif
 #endif
 
+/**
+ * @brief Used to identify a thread.
+ */
 typedef uint32_t pthread_t;
+
+/**
+ * @brief Used to identify a spin lock.
+ */
 typedef uint32_t pthread_spinlock_t;
 
 /* Semaphore */
+
+/**
+ * @brief Used for semaphores.
+ */
 typedef struct k_sem sem_t;
 
 /* Mutex */
+
+/**
+ * @brief Used for mutexes.
+ */
 typedef uint32_t pthread_mutex_t;
 
+/**
+ * @brief Implementation-specific storage for mutex attributes.
+ */
 struct pthread_mutexattr {
+	/**
+	 * @brief Mutex type (normal, recursive, or error-checking).
+	 */
 	unsigned char type: 2;
+	/**
+	 * @brief True if the attributes object has been initialized.
+	 */
 	bool initialized: 1;
 };
 #if !defined(CONFIG_NEWLIB_LIBC)
+/**
+ * @brief Used to identify a mutex attribute object.
+ */
 typedef struct pthread_mutexattr pthread_mutexattr_t;
 BUILD_ASSERT(sizeof(pthread_mutexattr_t) >= sizeof(struct pthread_mutexattr));
 #endif
 
 /* Condition variables */
+
+/**
+ * @brief Used for condition variables.
+ */
 typedef uint32_t pthread_cond_t;
 
+/**
+ * @brief Implementation-specific storage for condition variable attributes.
+ */
 struct pthread_condattr {
+	/**
+	 * @brief ID of the clock used to measure timed waits.
+	 */
 	clockid_t clock;
 };
 
 #if !defined(CONFIG_NEWLIB_LIBC)
+/**
+ * @brief Used to identify a condition attribute object.
+ */
 typedef struct pthread_condattr pthread_condattr_t;
 BUILD_ASSERT(sizeof(pthread_condattr_t) >= sizeof(struct pthread_condattr));
 #endif
 
 /* Barrier */
+
+/**
+ * @brief Used to identify a barrier.
+ */
 typedef uint32_t pthread_barrier_t;
 
+/**
+ * @brief Used to define a barrier attributes object.
+ */
 typedef struct pthread_barrierattr {
+	/**
+	 * @brief Process-shared attribute value.
+	 */
 	int pshared;
 } pthread_barrierattr_t;
 
+/**
+ * @brief Used for read-write lock attributes.
+ */
 typedef uint32_t pthread_rwlockattr_t;
 
+/**
+ * @brief Used for read-write locks.
+ */
 typedef uint32_t pthread_rwlock_t;
 
+/**
+ * @brief Implementation-specific storage for dynamic package initialization state.
+ */
 struct pthread_once {
+	/**
+	 * @brief Flag set once the initialization routine has run.
+	 */
 	bool flag;
 };
 
 #if !defined(CONFIG_NEWLIB_LIBC)
+/**
+ * @brief Used for thread-specific data keys.
+ */
 typedef uint32_t pthread_key_t;
+
+/**
+ * @brief Used for dynamic package initialization.
+ */
 typedef struct pthread_once pthread_once_t;
 /* Newlib typedefs pthread_once_t as a struct with two ints */
 BUILD_ASSERT(sizeof(pthread_once_t) >= sizeof(struct pthread_once));

--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -4,6 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Threads.
+ * @ingroup posix
+ *
+ * Covers thread lifecycle, attributes, cancellation, scheduling, mutexes,
+ * condition variables, barriers, reader-writer locks, spin locks, and
+ * thread-specific data.
+ *
+ * @posix_header{pthread.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_PTHREAD_H_
 #define ZEPHYR_INCLUDE_POSIX_PTHREAD_H_
 
@@ -24,37 +36,97 @@ extern "C" {
  * Undefine possibly predefined values by external toolchain headers
  */
 #undef PTHREAD_CREATE_DETACHED
+
+/**
+ * @brief Thread is created in the detached state.
+ */
 #define PTHREAD_CREATE_DETACHED 1
 #undef PTHREAD_CREATE_JOINABLE
+
+/**
+ * @brief Thread is created in the joinable state (default).
+ */
 #define PTHREAD_CREATE_JOINABLE 0
 
 /* Pthread resource visibility */
+
+/**
+ * @brief Mutex or barrier attribute: object is private to the process (default).
+ */
 #define PTHREAD_PROCESS_PRIVATE 0
+
+/**
+ * @brief Mutex or barrier attribute: object is shared between processes.
+ */
 #define PTHREAD_PROCESS_SHARED  1
 
 /* Pthread cancellation */
+
+/**
+ * @brief Value returned by pthread_join() for a canceled thread.
+ */
 #define PTHREAD_CANCELED       ((void *)-1)
+
+/**
+ * @brief Cancellation is enabled (default).
+ */
 #define PTHREAD_CANCEL_ENABLE  0
+
+/**
+ * @brief Cancellation delivery is disabled.
+ */
 #define PTHREAD_CANCEL_DISABLE 1
+
+/**
+ * @brief Cancellation is deferred until a cancellation point (default).
+ */
 #define PTHREAD_CANCEL_DEFERRED     0
+
+/**
+ * @brief Thread cancellation is performed immediately.
+ */
 #define PTHREAD_CANCEL_ASYNCHRONOUS 1
 
 /* Pthread scope */
 #undef PTHREAD_SCOPE_PROCESS
+
+/**
+ * @brief Thread competes for resources only with threads in the same process.
+ */
 #define PTHREAD_SCOPE_PROCESS    1
 #undef PTHREAD_SCOPE_SYSTEM
+
+/**
+ * @brief Thread competes for resources with all threads in the system (default).
+ */
 #define PTHREAD_SCOPE_SYSTEM     0
 
 /* Pthread inherit scheduler */
 #undef PTHREAD_INHERIT_SCHED
+
+/**
+ * @brief Thread inherits the scheduling policy of its creator (default).
+ */
 #define PTHREAD_INHERIT_SCHED  0
 #undef PTHREAD_EXPLICIT_SCHED
+
+/**
+ * @brief Thread uses an explicitly provided scheduling policy.
+ */
 #define PTHREAD_EXPLICIT_SCHED 1
 
 /* Passed to pthread_once */
+
+/**
+ * @brief Initializer for one-time initialization control.
+ */
 #define PTHREAD_ONCE_INIT {0}
 
 /* The minimum allowable stack size */
+
+/**
+ * @brief Minimum thread stack size.
+ */
 #define PTHREAD_STACK_MIN K_KERNEL_STACK_LEN(0)
 
 /**
@@ -65,78 +137,120 @@ extern "C" {
 #define PTHREAD_COND_INITIALIZER (-1)
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Initialize a condition variable.
  *
- * See IEEE 1003.1
+ * @param cv  Condition variable to initialize.
+ * @param att Condition variable attributes, or NULL for defaults.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_cond_init}
  */
 int pthread_cond_init(pthread_cond_t *cv, const pthread_condattr_t *att);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Destroy a condition variable.
  *
- * See IEEE 1003.1
+ * @param cv Condition variable to destroy.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_cond_destroy}
  */
 int pthread_cond_destroy(pthread_cond_t *cv);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Signal a condition variable, waking at least one waiting thread.
  *
- * See IEEE 1003.1
+ * @param cv Condition variable to signal.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_cond_signal}
  */
 int pthread_cond_signal(pthread_cond_t *cv);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Broadcast a condition variable, waking all waiting threads.
  *
- * See IEEE 1003.1
+ * @param cv Condition variable to broadcast.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_cond_broadcast}
  */
 int pthread_cond_broadcast(pthread_cond_t *cv);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Wait on a condition variable.
  *
- * See IEEE 1003.1
+ * @param cv  Condition variable.
+ * @param mut Associated mutex (must be locked by the caller).
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_cond_wait}
  */
 int pthread_cond_wait(pthread_cond_t *cv, pthread_mutex_t *mut);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Wait on a condition variable with an absolute timeout.
  *
- * See IEEE 1003.1
+ * @param cv      Condition variable.
+ * @param mut     Associated mutex (must be locked by the caller).
+ * @param abstime Absolute timeout (@c CLOCK_REALTIME).
+ *
+ * @return 0 on success, @c ETIMEDOUT on timeout, or a positive error number on failure.
+ *
+ * @posix_func{pthread_cond_timedwait}
  */
 int pthread_cond_timedwait(pthread_cond_t *cv, pthread_mutex_t *mut,
 			   const struct timespec *abstime);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Initialize a condition variable attributes object with default values.
  *
- * See IEEE 1003.1.
+ * @param att Condition variable attributes object to initialize.
  *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_condattr_init}
  */
 int pthread_condattr_init(pthread_condattr_t *att);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Destroy a condition variable attributes object.
  *
- * See IEEE 1003.1
+ * @param att Condition variable attributes object to destroy.
  *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_condattr_destroy}
  */
 int pthread_condattr_destroy(pthread_condattr_t *att);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Get the clock attribute of a condition variable attributes object.
  *
- * See IEEE 1003.1
+ * @param att      Condition variable attributes object.
+ * @param clock_id Output: clock ID.
  *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_condattr_getclock}
  */
 int pthread_condattr_getclock(const pthread_condattr_t *ZRESTRICT att,
 		clockid_t *ZRESTRICT clock_id);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Set the clock attribute of a condition variable attributes object.
  *
- * See IEEE 1003.1
+ * @param att      Condition variable attributes object.
+ * @param clock_id Clock ID (e.g. @c CLOCK_MONOTONIC or @c CLOCK_REALTIME).
  *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_condattr_setclock}
  */
 
 int pthread_condattr_setclock(pthread_condattr_t *att, clockid_t clock_id);
@@ -165,9 +279,25 @@ int pthread_condattr_setclock(pthread_condattr_t *att, clockid_t clock_id);
  *      error is returned.
  *
  */
+
+/**
+ * @brief Non-recursive mutex with no error checks (fastest).
+ */
 #define PTHREAD_MUTEX_NORMAL        0
+
+/**
+ * @brief Recursive mutex; the owning thread may lock it multiple times.
+ */
 #define PTHREAD_MUTEX_RECURSIVE     1
+
+/**
+ * @brief Mutex that returns an error on deadlock or unlock by a non-owner.
+ */
 #define PTHREAD_MUTEX_ERRORCHECK    2
+
+/**
+ * @brief Default mutex type; behavior on deadlock or unlock by a non-owner is undefined.
+ */
 #define PTHREAD_MUTEX_DEFAULT       PTHREAD_MUTEX_NORMAL
 
 /*
@@ -182,157 +312,274 @@ int pthread_condattr_setclock(pthread_condattr_t *att, clockid_t clock_id);
  *      any of these mutexes).
  *  FIXME: Only PRIO_NONE is supported. Implement other protocols.
  */
+
+/**
+ * @brief Mutex protocol: no priority inheritance or ceiling.
+ */
 #define PTHREAD_PRIO_NONE           0
+
+/**
+ * @brief Mutex protocol: owning thread inherits the priority of the highest-priority waiter.
+ */
 #define PTHREAD_PRIO_INHERIT        1
+
+/**
+ * @brief Mutex protocol: owner runs at ceiling priority while holding the mutex.
+ */
 #define PTHREAD_PRIO_PROTECT        2
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Destroy a mutex.
  *
- * See IEEE 1003.1
+ * @param m Mutex to destroy.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_mutex_destroy}
  */
 int pthread_mutex_destroy(pthread_mutex_t *m);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Lock a mutex, blocking until it is available.
  *
- * See IEEE 1003.1
+ * @param m Mutex to lock.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_mutex_lock}
  */
 int pthread_mutex_lock(pthread_mutex_t *m);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Unlock a mutex.
  *
- * See IEEE 1003.1
+ * @param m Mutex to unlock.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_mutex_unlock}
  */
 int pthread_mutex_unlock(pthread_mutex_t *m);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Lock a mutex with an absolute timeout.
  *
- * See IEEE 1003.1
+ * @param m       Mutex to lock.
+ * @param abstime Absolute timeout (@c CLOCK_REALTIME).
+ *
+ * @return 0 on success, @c ETIMEDOUT on timeout, or a positive error number on failure.
+ *
+ * @posix_func{pthread_mutex_timedlock}
  */
 
 int pthread_mutex_timedlock(pthread_mutex_t *m,
 			    const struct timespec *abstime);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Try to lock a mutex without blocking.
  *
- * See IEEE 1003.1
+ * @param m Mutex to try to lock.
+ *
+ * @return 0 if the lock was acquired, @c EBUSY if already locked, or a positive error number.
+ *
+ * @posix_func{pthread_mutex_trylock}
  */
 int pthread_mutex_trylock(pthread_mutex_t *m);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Initialize a mutex.
  *
- * See IEEE 1003.1
+ * @param m   Mutex to initialize.
+ * @param att Mutex attributes, or NULL for defaults.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_mutex_init}
  */
 int pthread_mutex_init(pthread_mutex_t *m,
 				     const pthread_mutexattr_t *att);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Set the protocol attribute of a mutex attributes object.
  *
- * See IEEE 1003.1
+ * @param attr     Mutex attributes object.
+ * @param protocol @c PTHREAD_PRIO_NONE, @c PTHREAD_PRIO_INHERIT, or @c PTHREAD_PRIO_PROTECT.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_mutexattr_setprotocol}
  */
 int pthread_mutexattr_setprotocol(pthread_mutexattr_t *attr, int protocol);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Set the type attribute of a mutex attributes object.
  *
- * See IEEE 1003.1
+ * @param attr Mutex attributes object.
+ * @param type @c PTHREAD_MUTEX_NORMAL, @c PTHREAD_MUTEX_ERRORCHECK,
+ *             @c PTHREAD_MUTEX_RECURSIVE, or @c PTHREAD_MUTEX_DEFAULT.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_mutexattr_settype}
  */
 int pthread_mutexattr_settype(pthread_mutexattr_t *attr, int type);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Get the protocol attribute of a mutex attributes object.
  *
- * See IEEE 1003.1
+ * @param attr     Mutex attributes object.
+ * @param protocol Output: @c PTHREAD_PRIO_NONE, @c PTHREAD_PRIO_INHERIT,
+ *                 or @c PTHREAD_PRIO_PROTECT.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_mutexattr_getprotocol}
  */
 int pthread_mutexattr_getprotocol(const pthread_mutexattr_t *attr,
 				  int *protocol);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Get the type attribute of a mutex attributes object.
  *
- * See IEEE 1003.1
+ * @param attr Mutex attributes object.
+ * @param type Output: @c PTHREAD_MUTEX_NORMAL, @c PTHREAD_MUTEX_ERRORCHECK,
+ *             @c PTHREAD_MUTEX_RECURSIVE, or @c PTHREAD_MUTEX_DEFAULT.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_mutexattr_gettype}
  */
 int pthread_mutexattr_gettype(const pthread_mutexattr_t *attr, int *type);
 
 /**
- * @brief POSIX threading compatibility API
- *
- * See IEEE 1003.1
+ * @brief Initialize a mutex attributes object with default values.
  *
  * Note that pthread attribute structs are currently noops in Zephyr.
+ *
+ * @param attr Mutex attributes object to initialize.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_mutexattr_init}
  */
 int pthread_mutexattr_init(pthread_mutexattr_t *attr);
 
 /**
- * @brief POSIX threading compatibility API
- *
- * See IEEE 1003.1
+ * @brief Destroy a mutex attributes object.
  *
  * Note that pthread attribute structs are currently noops in Zephyr.
+ *
+ * @param attr Mutex attributes object to destroy.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_mutexattr_destroy}
  */
 int pthread_mutexattr_destroy(pthread_mutexattr_t *attr);
 
+/**
+ * @brief Returned by pthread_barrier_wait() to one (arbitrary) thread per barrier cycle.
+ */
 #define PTHREAD_BARRIER_SERIAL_THREAD 1
 
 /*
  *  Barrier attributes - type
  */
+
+/**
+ * @brief Mutex or barrier attribute: object is private to the process (default).
+ */
 #define PTHREAD_PROCESS_PRIVATE		0
+
+/**
+ * @brief Non-standard alias for @c PTHREAD_PROCESS_SHARED.
+ */
 #define PTHREAD_PROCESS_PUBLIC		1
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Synchronize participating threads at a barrier.
  *
- * See IEEE 1003.1
+ * Blocks until the number of threads specified in pthread_barrier_init() have
+ * called this function on the same barrier. Exactly one thread receives
+ * @c PTHREAD_BARRIER_SERIAL_THREAD as the return value.
+ *
+ * @param b Barrier to wait on.
+ *
+ * @return @c PTHREAD_BARRIER_SERIAL_THREAD for one thread, 0 for all others,
+ *         or a positive error number on failure.
+ *
+ * @posix_func{pthread_barrier_wait}
  */
 int pthread_barrier_wait(pthread_barrier_t *b);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Initialize a barrier object.
  *
- * See IEEE 1003.1
+ * @param b     Barrier to initialize.
+ * @param attr  Barrier attributes, or NULL for defaults.
+ * @param count Number of threads that must call pthread_barrier_wait() before any proceeds.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_barrier_init}
  */
 int pthread_barrier_init(pthread_barrier_t *b, const pthread_barrierattr_t *attr,
 			 unsigned int count);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Destroy a barrier object.
  *
- * See IEEE 1003.1
+ * @param b Barrier to destroy.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_barrier_destroy}
  */
 int pthread_barrier_destroy(pthread_barrier_t *b);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Initialize a barrier attributes object with default values.
  *
- * See IEEE 1003.1
+ * @param b Barrier attributes object to initialize.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_barrierattr_init}
  */
 int pthread_barrierattr_init(pthread_barrierattr_t *b);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Destroy a barrier attributes object.
  *
- * See IEEE 1003.1
+ * @param b Barrier attributes object to destroy.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_barrierattr_destroy}
  */
 int pthread_barrierattr_destroy(pthread_barrierattr_t *b);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Set the process-shared attribute of a barrier attributes object.
  *
- * See IEEE 1003.1
+ * @param attr    Barrier attributes object.
+ * @param pshared @c PTHREAD_PROCESS_SHARED or @c PTHREAD_PROCESS_PRIVATE.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_barrierattr_setpshared}
  */
 int pthread_barrierattr_setpshared(pthread_barrierattr_t *attr, int pshared);
 
 /**
- * @brief POSIX threading compatibility API
+ * @brief Get the process-shared attribute of a barrier attributes object.
  *
- * See IEEE 1003.1
+ * @param attr    Barrier attributes object.
+ * @param pshared Output: @c PTHREAD_PROCESS_SHARED or @c PTHREAD_PROCESS_PRIVATE.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_barrierattr_getpshared}
  */
 int pthread_barrierattr_getpshared(const pthread_barrierattr_t *ZRESTRICT attr,
 				   int *ZRESTRICT pshared);
@@ -357,122 +604,737 @@ int pthread_mutexattr_setrobust(pthread_mutexattr_t *, int);
 */
 
 #ifdef CONFIG_POSIX_THREAD_PRIO_PROTECT
+/**
+ * @brief Get the priority ceiling of a mutex.
+ *
+ * @param mutex       Mutex to query.
+ * @param prioceiling Output: priority ceiling value.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_mutex_getprioceiling}
+ */
 int pthread_mutex_getprioceiling(const pthread_mutex_t *ZRESTRICT mutex,
 				 int *ZRESTRICT prioceiling);
+
+/**
+ * @brief Set the priority ceiling of a mutex.
+ *
+ * @param mutex       Mutex to update.
+ * @param prioceiling New priority ceiling value.
+ * @param old_ceiling Output: previous priority ceiling.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_mutex_setprioceiling}
+ */
 int pthread_mutex_setprioceiling(pthread_mutex_t *ZRESTRICT mutex, int prioceiling,
 				 int *ZRESTRICT old_ceiling);
+
+/**
+ * @brief Get the priority ceiling attribute of a mutex attributes object.
+ *
+ * @param attr        Mutex attributes object.
+ * @param prioceiling Output: priority ceiling.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_mutexattr_getprioceiling}
+ */
 int pthread_mutexattr_getprioceiling(const pthread_mutexattr_t *ZRESTRICT attr,
 				     int *ZRESTRICT prioceiling);
+
+/**
+ * @brief Set the priority ceiling attribute of a mutex attributes object.
+ *
+ * @param attr        Mutex attributes object.
+ * @param prioceiling Priority ceiling value.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_mutexattr_setprioceiling}
+ */
 int pthread_mutexattr_setprioceiling(pthread_mutexattr_t *attr, int prioceiling);
 #endif /* CONFIG_POSIX_THREAD_PRIO_PROTECT */
 
 /* Base Pthread related APIs */
 
 /**
- * @brief Obtain ID of the calling thread.
+ * @brief Return the thread ID of the calling thread.
  *
  * The results of calling this API from threads not created with
  * pthread_create() are undefined.
  *
- * See IEEE 1003.1
+ * @return Thread ID of the calling thread.
+ *
+ * @posix_func{pthread_self}
  */
 pthread_t pthread_self(void);
 
 /**
- * @brief Compare thread IDs.
+ * @brief Compare two thread IDs.
  *
- * See IEEE 1003.1
+ * @param pt1 First thread ID.
+ * @param pt2 Second thread ID.
+ *
+ * @return Non-zero if @p pt1 and @p pt2 refer to the same thread, 0 otherwise.
+ *
+ * @posix_func{pthread_equal}
  */
 int pthread_equal(pthread_t pt1, pthread_t pt2);
 
 /**
- * @brief Destroy the read-write lock attributes object.
+ * @brief Destroy a reader-writer lock attributes object.
  *
- * See IEEE 1003.1
+ * @param attr Attributes object to destroy.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_rwlockattr_destroy}
  */
 int pthread_rwlockattr_destroy(pthread_rwlockattr_t *attr);
 
 /**
- * @brief initialize the read-write lock attributes object.
+ * @brief Initialize a reader-writer lock attributes object with default values.
  *
- * See IEEE 1003.1
+ * @param attr Attributes object to initialize.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_rwlockattr_init}
  */
 int pthread_rwlockattr_init(pthread_rwlockattr_t *attr);
 
+/**
+ * @brief Get the process-shared attribute of a reader-writer lock attributes object.
+ *
+ * @param attr    Attributes object.
+ * @param pshared Output: @c PTHREAD_PROCESS_SHARED or @c PTHREAD_PROCESS_PRIVATE.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_rwlockattr_getpshared}
+ */
 int pthread_rwlockattr_getpshared(const pthread_rwlockattr_t *ZRESTRICT attr,
 				  int *ZRESTRICT pshared);
+
+/**
+ * @brief Set the process-shared attribute of a reader-writer lock attributes object.
+ *
+ * @param attr    Attributes object.
+ * @param pshared @c PTHREAD_PROCESS_SHARED or @c PTHREAD_PROCESS_PRIVATE.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_rwlockattr_setpshared}
+ */
 int pthread_rwlockattr_setpshared(pthread_rwlockattr_t *attr, int pshared);
 
+/**
+ * @brief Get the guard size attribute of a thread attributes object.
+ *
+ * @param attr      Thread attributes object.
+ * @param guardsize Output: guard size in bytes.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_getguardsize}
+ */
 int pthread_attr_getguardsize(const pthread_attr_t *ZRESTRICT attr, size_t *ZRESTRICT guardsize);
+
+/**
+ * @brief Get the stack size attribute of a thread attributes object.
+ *
+ * @param attr      Thread attributes object.
+ * @param stacksize Output: stack size in bytes.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_getstacksize}
+ */
 int pthread_attr_getstacksize(const pthread_attr_t *attr, size_t *stacksize);
+
+/**
+ * @brief Set the guard size attribute of a thread attributes object.
+ *
+ * @param attr      Thread attributes object.
+ * @param guardsize Guard size in bytes.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_setguardsize}
+ */
 int pthread_attr_setguardsize(pthread_attr_t *attr, size_t guardsize);
+
+/**
+ * @brief Set the stack size attribute of a thread attributes object.
+ *
+ * @param attr      Thread attributes object.
+ * @param stacksize Stack size in bytes (at least @c PTHREAD_STACK_MIN).
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_setstacksize}
+ */
 int pthread_attr_setstacksize(pthread_attr_t *attr, size_t stacksize);
+
+/**
+ * @brief Set the scheduling policy attribute of a thread attributes object.
+ *
+ * @param attr   Thread attributes object.
+ * @param policy Scheduling policy (e.g. @c SCHED_FIFO, @c SCHED_RR, or @c SCHED_OTHER).
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_setschedpolicy}
+ */
 int pthread_attr_setschedpolicy(pthread_attr_t *attr, int policy);
+
+/**
+ * @brief Get the scheduling policy attribute of a thread attributes object.
+ *
+ * @param attr   Thread attributes object.
+ * @param policy Output: scheduling policy (e.g. @c SCHED_FIFO, @c SCHED_RR, or @c SCHED_OTHER).
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_getschedpolicy}
+ */
 int pthread_attr_getschedpolicy(const pthread_attr_t *attr, int *policy);
+
+/**
+ * @brief Set the detach state attribute of a thread attributes object.
+ *
+ * @param attr        Thread attributes object.
+ * @param detachstate @c PTHREAD_CREATE_DETACHED or @c PTHREAD_CREATE_JOINABLE.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_setdetachstate}
+ */
 int pthread_attr_setdetachstate(pthread_attr_t *attr, int detachstate);
+
+/**
+ * @brief Get the detach state attribute of a thread attributes object.
+ *
+ * @param attr        Thread attributes object.
+ * @param detachstate Output: @c PTHREAD_CREATE_DETACHED or @c PTHREAD_CREATE_JOINABLE.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_getdetachstate}
+ */
 int pthread_attr_getdetachstate(const pthread_attr_t *attr, int *detachstate);
+
+/**
+ * @brief Initialize a thread attributes object with default values.
+ *
+ * @param attr Thread attributes object to initialize.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_init}
+ */
 int pthread_attr_init(pthread_attr_t *attr);
+
+/**
+ * @brief Destroy a thread attributes object.
+ *
+ * @param attr Thread attributes object to destroy.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_destroy}
+ */
 int pthread_attr_destroy(pthread_attr_t *attr);
+
+/**
+ * @brief Get the scheduling parameter attribute of a thread attributes object.
+ *
+ * @param attr       Thread attributes object.
+ * @param schedparam Output: scheduling parameters.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_getschedparam}
+ */
 int pthread_attr_getschedparam(const pthread_attr_t *attr,
 			       struct sched_param *schedparam);
+
+/**
+ * @brief Get the scheduling policy and parameters of a thread.
+ *
+ * @param pthread Thread to query.
+ * @param policy  Output: scheduling policy.
+ * @param param   Output: scheduling parameters.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_getschedparam}
+ */
 int pthread_getschedparam(pthread_t pthread, int *policy,
 			  struct sched_param *param);
+
+/**
+ * @brief Get the stack address and size attributes of a thread attributes object.
+ *
+ * @param attr      Thread attributes object.
+ * @param stackaddr Output: stack base address.
+ * @param stacksize Output: stack size in bytes.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_getstack}
+ */
 int pthread_attr_getstack(const pthread_attr_t *attr,
 			  void **stackaddr, size_t *stacksize);
+
+/**
+ * @brief Set the stack address and size attributes of a thread attributes object.
+ *
+ * @param attr      Thread attributes object.
+ * @param stackaddr Stack base address.
+ * @param stacksize Stack size in bytes (at least @c PTHREAD_STACK_MIN).
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_setstack}
+ */
 int pthread_attr_setstack(pthread_attr_t *attr, void *stackaddr,
 			  size_t stacksize);
+
+/**
+ * @brief Get the contention scope attribute of a thread attributes object.
+ *
+ * @param attr            Thread attributes object.
+ * @param contentionscope Output: @c PTHREAD_SCOPE_SYSTEM or @c PTHREAD_SCOPE_PROCESS.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_getscope}
+ */
 int pthread_attr_getscope(const pthread_attr_t *attr, int *contentionscope);
+
+/**
+ * @brief Set the contention scope attribute of a thread attributes object.
+ *
+ * @param attr            Thread attributes object.
+ * @param contentionscope @c PTHREAD_SCOPE_SYSTEM or @c PTHREAD_SCOPE_PROCESS.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_setscope}
+ */
 int pthread_attr_setscope(pthread_attr_t *attr, int contentionscope);
+
+/**
+ * @brief Get the inherit-scheduler attribute of a thread attributes object.
+ *
+ * @param attr         Thread attributes object.
+ * @param inheritsched Output: @c PTHREAD_INHERIT_SCHED or @c PTHREAD_EXPLICIT_SCHED.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_getinheritsched}
+ */
 int pthread_attr_getinheritsched(const pthread_attr_t *attr, int *inheritsched);
+
+/**
+ * @brief Set the inherit-scheduler attribute of a thread attributes object.
+ *
+ * @param attr         Thread attributes object.
+ * @param inheritsched @c PTHREAD_INHERIT_SCHED or @c PTHREAD_EXPLICIT_SCHED.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_setinheritsched}
+ */
 int pthread_attr_setinheritsched(pthread_attr_t *attr, int inheritsched);
 #ifdef CONFIG_POSIX_THREADS
+/**
+ * @brief Ensure a one-time initialization routine is called exactly once.
+ *
+ * @param once     Pointer to a @c pthread_once_t initialized with @c PTHREAD_ONCE_INIT.
+ * @param initFunc Initialization function to call at most once.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_once}
+ */
 int pthread_once(pthread_once_t *once, void (*initFunc)(void));
 #endif
+
+/**
+ * @brief Terminate the calling thread.
+ *
+ * @param retval Value made available to pthread_join().
+ *
+ * @posix_func{pthread_exit}
+ */
 FUNC_NORETURN void pthread_exit(void *retval);
+
+/**
+ * @brief Join a thread with a non-portable timeout.
+ * @ingroup posix_extensions
+ *
+ * @param thread  Thread to wait for.
+ * @param status  Output: exit value of the thread, or @c PTHREAD_CANCELED.
+ * @param abstime Absolute timeout (@c CLOCK_REALTIME).
+ *
+ * @return 0 on success, @c ETIMEDOUT on timeout, or a positive error number on failure.
+ *
+ * @compat_api{pthread_timedjoin_np}
+ */
 int pthread_timedjoin_np(pthread_t thread, void **status, const struct timespec *abstime);
+
+/**
+ * @brief Try to join a thread without blocking.
+ * @ingroup posix_extensions
+ *
+ * @param thread Thread to try to join.
+ * @param status Output: exit value if joined, or unchanged if not yet terminated.
+ *
+ * @return 0 if joined, @c EBUSY if the thread has not yet terminated,
+ *         or a positive error number on failure.
+ *
+ * @compat_api{pthread_tryjoin_np}
+ */
 int pthread_tryjoin_np(pthread_t thread, void **status);
+
+/**
+ * @brief Wait for a thread to terminate and retrieve its exit status.
+ *
+ * @param thread Thread to wait for.
+ * @param status Output: exit value of the thread, or @c PTHREAD_CANCELED.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_join}
+ */
 int pthread_join(pthread_t thread, void **status);
+
+/**
+ * @brief Send a cancellation request to a thread.
+ *
+ * @param pthread Thread to cancel.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_cancel}
+ */
 int pthread_cancel(pthread_t pthread);
+
+/**
+ * @brief Detach a thread, releasing its resources automatically on termination.
+ *
+ * @param thread Thread to detach.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_detach}
+ */
 int pthread_detach(pthread_t thread);
+
+/**
+ * @brief Create a new thread.
+ *
+ * @param newthread     Output: thread ID of the new thread.
+ * @param attr          Thread attributes, or NULL for defaults.
+ * @param threadroutine Thread entry point function.
+ * @param arg           Argument passed to @p threadroutine.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_create}
+ */
 int pthread_create(pthread_t *newthread, const pthread_attr_t *attr,
 		   void *(*threadroutine)(void *), void *arg);
+
+/**
+ * @brief Set the cancelability state of the calling thread.
+ *
+ * @param state    @c PTHREAD_CANCEL_ENABLE or @c PTHREAD_CANCEL_DISABLE.
+ * @param oldstate Output: previous cancelability state.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_setcancelstate}
+ */
 int pthread_setcancelstate(int state, int *oldstate);
+
+/**
+ * @brief Set the cancelability type of the calling thread.
+ *
+ * @param type    @c PTHREAD_CANCEL_DEFERRED or @c PTHREAD_CANCEL_ASYNCHRONOUS.
+ * @param oldtype Output: previous cancelability type.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_setcanceltype}
+ */
 int pthread_setcanceltype(int type, int *oldtype);
+
+/**
+ * @brief Create a cancellation point in the calling thread.
+ *
+ * If cancellation is pending and enabled, this function does not return.
+ *
+ * @posix_func{pthread_testcancel}
+ */
 void pthread_testcancel(void);
+
+/**
+ * @brief Set the scheduling parameter attribute of a thread attributes object.
+ *
+ * @param attr       Thread attributes object.
+ * @param schedparam Scheduling parameters to apply.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_attr_setschedparam}
+ */
 int pthread_attr_setschedparam(pthread_attr_t *attr,
 			       const struct sched_param *schedparam);
+
+/**
+ * @brief Set the scheduling policy and parameters of a thread.
+ *
+ * @param pthread Thread to modify.
+ * @param policy  New scheduling policy.
+ * @param param   New scheduling parameters.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_setschedparam}
+ */
 int pthread_setschedparam(pthread_t pthread, int policy,
 			  const struct sched_param *param);
+
+/**
+ * @brief Set the scheduling priority of a thread.
+ *
+ * @param thread Thread to modify.
+ * @param prio   New priority value.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_setschedprio}
+ */
 int pthread_setschedprio(pthread_t thread, int prio);
+
+/**
+ * @brief Destroy a reader-writer lock.
+ *
+ * @param rwlock Reader-writer lock to destroy.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_rwlock_destroy}
+ */
 int pthread_rwlock_destroy(pthread_rwlock_t *rwlock);
+
+/**
+ * @brief Initialize a reader-writer lock.
+ *
+ * @param rwlock Reader-writer lock to initialize.
+ * @param attr   Attributes, or NULL for defaults.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_rwlock_init}
+ */
 int pthread_rwlock_init(pthread_rwlock_t *rwlock,
 			const pthread_rwlockattr_t *attr);
+
+/**
+ * @brief Acquire a read lock, blocking until available.
+ *
+ * @param rwlock Reader-writer lock.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_rwlock_rdlock}
+ */
 int pthread_rwlock_rdlock(pthread_rwlock_t *rwlock);
+
+/**
+ * @brief Acquire a read lock with an absolute timeout.
+ *
+ * @param rwlock  Reader-writer lock.
+ * @param abstime Absolute timeout (@c CLOCK_REALTIME).
+ *
+ * @return 0 on success, @c ETIMEDOUT on timeout, or a positive error number on failure.
+ *
+ * @posix_func{pthread_rwlock_timedrdlock}
+ */
 int pthread_rwlock_timedrdlock(pthread_rwlock_t *rwlock,
 			       const struct timespec *abstime);
+
+/**
+ * @brief Acquire a write lock with an absolute timeout.
+ *
+ * @param rwlock  Reader-writer lock.
+ * @param abstime Absolute timeout (@c CLOCK_REALTIME).
+ *
+ * @return 0 on success, @c ETIMEDOUT on timeout, or a positive error number on failure.
+ *
+ * @posix_func{pthread_rwlock_timedwrlock}
+ */
 int pthread_rwlock_timedwrlock(pthread_rwlock_t *rwlock,
 			       const struct timespec *abstime);
+
+/**
+ * @brief Try to acquire a read lock without blocking.
+ *
+ * @param rwlock Reader-writer lock.
+ *
+ * @return 0 on success, @c EBUSY if locked, or a positive error number on failure.
+ *
+ * @posix_func{pthread_rwlock_tryrdlock}
+ */
 int pthread_rwlock_tryrdlock(pthread_rwlock_t *rwlock);
+
+/**
+ * @brief Try to acquire a write lock without blocking.
+ *
+ * @param rwlock Reader-writer lock.
+ *
+ * @return 0 on success, @c EBUSY if locked, or a positive error number on failure.
+ *
+ * @posix_func{pthread_rwlock_trywrlock}
+ */
 int pthread_rwlock_trywrlock(pthread_rwlock_t *rwlock);
+
+/**
+ * @brief Release a reader-writer lock.
+ *
+ * @param rwlock Reader-writer lock to release.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_rwlock_unlock}
+ */
 int pthread_rwlock_unlock(pthread_rwlock_t *rwlock);
+
+/**
+ * @brief Acquire a write lock, blocking until available.
+ *
+ * @param rwlock Reader-writer lock.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_rwlock_wrlock}
+ */
 int pthread_rwlock_wrlock(pthread_rwlock_t *rwlock);
+
+/**
+ * @brief Create a thread-specific data key.
+ *
+ * @param key        Output: new thread-specific data key.
+ * @param destructor Destructor called with the thread's value when the thread exits, or NULL.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_key_create}
+ */
 int pthread_key_create(pthread_key_t *key,
 		void (*destructor)(void *));
+
+/**
+ * @brief Delete a thread-specific data key.
+ *
+ * @param key Key to delete.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_key_delete}
+ */
 int pthread_key_delete(pthread_key_t key);
+
+/**
+ * @brief Set the thread-specific value associated with a key.
+ *
+ * @param key   Thread-specific data key.
+ * @param value Value to associate with @p key for the calling thread.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_setspecific}
+ */
 int pthread_setspecific(pthread_key_t key, const void *value);
+
+/**
+ * @brief Get the thread-specific value associated with a key.
+ *
+ * @param key Thread-specific data key.
+ *
+ * @return Value associated with @p key for the calling thread, or NULL if none.
+ *
+ * @posix_func{pthread_getspecific}
+ */
 void *pthread_getspecific(pthread_key_t key);
+
+/**
+ * @brief Register fork handlers to be called around fork().
+ *
+ * @param prepare Handler called in the parent before fork().
+ * @param parent  Handler called in the parent after fork().
+ * @param child   Handler called in the child after fork().
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_atfork}
+ */
 int pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(void));
+
+/**
+ * @brief Get the concurrency level (advisory, has no effect on scheduling).
+ *
+ * @return Current concurrency level.
+ *
+ * @posix_func{pthread_getconcurrency}
+ */
 int pthread_getconcurrency(void);
+
+/**
+ * @brief Set the concurrency level (advisory, has no effect on scheduling).
+ *
+ * @param new_level Desired concurrency level (0 = implementation default).
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_setconcurrency}
+ */
 int pthread_setconcurrency(int new_level);
-
+/** @cond INTERNAL_HIDDEN */
 void __z_pthread_cleanup_push(void *cleanup[3], void (*routine)(void *arg), void *arg);
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 void __z_pthread_cleanup_pop(int execute);
+/** @endcond */
 
+/**
+ * @brief Establish a cancellation cleanup handler.
+ *
+ * The handler @p _rtn is called with @p _arg when the thread exits or calls
+ * pthread_cleanup_pop() with a non-zero argument.
+ *
+ * @note This macro must be paired with pthread_cleanup_pop() in the same
+ *       lexical scope.
+ */
 #define pthread_cleanup_push(_rtn, _arg)                                                           \
 	do /* enforce '{'-like behaviour */ {                                                      \
 		void *_z_pthread_cleanup[3];                                                       \
 		__z_pthread_cleanup_push(_z_pthread_cleanup, _rtn, _arg)
 
+/**
+ * @brief Remove a cancellation cleanup handler.
+ *
+ * @param _ex If non-zero, the handler is executed before being removed.
+ *
+ * @note This macro must be paired with pthread_cleanup_push() in the same
+ *       lexical scope.
+ */
 #define pthread_cleanup_pop(_ex)                                                                   \
 		__z_pthread_cleanup_pop(_ex);                                                      \
 	} /* enforce '}'-like behaviour */ while (0)
@@ -492,12 +1354,13 @@ void __z_pthread_cleanup_pop(int execute);
  * @retval EINVAL Name buffer is NULL
  * @retval <0 Negative value if kernel function error
  *
+ * @ingroup posix_extensions
+ * @compat_api{pthread_setname_np}
  */
 int pthread_setname_np(pthread_t thread, const char *name);
 
 /**
- * @brief Get name of POSIX thread and store in name buffer
- *  	  that is of size len.
+ * @brief Get name of POSIX thread and store in name buffer that is of size len.
  *
  * Non-portable, extension function that conforms with most
  * other definitions of this function.
@@ -509,43 +1372,66 @@ int pthread_setname_np(pthread_t thread, const char *name);
  * @retval ESRCH Thread does not exist
  * @retval EINVAL Name buffer is NULL
  * @retval <0 negative value if kernel function error
+ * @ingroup posix_extensions
+ * @compat_api{pthread_getname_np}
  */
 int pthread_getname_np(pthread_t thread, char *name, size_t len);
 
 #ifdef CONFIG_POSIX_THREADS
 
 /**
- * @brief Destroy a pthread_spinlock_t.
+ * @brief Destroy a spin lock.
  *
- * See IEEE 1003.1
+ * @param lock Spin lock to destroy.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_spin_destroy}
  */
 int pthread_spin_destroy(pthread_spinlock_t *lock);
 
 /**
- * @brief Initialize a thread_spinlock_t.
+ * @brief Initialize a spin lock.
  *
- * See IEEE 1003.1
+ * @param lock    Spin lock to initialize.
+ * @param pshared @c PTHREAD_PROCESS_SHARED or @c PTHREAD_PROCESS_PRIVATE.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_spin_init}
  */
 int pthread_spin_init(pthread_spinlock_t *lock, int pshared);
 
 /**
- * @brief Lock a previously initialized thread_spinlock_t.
+ * @brief Acquire a spin lock, busy-waiting until available.
  *
- * See IEEE 1003.1
+ * @param lock Spin lock to acquire.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_spin_lock}
  */
 int pthread_spin_lock(pthread_spinlock_t *lock);
 
 /**
- * @brief Attempt to lock a previously initialized thread_spinlock_t.
+ * @brief Try to acquire a spin lock without busy-waiting.
  *
- * See IEEE 1003.1
+ * @param lock Spin lock to try.
+ *
+ * @return 0 on success, @c EBUSY if already locked, or a positive error number on failure.
+ *
+ * @posix_func{pthread_spin_trylock}
  */
 int pthread_spin_trylock(pthread_spinlock_t *lock);
 
 /**
- * @brief Unlock a previously locked thread_spinlock_t.
+ * @brief Release a spin lock.
  *
- * See IEEE 1003.1
+ * @param lock Spin lock to release.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{pthread_spin_unlock}
  */
 int pthread_spin_unlock(pthread_spinlock_t *lock);
 

--- a/include/zephyr/posix/pwd.h
+++ b/include/zephyr/posix/pwd.h
@@ -3,6 +3,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Password database access.
+ * @ingroup posix
+ *
+ * Defines the passwd structure and the thread-safe functions used to search
+ * the system user database by login name or numeric user ID.
+ *
+ * @posix_header{pwd.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_PWD_H_
 #define ZEPHYR_INCLUDE_POSIX_PWD_H_
 
@@ -12,21 +24,61 @@ extern "C" {
 
 #include <zephyr/posix/sys/stat.h>
 
+/**
+ * @brief User database entry.
+ */
 struct passwd {
-	/* user's login name */
+	/**
+	 * @brief User login name.
+	 */
 	char *pw_name;
-	/* numerical user ID */
+	/**
+	 * @brief Numeric user ID.
+	 */
 	uid_t pw_uid;
-	/* numerical group ID */
+	/**
+	 * @brief Numeric group ID.
+	 */
 	gid_t pw_gid;
-	/* initial working directory */
+	/**
+	 * @brief Initial working directory.
+	 */
 	char *pw_dir;
-	/* program to use as shell */
+	/**
+	 * @brief Program to use as the shell.
+	 */
 	char *pw_shell;
 };
 
+/**
+ * @brief Look up a password entry by name (thread-safe).
+ *
+ * @param nam     User login name to search for.
+ * @param pwd     Caller-supplied structure to fill in.
+ * @param buffer  Caller-supplied buffer for string fields.
+ * @param bufsize Size of @p buffer.
+ * @param result  Output: pointer to @p pwd on success, or NULL if not found.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{getpwnam_r}
+ */
 int getpwnam_r(const char *nam, struct passwd *pwd, char *buffer, size_t bufsize,
 	       struct passwd **result);
+
+/**
+ * @brief Look up a password entry by user ID (thread-safe).
+ *
+ * @param uid     Numerical user ID to search for.
+ * @param pwd     Caller-supplied structure to fill in.
+ * @param buffer  Caller-supplied buffer for string fields.
+ * @param bufsize Size of @p buffer.
+ * @param result  Output: pointer to @p pwd on success, or NULL if not found.
+ *
+ * @return 0 on success, or a positive error number on failure.
+ *
+ * @posix_func{getpwuid_r}
+ */
 int getpwuid_r(uid_t uid, struct passwd *pwd, char *buffer, size_t bufsize, struct passwd **result);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/sched.h
+++ b/include/zephyr/posix/sched.h
@@ -3,6 +3,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Execution scheduling.
+ * @ingroup posix
+ *
+ * Provides the scheduling policies and the sched_* functions used to query
+ * and control process and thread scheduling parameters.
+ *
+ * @posix_header{sched.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_SCHED_H_
 #define ZEPHYR_INCLUDE_POSIX_SCHED_H_
 
@@ -20,36 +32,130 @@ extern "C" {
  * execute identically to SCHED_RR or SCHED_FIFO. For Zephyr this is a
  * pseudonym for SCHED_RR.
  */
+
+/**
+ * @brief Round-robin or other time-sharing scheduling policy (default).
+ */
 #define SCHED_OTHER 0
 
 /* Cooperative scheduling policy */
+
+/**
+ * @brief First-in first-out (cooperative) scheduling policy.
+ */
 #define SCHED_FIFO 1
 
 /* Priority based preemptive scheduling policy */
+
+/**
+ * @brief Round-robin (preemptive, priority-based) scheduling policy.
+ */
 #define SCHED_RR 2
 
 #if defined(CONFIG_MINIMAL_LIBC) || defined(CONFIG_PICOLIBC) || defined(CONFIG_ARMCLANG_STD_LIBC) \
 	|| defined(CONFIG_ARCMWDT_LIBC)
+
+/**
+ * @brief Scheduling parameters used with sched_setparam() and pthread_attr_setschedparam().
+ */
 struct sched_param {
+	/**
+	 * @brief Process or thread execution scheduling priority.
+	 */
 	int sched_priority;
 };
 #endif
 
 /**
- * @brief Yield the processor
+ * @brief Yield the processor to another thread of equal or higher priority.
  *
- * See IEEE 1003.1
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sched_yield}
  */
 int sched_yield(void);
 
+/**
+ * @brief Get the minimum priority value for a scheduling policy.
+ *
+ * @param policy @c SCHED_FIFO, @c SCHED_RR, or @c SCHED_OTHER.
+ *
+ * @return Minimum priority on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sched_get_priority_min}
+ */
 int sched_get_priority_min(int policy);
+
+/**
+ * @brief Get the maximum priority value for a scheduling policy.
+ *
+ * @param policy @c SCHED_FIFO, @c SCHED_RR, or @c SCHED_OTHER.
+ *
+ * @return Maximum priority on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sched_get_priority_max}
+ */
 int sched_get_priority_max(int policy);
 
+/**
+ * @brief Get scheduling parameters for a process.
+ *
+ * @param pid   Process ID (0 = calling process).
+ * @param param Output: current scheduling parameters.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sched_getparam}
+ */
 int sched_getparam(pid_t pid, struct sched_param *param);
+
+/**
+ * @brief Get the scheduling policy of a process.
+ *
+ * @param pid Process ID (0 = calling process).
+ *
+ * @return Scheduling policy (@c SCHED_FIFO, @c SCHED_RR, @c SCHED_OTHER),
+ *         or -1 with errno set on failure.
+ *
+ * @posix_func{sched_getscheduler}
+ */
 int sched_getscheduler(pid_t pid);
 
+/**
+ * @brief Set scheduling parameters for a process.
+ *
+ * @param pid   Process ID (0 = calling process).
+ * @param param New scheduling parameters.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sched_setparam}
+ */
 int sched_setparam(pid_t pid, const struct sched_param *param);
+
+/**
+ * @brief Set the scheduling policy and parameters of a process.
+ *
+ * @param pid    Process ID (0 = calling process).
+ * @param policy @c SCHED_FIFO, @c SCHED_RR, or @c SCHED_OTHER.
+ * @param param  New scheduling parameters.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sched_setscheduler}
+ */
 int sched_setscheduler(pid_t pid, int policy, const struct sched_param *param);
+
+/**
+ * @brief Get the round-robin time quantum for a process.
+ *
+ * @param pid      Process ID (0 = calling process).
+ * @param interval Output: round-robin interval.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sched_rr_get_interval}
+ */
 int sched_rr_get_interval(pid_t pid, struct timespec *interval);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/semaphore.h
+++ b/include/zephyr/posix/semaphore.h
@@ -3,6 +3,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Semaphores.
+ * @ingroup posix
+ *
+ * Provides counting semaphores for synchronization between threads and
+ * processes, in both named (sem_open()) and unnamed (sem_init()) forms.
+ *
+ * @posix_header{semaphore.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_SEMAPHORE_H_
 #define ZEPHYR_INCLUDE_POSIX_SEMAPHORE_H_
 
@@ -14,17 +26,127 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Value returned by sem_open() on failure.
+ */
 #define SEM_FAILED ((sem_t *) 0)
 
+/**
+ * @brief Destroy an unnamed semaphore.
+ *
+ * @param semaphore Semaphore to destroy.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sem_destroy}
+ */
 int sem_destroy(sem_t *semaphore);
+
+/**
+ * @brief Get the current value of a semaphore.
+ *
+ * @param semaphore Semaphore to query.
+ * @param value     Output: current count (implementation may report 0 if waiters are present).
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sem_getvalue}
+ */
 int sem_getvalue(sem_t *ZRESTRICT semaphore, int *ZRESTRICT value);
+
+/**
+ * @brief Initialize an unnamed semaphore.
+ *
+ * @param semaphore Semaphore to initialize.
+ * @param pshared   Non-zero if the semaphore is shared between processes.
+ * @param value     Initial count (must be <= @c SEM_VALUE_MAX).
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sem_init}
+ */
 int sem_init(sem_t *semaphore, int pshared, unsigned int value);
+
+/**
+ * @brief Unlock a semaphore (increment its count).
+ *
+ * @param semaphore Semaphore to post.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sem_post}
+ */
 int sem_post(sem_t *semaphore);
+
+/**
+ * @brief Lock a semaphore with an absolute timeout.
+ *
+ * @param semaphore Semaphore to wait on.
+ * @param abstime   Absolute timeout (@c CLOCK_REALTIME).
+ *
+ * @return 0 on success, -1 with @c errno = @c ETIMEDOUT on timeout,
+ *         or -1 with errno set on another failure.
+ *
+ * @posix_func{sem_timedwait}
+ */
 int sem_timedwait(sem_t *ZRESTRICT semaphore, struct timespec *ZRESTRICT abstime);
+
+/**
+ * @brief Try to lock a semaphore without blocking.
+ *
+ * @param semaphore Semaphore to try.
+ *
+ * @return 0 on success, -1 with @c errno = @c EAGAIN if the count is zero,
+ *         or -1 with errno set on another failure.
+ *
+ * @posix_func{sem_trywait}
+ */
 int sem_trywait(sem_t *semaphore);
+
+/**
+ * @brief Lock a semaphore, blocking until it becomes available.
+ *
+ * @param semaphore Semaphore to wait on.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sem_wait}
+ */
 int sem_wait(sem_t *semaphore);
+
+/**
+ * @brief Open or create a named semaphore.
+ *
+ * @param name   Semaphore name (implementation-defined path).
+ * @param oflags Flags: @c O_CREAT, @c O_EXCL.
+ * @param ...    If @c O_CREAT is set: mode_t mode, unsigned int value.
+ *
+ * @return Pointer to the semaphore on success, or @c SEM_FAILED on failure.
+ *
+ * @posix_func{sem_open}
+ */
 sem_t *sem_open(const char *name, int oflags, ...);
+
+/**
+ * @brief Remove a named semaphore.
+ *
+ * @param name Semaphore name.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sem_unlink}
+ */
 int sem_unlink(const char *name);
+
+/**
+ * @brief Close a named semaphore.
+ *
+ * @param sem Semaphore to close.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sem_close}
+ */
 int sem_close(sem_t *sem);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/stropts.h
+++ b/include/zephyr/posix/stropts.h
@@ -3,25 +3,125 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief STREAMS interface.
+ * @ingroup posix
+ *
+ * Provides the STREAMS I/O control interface (a legacy XSI extension). STREAMS is
+ * rarely implemented in its entirety; Zephyr provides minimal support for compatibility.
+ *
+ * @posix_header{stropts.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_STROPTS_H_
 #define ZEPHYR_INCLUDE_POSIX_STROPTS_H_
+
+/**
+ * @brief Flag: message carries high-priority data.
+ */
 #define RS_HIPRI BIT(0)
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/**
+ * @brief Buffer descriptor for STREAMS getmsg() / putmsg() control and data parts.
+ */
 struct strbuf {
+	/**
+	 * @brief Maximum buffer length.
+	 */
 	int maxlen;
+	/**
+	 * @brief Length of data, or -1 to indicate no data/control part.
+	 */
 	int len;
+	/**
+	 * @brief Pointer to data buffer.
+	 */
 	char *buf;
 };
 
+/**
+ * @brief Send a message on a STREAM.
+ *
+ * @param fildes  STREAMS file descriptor.
+ * @param ctlptr  Control part of the message, or NULL.
+ * @param dataptr Data part of the message, or NULL.
+ * @param flags   0, or @c RS_HIPRI to send a high-priority message.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{putmsg}
+ */
 int putmsg(int fildes, const struct strbuf *ctlptr, const struct strbuf *dataptr, int flags);
+
+/**
+ * @brief Detach a name from a STREAMS-based file descriptor.
+ *
+ * @param path Pathname previously used with fattach().
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{fdetach}
+ */
 int fdetach(const char *path);
+
+/**
+ * @brief Attach a STREAMS-based file descriptor to a file in the file system name space.
+ *
+ * @param fildes STREAMS file descriptor to attach.
+ * @param path   Existing pathname to attach the STREAMS file descriptor to.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{fattach}
+ */
 int fattach(int fildes, const char *path);
+
+/**
+ * @brief Receive next message from a STREAMS file.
+ *
+ * @param fildes  STREAMS file descriptor.
+ * @param ctlptr  Output: control part buffer, or NULL.
+ * @param dataptr Output: data part buffer, or NULL.
+ * @param flagsp  Input/output: 0, or @c RS_HIPRI to request high-priority messages only.
+ *
+ * @return 0 if a complete message was received, a positive value if more of the message
+ *         remains, or -1 with errno set on failure.
+ *
+ * @posix_func{getmsg}
+ */
 int getmsg(int fildes, struct strbuf *ctlptr, struct strbuf *dataptr, int *flagsp);
+
+/**
+ * @brief Receive a priority-banded message from a STREAMS file.
+ *
+ * @param fildes  STREAMS file descriptor.
+ * @param ctlptr  Output: control part buffer, or NULL.
+ * @param dataptr Output: data part buffer, or NULL.
+ * @param bandp   Input/output: priority band of the message.
+ * @param flagsp  Input/output: message flags.
+ *
+ * @return 0 if a complete message was received, a positive value if more of the message
+ *         remains, or -1 with errno set on failure.
+ *
+ * @posix_func{getpmsg}
+ */
 int getpmsg(int fildes, struct strbuf *ctlptr, struct strbuf *dataptr, int *bandp, int *flagsp);
+
+/**
+ * @brief Test whether a file descriptor refers to a STREAMS file.
+ *
+ * @param fildes File descriptor to test.
+ *
+ * @return 1 if @p fildes is a STREAMS file, 0 if not, or -1 with errno set on error.
+ *
+ * @posix_func{isastream}
+ */
 int isastream(int fildes);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/sys/confstr.h
+++ b/include/zephyr/posix/sys/confstr.h
@@ -3,6 +3,16 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief POSIX configuration string name declarations.
+ * @ingroup posix
+ *
+ * Defines the @c _CS_* name constants used as the first argument to
+ * confstr() to query implementation-defined configuration strings.
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_CONFSTR_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_CONFSTR_H_
 
@@ -10,37 +20,139 @@
 extern "C" {
 #endif
 
+/**
+ * @brief confstr() name constants.
+ */
 enum {
+	/**
+	 * @brief Value for the PATH environment variable that finds all standard utilities.
+	 */
 	_CS_PATH,
+	/**
+	 * @brief C compiler flags for the ILP32 model with 32-bit @c off_t (POSIX.1-2008).
+	 */
 	_CS_POSIX_V7_ILP32_OFF32_CFLAGS,
+	/**
+	 * @brief Linker flags for the ILP32 model with 32-bit @c off_t (POSIX.1-2008).
+	 */
 	_CS_POSIX_V7_ILP32_OFF32_LDFLAGS,
+	/**
+	 * @brief Libraries for the ILP32 model with 32-bit @c off_t (POSIX.1-2008).
+	 */
 	_CS_POSIX_V7_ILP32_OFF32_LIBS,
+	/**
+	 * @brief C compiler flags for the ILP32 model with 64-bit or larger @c off_t
+	 * (POSIX.1-2008).
+	 */
 	_CS_POSIX_V7_ILP32_OFFBIG_CFLAGS,
+	/**
+	 * @brief Linker flags for the ILP32 model with 64-bit or larger @c off_t (POSIX.1-2008).
+	 */
 	_CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS,
+	/**
+	 * @brief Libraries for the ILP32 model with 64-bit or larger @c off_t (POSIX.1-2008).
+	 */
 	_CS_POSIX_V7_ILP32_OFFBIG_LIBS,
+	/**
+	 * @brief C compiler flags for the LP64 model with 64-bit @c off_t (POSIX.1-2008).
+	 */
 	_CS_POSIX_V7_LP64_OFF64_CFLAGS,
+	/**
+	 * @brief Linker flags for the LP64 model with 64-bit @c off_t (POSIX.1-2008).
+	 */
 	_CS_POSIX_V7_LP64_OFF64_LDFLAGS,
+	/**
+	 * @brief Libraries for the LP64 model with 64-bit @c off_t (POSIX.1-2008).
+	 */
 	_CS_POSIX_V7_LP64_OFF64_LIBS,
+	/**
+	 * @brief C compiler flags for the LPBIG model with 64-bit or larger @c off_t
+	 * (POSIX.1-2008).
+	 */
 	_CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS,
+	/**
+	 * @brief Linker flags for the LPBIG model with 64-bit or larger @c off_t (POSIX.1-2008).
+	 */
 	_CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS,
+	/**
+	 * @brief Libraries for the LPBIG model with 64-bit or larger @c off_t (POSIX.1-2008).
+	 */
 	_CS_POSIX_V7_LPBIG_OFFBIG_LIBS,
+	/**
+	 * @brief C compiler flags for building multi-threaded applications (POSIX.1-2008).
+	 */
 	_CS_POSIX_V7_THREADS_CFLAGS,
+	/**
+	 * @brief Linker flags for building multi-threaded applications (POSIX.1-2008).
+	 */
 	_CS_POSIX_V7_THREADS_LDFLAGS,
+	/**
+	 * @brief Newline-separated list of width-restricted programming environments
+	 * (POSIX.1-2008).
+	 */
 	_CS_POSIX_V7_WIDTH_RESTRICTED_ENVS,
+	/**
+	 * @brief Environment variable settings required for a conforming POSIX.1-2008 environment.
+	 */
 	_CS_V7_ENV,
+	/**
+	 * @brief C compiler flags for the ILP32 model with 32-bit @c off_t (POSIX.1-2001).
+	 */
 	_CS_POSIX_V6_ILP32_OFF32_CFLAGS,
+	/**
+	 * @brief Linker flags for the ILP32 model with 32-bit @c off_t (POSIX.1-2001).
+	 */
 	_CS_POSIX_V6_ILP32_OFF32_LDFLAGS,
+	/**
+	 * @brief Libraries for the ILP32 model with 32-bit @c off_t (POSIX.1-2001).
+	 */
 	_CS_POSIX_V6_ILP32_OFF32_LIBS,
+	/**
+	 * @brief C compiler flags for the ILP32 model with 64-bit or larger @c off_t
+	 * (POSIX.1-2001).
+	 */
 	_CS_POSIX_V6_ILP32_OFFBIG_CFLAGS,
+	/**
+	 * @brief Linker flags for the ILP32 model with 64-bit or larger @c off_t (POSIX.1-2001).
+	 */
 	_CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS,
+	/**
+	 * @brief Libraries for the ILP32 model with 64-bit or larger @c off_t (POSIX.1-2001).
+	 */
 	_CS_POSIX_V6_ILP32_OFFBIG_LIBS,
+	/**
+	 * @brief C compiler flags for the LP64 model with 64-bit @c off_t (POSIX.1-2001).
+	 */
 	_CS_POSIX_V6_LP64_OFF64_CFLAGS,
+	/**
+	 * @brief Linker flags for the LP64 model with 64-bit @c off_t (POSIX.1-2001).
+	 */
 	_CS_POSIX_V6_LP64_OFF64_LDFLAGS,
+	/**
+	 * @brief Libraries for the LP64 model with 64-bit @c off_t (POSIX.1-2001).
+	 */
 	_CS_POSIX_V6_LP64_OFF64_LIBS,
+	/**
+	 * @brief C compiler flags for the LPBIG model with 64-bit or larger @c off_t
+	 * (POSIX.1-2001).
+	 */
 	_CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS,
+	/**
+	 * @brief Linker flags for the LPBIG model with 64-bit or larger @c off_t (POSIX.1-2001).
+	 */
 	_CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS,
+	/**
+	 * @brief Libraries for the LPBIG model with 64-bit or larger @c off_t (POSIX.1-2001).
+	 */
 	_CS_POSIX_V6_LPBIG_OFFBIG_LIBS,
+	/**
+	 * @brief Newline-separated list of width-restricted programming environments
+	 * (POSIX.1-2001).
+	 */
 	_CS_POSIX_V6_WIDTH_RESTRICTED_ENVS,
+	/**
+	 * @brief Environment variable settings required for a conforming POSIX.1-2001 environment.
+	 */
 	_CS_V6_ENV,
 };
 

--- a/include/zephyr/posix/sys/dirent.h
+++ b/include/zephyr/posix/sys/dirent.h
@@ -4,16 +4,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Format of directory entries.
+ * @ingroup posix
+ *
+ * Defines the DIR directory stream type and the dirent structure that describes a
+ * single directory entry.
+ *
+ * @posix_header{dirent.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_DIRENT_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_DIRENT_H_
 
 #include <limits.h>
 
 #if !defined(NAME_MAX) && defined(_XOPEN_SOURCE)
+/**
+ * @brief Maximum number of bytes in a filename (not including the terminating null).
+ */
 #define NAME_MAX _XOPEN_NAME_MAX
 #endif
 
 #if !defined(NAME_MAX) && defined(_POSIX_C_SOURCE)
+/**
+ * @brief Maximum number of bytes in a filename (not including the terminating null).
+ */
 #define NAME_MAX _POSIX_NAME_MAX
 #endif
 
@@ -21,10 +38,22 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Opaque directory stream type.
+ */
 typedef void DIR;
 
+/**
+ * @brief Directory entry returned by readdir().
+ */
 struct dirent {
+	/**
+	 * @brief File serial number.
+	 */
 	unsigned int d_ino;
+	/**
+	 * @brief Filename (null-terminated).
+	 */
 	char d_name[NAME_MAX + 1];
 };
 

--- a/include/zephyr/posix/sys/eventfd.h
+++ b/include/zephyr/posix/sys/eventfd.h
@@ -4,6 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Linux-compatible eventfd declarations.
+ * @ingroup posix_extensions
+ *
+ * An eventfd is a lightweight, kernel-managed counter that can be used for
+ * event notification between threads. It integrates with poll() and select().
+ *
+ * @compat_api{This header provides non-POSIX compatibility interfaces.}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_EVENTFD_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_EVENTFD_H_
 
@@ -13,9 +24,28 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Semaphore mode: each read decrements the counter by 1 instead of resetting it to 0.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{EFD_SEMAPHORE}
+ */
 #define EFD_SEMAPHORE ZVFS_EFD_SEMAPHORE
+
+/**
+ * @brief Non-blocking mode: reads and writes fail with @c EAGAIN instead of blocking.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{EFD_NONBLOCK}
+ */
 #define EFD_NONBLOCK  ZVFS_EFD_NONBLOCK
 
+/**
+ * @brief Counter value type for eventfd operations.
+ * @ingroup posix_extensions
+ *
+ * @compat_api{eventfd_t}
+ */
 typedef zvfs_eventfd_t eventfd_t;
 
 /**
@@ -29,21 +59,30 @@ typedef zvfs_eventfd_t eventfd_t;
  * the eventfd.
  *
  * When using read() and write() on an eventfd, the size must always be at
- * least 8 bytes or the operation will fail with EINVAL.
+ * least 8 bytes or the operation will fail with @c EINVAL.
+ *
+ * @param initval Initial value of the eventfd counter.
+ * @param flags   0, or a combination of @c EFD_SEMAPHORE and @c EFD_NONBLOCK.
  *
  * @return New eventfd file descriptor on success, -1 on error
+ * @ingroup posix_extensions
+ * @compat_api{eventfd}
  */
 int eventfd(unsigned int initval, int flags);
 
 /**
  * @brief Read from an eventfd
  *
- * If call is successful, the value parameter will have the value 1
+ * In normal mode the current counter value is stored in @p value and the
+ * counter is reset to 0. In @c EFD_SEMAPHORE mode, @p value receives 1 and
+ * the counter is decremented by 1.
  *
  * @param fd File descriptor
  * @param value Pointer for storing the read value
  *
  * @return 0 on success, -1 on error
+ * @ingroup posix_extensions
+ * @compat_api{eventfd_read}
  */
 int eventfd_read(int fd, eventfd_t *value);
 
@@ -54,6 +93,8 @@ int eventfd_read(int fd, eventfd_t *value);
  * @param value Value to write
  *
  * @return 0 on success, -1 on error
+ * @ingroup posix_extensions
+ * @compat_api{eventfd_write}
  */
 int eventfd_write(int fd, eventfd_t value);
 

--- a/include/zephyr/posix/sys/ioctl.h
+++ b/include/zephyr/posix/sys/ioctl.h
@@ -3,22 +3,57 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief POSIX ioctl declarations.
+ * @ingroup posix
+ *
+ * Provides ioctl() for performing device-specific control operations on file
+ * descriptors, along with the standard non-blocking and pending-read requests.
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_IOCTL_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_IOCTL_H_
 
 #include <zephyr/sys/fdtable.h>
 
 /** Set non-blocking mode */
+
+/**
+ * @brief Set or clear non-blocking I/O mode on a file descriptor.
+ */
 #define FIONBIO ZFD_IOCTL_FIONBIO
+
 /** Get the number of bytes available to read */
+
+/**
+ * @brief Get the number of bytes available to read without blocking.
+ */
 #define FIONREAD ZFD_IOCTL_FIONREAD
+
 /** Get the number of bytes queued for TCP TX which have not yet been acknowledged */
+
+/**
+ * @brief Get the number of queued TCP transmit bytes not yet acknowledged.
+ */
 #define FIONWRITE ZFD_IOCTL_FIONWRITE
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/**
+ * @brief Perform a device-specific control operation.
+ *
+ * @param fd      File descriptor.
+ * @param request Device-dependent request code (e.g. @c FIONBIO, @c FIONREAD).
+ * @param ...     Optional argument whose type depends on @p request.
+ *
+ * @return Request-specific non-negative value on success, or -1 with errno set on failure.
+ *
+ * @posix_func{ioctl}
+ */
 int ioctl(int fd, unsigned long request, ...);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/sys/mman.h
+++ b/include/zephyr/posix/sys/mman.h
@@ -4,45 +4,205 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Memory management declarations.
+ * @ingroup posix
+ *
+ * Provides memory mapping, shared memory objects, and memory locking.
+ *
+ * @posix_header{sys_mman.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_MMAN_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_MMAN_H_
 
 #include <stddef.h>
 #include <sys/types.h>
 
+/**
+ * @brief Page cannot be accessed.
+ */
 #define PROT_NONE  0x0
+
+/**
+ * @brief Page can be read.
+ */
 #define PROT_READ  0x1
+
+/**
+ * @brief Page can be written.
+ */
 #define PROT_WRITE 0x2
+
+/**
+ * @brief Page can be executed.
+ */
 #define PROT_EXEC  0x4
 
+/**
+ * @brief Changes are shared between all mappings of the same object.
+ */
 #define MAP_SHARED  0x1
+
+/**
+ * @brief Changes are private (copy-on-write).
+ */
 #define MAP_PRIVATE 0x2
+
+/**
+ * @brief Map at the exact address given to mmap().
+ */
 #define MAP_FIXED   0x4
 
 /* for Linux compatibility */
+
+/**
+ * @brief Anonymous mapping; the file descriptor argument is ignored.
+ */
 #define MAP_ANONYMOUS 0x20
 
+/**
+ * @brief Flush modified pages to the underlying storage synchronously.
+ */
 #define MS_SYNC       0x0
+
+/**
+ * @brief Schedule writes and return immediately.
+ */
 #define MS_ASYNC      0x1
+
+/**
+ * @brief Invalidate cached data so subsequent reads reflect the file.
+ */
 #define MS_INVALIDATE 0x2
 
+/**
+ * @brief Value returned by mmap() on failure.
+ */
 #define MAP_FAILED ((void *)-1)
 
+/**
+ * @brief Lock all currently mapped pages into memory.
+ */
 #define MCL_CURRENT 0
+
+/**
+ * @brief Lock all future mappings into memory.
+ */
 #define MCL_FUTURE  1
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/**
+ * @brief Lock a range of the calling process's address space into memory.
+ *
+ * @param addr Base address of the region to lock.
+ * @param len  Length of the region in bytes.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mlock}
+ */
 int mlock(const void *addr, size_t len);
+
+/**
+ * @brief Lock all current and/or future memory mappings of the calling process.
+ *
+ * @param flags @c MCL_CURRENT, @c MCL_FUTURE, or both.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mlockall}
+ */
 int mlockall(int flags);
+
+/**
+ * @brief Map a file or device into memory.
+ *
+ * @param addr   Suggested address (hint), or NULL.
+ * @param len    Length of the mapping in bytes.
+ * @param prot   Memory protection (@c PROT_* flags).
+ * @param flags  Mapping type and options (@c MAP_* flags).
+ * @param fildes File descriptor (-1 for anonymous mappings).
+ * @param off    Offset within the file (must be page-aligned).
+ *
+ * @return Base address of the mapping, or @c MAP_FAILED on failure.
+ *
+ * @posix_func{mmap}
+ */
 void *mmap(void *addr, size_t len, int prot, int flags, int fildes, off_t off);
+
+/**
+ * @brief Synchronize a memory mapping with the underlying storage.
+ *
+ * @param addr   Base address of the region (must be page-aligned).
+ * @param length Length of the region in bytes.
+ * @param flags  @c MS_SYNC, @c MS_ASYNC, or @c MS_INVALIDATE.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{msync}
+ */
 int msync(void *addr, size_t length, int flags);
+
+/**
+ * @brief Unlock a range of the calling process's address space.
+ *
+ * @param addr Base address of the region to unlock.
+ * @param len  Length of the region in bytes.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{munlock}
+ */
 int munlock(const void *addr, size_t len);
+
+/**
+ * @brief Unlock all memory locked by the calling process.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{munlockall}
+ */
 int munlockall(void);
+
+/**
+ * @brief Unmap a previously mapped region.
+ *
+ * @param addr Base address of the mapping.
+ * @param len  Length of the region in bytes.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{munmap}
+ */
 int munmap(void *addr, size_t len);
+
+/**
+ * @brief Open or create a shared memory object.
+ *
+ * @param name  Shared memory object name (must begin with '/').
+ * @param oflag Open flags (@c O_RDONLY, @c O_RDWR, @c O_CREAT, @c O_EXCL, @c O_TRUNC).
+ * @param mode  Permission bits applied if the object is created.
+ *
+ * @return File descriptor for the shared memory object, or -1 on failure.
+ *
+ * @posix_func{shm_open}
+ */
 int shm_open(const char *name, int oflag, mode_t mode);
+
+/**
+ * @brief Remove a shared memory object.
+ *
+ * @param name Shared memory object name.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{shm_unlink}
+ */
 int shm_unlink(const char *name);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/sys/select.h
+++ b/include/zephyr/posix/sys/select.h
@@ -3,6 +3,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Select types.
+ * @ingroup posix
+ *
+ * Provides the select() and pselect() functions and the associated
+ * fd_set type and macros for multiplexed I/O.
+ *
+ * @posix_header{sys_select.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_SELECT_H_
 
@@ -13,18 +25,91 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Maximum number of file descriptors in an fd_set structure.
+ */
 #define FD_SETSIZE ZVFS_FD_SETSIZE
 
+/**
+ * @brief Set of file descriptors for select()/pselect().
+ */
 typedef struct zvfs_fd_set fd_set;
 
 struct timeval;
 
+/**
+ * @brief Synchronous multiplexed I/O with signal mask and nanosecond timeout.
+ *
+ * @param nfds      Highest-numbered file descriptor in any set + 1.
+ * @param readfds   Set of file descriptors to watch for readability, or NULL.
+ * @param writefds  Set of file descriptors to watch for writability, or NULL.
+ * @param exceptfds Set of file descriptors to watch for exceptions, or NULL.
+ * @param timeout   Maximum wait time, or NULL to block indefinitely.
+ * @param sigmask   Signal mask to apply during the wait, or NULL.
+ *
+ * @return Number of ready file descriptors on success, 0 on timeout,
+ *         or -1 with errno set on failure.
+ *
+ * @posix_func{pselect}
+ */
 int pselect(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
 	    const struct timespec *timeout, const void *sigmask);
+
+/**
+ * @brief Synchronous multiplexed I/O (legacy interface, use pselect() for new code).
+ *
+ * @param nfds     Highest-numbered file descriptor in any set + 1.
+ * @param readfds  Set of file descriptors to watch for readability, or NULL.
+ * @param writefds Set of file descriptors to watch for writability, or NULL.
+ * @param errorfds Set of file descriptors to watch for errors, or NULL.
+ * @param timeout  Maximum wait time, or NULL to block indefinitely.
+ *
+ * @return Number of ready file descriptors on success, 0 on timeout,
+ *         or -1 with errno set on failure.
+ *
+ * @posix_func{select}
+ */
 int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *errorfds, struct timeval *timeout);
+
+/**
+ * @brief Remove a file descriptor from an fd_set.
+ *
+ * @param fd    File descriptor to clear.
+ * @param fdset File descriptor set to modify.
+ *
+ * @posix_func{FD_CLR}
+ */
 void FD_CLR(int fd, fd_set *fdset);
+
+/**
+ * @brief Test whether a file descriptor is in an fd_set.
+ *
+ * @param fd    File descriptor to test.
+ * @param fdset File descriptor set.
+ *
+ * @return Non-zero if @p fd is set, 0 otherwise.
+ *
+ * @posix_func{FD_ISSET}
+ */
 int FD_ISSET(int fd, fd_set *fdset);
+
+/**
+ * @brief Add a file descriptor to an fd_set.
+ *
+ * @param fd    File descriptor to add.
+ * @param fdset File descriptor set to modify.
+ *
+ * @posix_func{FD_SET}
+ */
 void FD_SET(int fd, fd_set *fdset);
+
+/**
+ * @brief Clear all file descriptors from an fd_set.
+ *
+ * @param fdset File descriptor set to clear.
+ *
+ * @posix_func{FD_ZERO}
+ */
 void FD_ZERO(fd_set *fdset);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/sys/socket.h
+++ b/include/zephyr/posix/sys/socket.h
@@ -3,13 +3,27 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Main sockets header.
+ * @ingroup posix
+ *
+ * Provides the BSD socket interface: creating sockets, binding, connecting,
+ * sending, receiving, and socket options.
+ *
+ * @posix_header{sys_socket.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_SOCKET_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_SOCKET_H_
 
 #include <sys/types.h>
 
 #undef ZEPHYR_INCLUDE_NET_COMPAT_MODE_SYMBOLS
+/** @cond INTERNAL_HIDDEN */
 #define ZEPHYR_INCLUDE_NET_COMPAT_MODE_SYMBOLS
+/** @endcond */
 #include <zephyr/net/socket.h>
 #undef ZEPHYR_INCLUDE_NET_COMPAT_MODE_SYMBOLS
 
@@ -17,45 +31,308 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Socket linger option structure.
+ */
 struct linger {
+	/**
+	 * @brief Indicates whether linger option is enabled.
+	 */
 	int  l_onoff;
+	/**
+	 * @brief Linger time, in seconds.
+	 */
 	int  l_linger;
 };
 
 #if !defined(CONFIG_NET_NAMESPACE_COMPAT_MODE)
+/**
+ * @brief Type for socket address length values.
+ */
 typedef uint32_t socklen_t;
 struct msghdr;
 struct sockaddr;
 
+/**
+ * @brief Peek at incoming data without removing it from the queue.
+ */
 #define MSG_PEEK     ZSOCK_MSG_PEEK
+
+/**
+ * @brief Return the real length of the datagram even if it was truncated.
+ */
 #define MSG_TRUNC    ZSOCK_MSG_TRUNC
+
+/**
+ * @brief Enable non-blocking operation for this call only.
+ */
 #define MSG_DONTWAIT ZSOCK_MSG_DONTWAIT
+
+/**
+ * @brief Block until all requested data has been received.
+ */
 #define MSG_WAITALL  ZSOCK_MSG_WAITALL
 
+/**
+ * @brief Disables further receive operations.
+ */
 #define SHUT_RD   ZSOCK_SHUT_RD
+
+/**
+ * @brief Disables further send operations.
+ */
 #define SHUT_WR   ZSOCK_SHUT_WR
+
+/**
+ * @brief Disables further send and receive operations.
+ */
 #define SHUT_RDWR ZSOCK_SHUT_RDWR
 #endif
 
+/**
+ * @brief Accept a new connection on a socket.
+ *
+ * @param sock    Listening socket file descriptor.
+ * @param addr    Output: address of the connecting peer, or NULL.
+ * @param addrlen Input: size of @p addr; output: actual address size.
+ *
+ * @return New socket file descriptor on success, or -1 with errno set on failure.
+ *
+ * @posix_func{accept}
+ */
 int accept(int sock, struct sockaddr *addr, socklen_t *addrlen);
+
+/**
+ * @brief Bind a name to a socket.
+ *
+ * @param sock    Socket file descriptor.
+ * @param addr    Local address to bind.
+ * @param addrlen Size of @p addr in bytes.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{bind}
+ */
 int bind(int sock, const struct sockaddr *addr, socklen_t addrlen);
+
+/**
+ * @brief Connect a socket.
+ *
+ * @param sock    Socket file descriptor.
+ * @param addr    Remote address to connect to.
+ * @param addrlen Size of @p addr in bytes.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{connect}
+ */
 int connect(int sock, const struct sockaddr *addr, socklen_t addrlen);
+
+/**
+ * @brief Get the name of the peer socket.
+ *
+ * @param sock    Socket file descriptor.
+ * @param addr    Output: peer address.
+ * @param addrlen Input: size of @p addr; output: actual address size.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{getpeername}
+ */
 int getpeername(int sock, struct sockaddr *addr, socklen_t *addrlen);
+
+/**
+ * @brief Get the socket name.
+ *
+ * @param sock    Socket file descriptor.
+ * @param addr    Output: local address bound to the socket.
+ * @param addrlen Input: size of @p addr; output: actual address size.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{getsockname}
+ */
 int getsockname(int sock, struct sockaddr *addr, socklen_t *addrlen);
+
+/**
+ * @brief Get the socket options.
+ *
+ * @param sock    Socket file descriptor.
+ * @param level   Protocol level (@c SOL_SOCKET, @c IPPROTO_TCP, etc.).
+ * @param optname Option name (@c SO_REUSEADDR, @c SO_KEEPALIVE, etc.).
+ * @param optval  Output: option value.
+ * @param optlen  Input: size of @p optval; output: actual size.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{getsockopt}
+ */
 int getsockopt(int sock, int level, int optname, void *optval, socklen_t *optlen);
+
+/**
+ * @brief Listen for socket connections and limit the queue of incoming connections.
+ *
+ * @param sock    Socket file descriptor.
+ * @param backlog Maximum number of pending connections to queue.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{listen}
+ */
 int listen(int sock, int backlog);
+
+/**
+ * @brief Receive a message from a connected socket.
+ *
+ * @param sock    Socket file descriptor.
+ * @param buf     Buffer to receive data into.
+ * @param max_len Maximum number of bytes to receive.
+ * @param flags   Flags (e.g. @c MSG_PEEK, @c MSG_DONTWAIT, @c MSG_WAITALL).
+ *
+ * @return Number of bytes received, 0 when the peer has closed the connection,
+ *         or -1 with errno set on failure.
+ *
+ * @posix_func{recv}
+ */
 ssize_t recv(int sock, void *buf, size_t max_len, int flags);
+
+/**
+ * @brief Receive a message from a socket.
+ *
+ * @param sock     Socket file descriptor.
+ * @param buf      Buffer to receive data into.
+ * @param max_len  Maximum number of bytes to receive.
+ * @param flags    Flags (e.g. @c MSG_PEEK, @c MSG_DONTWAIT).
+ * @param src_addr Output: sender's address, or NULL.
+ * @param addrlen  Input: size of @p src_addr; output: actual address size.
+ *
+ * @return Number of bytes received on success, or -1 with errno set on failure.
+ *
+ * @posix_func{recvfrom}
+ */
 ssize_t recvfrom(int sock, void *buf, size_t max_len, int flags, struct sockaddr *src_addr,
 		 socklen_t *addrlen);
+
+/**
+ * @brief Receive a message from a socket.
+ *
+ * @param sock  Socket file descriptor.
+ * @param msg   Message header specifying I/O vectors and address buffer.
+ * @param flags Flags (e.g. @c MSG_PEEK, @c MSG_DONTWAIT).
+ *
+ * @return Number of bytes received on success, or -1 with errno set on failure.
+ *
+ * @posix_func{recvmsg}
+ */
 ssize_t recvmsg(int sock, struct msghdr *msg, int flags);
+
+/**
+ * @brief Send a message on a socket.
+ *
+ * @param sock  Socket file descriptor.
+ * @param buf   Data to send.
+ * @param len   Number of bytes to send.
+ * @param flags Flags (e.g. @c MSG_DONTWAIT).
+ *
+ * @return Number of bytes sent on success, or -1 with errno set on failure.
+ *
+ * @posix_func{send}
+ */
 ssize_t send(int sock, const void *buf, size_t len, int flags);
+
+/**
+ * @brief Send a message on a socket using a message structure.
+ *
+ * @param sock    Socket file descriptor.
+ * @param message Message header specifying I/O vectors and destination.
+ * @param flags   Flags (e.g. @c MSG_DONTWAIT).
+ *
+ * @return Number of bytes sent on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sendmsg}
+ */
 ssize_t sendmsg(int sock, const struct msghdr *message, int flags);
+
+/**
+ * @brief Send a message on a socket.
+ *
+ * @param sock      Socket file descriptor.
+ * @param buf       Data to send.
+ * @param len       Number of bytes to send.
+ * @param flags     Flags (e.g. @c MSG_DONTWAIT).
+ * @param dest_addr Destination address.
+ * @param addrlen   Size of @p dest_addr in bytes.
+ *
+ * @return Number of bytes sent on success, or -1 with errno set on failure.
+ *
+ * @posix_func{sendto}
+ */
 ssize_t sendto(int sock, const void *buf, size_t len, int flags, const struct sockaddr *dest_addr,
 	       socklen_t addrlen);
+
+/**
+ * @brief Set the socket options.
+ *
+ * @param sock    Socket file descriptor.
+ * @param level   Protocol level (@c SOL_SOCKET, @c IPPROTO_TCP, etc.).
+ * @param optname Option name (@c SO_REUSEADDR, @c SO_KEEPALIVE, etc.).
+ * @param optval  Pointer to the new option value.
+ * @param optlen  Size of @p optval in bytes.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{setsockopt}
+ */
 int setsockopt(int sock, int level, int optname, const void *optval, socklen_t optlen);
+
+/**
+ * @brief Shut down socket send and receive operations.
+ *
+ * @param sock Socket file descriptor.
+ * @param how  @c SHUT_RD, @c SHUT_WR, or @c SHUT_RDWR.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{shutdown}
+ */
 int shutdown(int sock, int how);
+
+/**
+ * @brief Determine whether a socket is at the out-of-band mark.
+ *
+ * @param s Socket file descriptor.
+ *
+ * @return 1 if at the mark, 0 if not, or -1 with errno set on failure.
+ *
+ * @posix_func{sockatmark}
+ */
 int sockatmark(int s);
+
+/**
+ * @brief Create an endpoint for communication.
+ *
+ * @param family Protocol family (@c AF_INET, @c AF_INET6, @c AF_UNIX, etc.).
+ * @param type   Socket type (@c SOCK_STREAM, @c SOCK_DGRAM, @c SOCK_RAW, etc.).
+ * @param proto  Protocol number (@c IPPROTO_TCP, @c IPPROTO_UDP, or 0 for the default).
+ *
+ * @return New socket file descriptor on success, or -1 with errno set on failure.
+ *
+ * @posix_func{socket}
+ */
 int socket(int family, int type, int proto);
+
+/**
+ * @brief Create a pair of connected sockets.
+ *
+ * @param family Protocol family (typically @c AF_UNIX).
+ * @param type   Socket type.
+ * @param proto  Protocol number.
+ * @param sv     Output: two-element array receiving the socket descriptors.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{socketpair}
+ */
 int socketpair(int family, int type, int proto, int sv[2]);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/sys/stat.h
+++ b/include/zephyr/posix/sys/stat.h
@@ -27,6 +27,18 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+
+/**
+ * @file
+ * @brief Data returned by the stat() function.
+ * @ingroup posix
+ *
+ * Defines the stat structure describing file status, the S_I* file type and
+ * permission bits, and functions such as stat(), fstat(), mkdir(), and umask().
+ *
+ * @posix_header{sys_stat.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_STAT_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_STAT_H_
 
@@ -51,56 +63,161 @@ extern "C" {
 #ifdef __CYGWIN__
 #include <cygwin/stat.h>
 #ifdef _LIBC
+/**
+ * @brief 64-bit file status information.
+ */
 #define stat64 stat
 #endif
 #else
+/**
+ * @brief File status information.
+ */
 struct stat {
+	/**
+	 * @brief Device ID of the device containing the file.
+	 */
 	dev_t st_dev;
+	/**
+	 * @brief File serial number.
+	 */
 	ino_t st_ino;
+	/**
+	 * @brief Mode of file (see below).
+	 */
 	mode_t st_mode;
+	/**
+	 * @brief Number of hard links to the file.
+	 */
 	nlink_t st_nlink;
+	/**
+	 * @brief User ID of the file owner.
+	 */
 	uid_t st_uid;
+	/**
+	 * @brief Group ID of the file's group.
+	 */
 	gid_t st_gid;
 #if defined(__linux) && defined(__x86_64__)
+	/**
+	 * @brief Padding for alignment.
+	 */
 	int __pad0;
 #endif
+	/**
+	 * @brief Device ID (for character or block special files).
+	 */
 	dev_t st_rdev;
 #if defined(__linux) && !defined(__x86_64__)
+	/**
+	 * @brief Padding for alignment.
+	 */
 	unsigned short int __pad2;
 #endif
+	/**
+	 * @brief For regular files, the file size in bytes.
+	 */
 	off_t st_size;
 #if defined(__linux)
+	/**
+	 * @brief A file system-specific preferred I/O block size.
+	 */
 	blksize_t st_blksize;
+	/**
+	 * @brief Number of blocks allocated for this object.
+	 */
 	blkcnt_t st_blocks;
+	/**
+	 * @brief Last data access timestamp.
+	 */
 	struct timespec st_atim;
+	/**
+	 * @brief Last data modification timestamp.
+	 */
 	struct timespec st_mtim;
+	/**
+	 * @brief Last file status change timestamp.
+	 */
 	struct timespec st_ctim;
+	/**
+	 * @brief Last data access timestamp in seconds.
+	 */
 #define st_atime st_atim.tv_sec /* Backward compatibility */
+	/**
+	 * @brief Last data modification timestamp in seconds.
+	 */
 #define st_mtime st_mtim.tv_sec
+	/**
+	 * @brief Last file status change timestamp in seconds.
+	 */
 #define st_ctime st_ctim.tv_sec
 #if defined(__linux) && defined(__x86_64__)
+	/**
+	 * @brief Reserved for future use.
+	 */
 	uint64_t __glibc_reserved[3];
 #endif
 #else
 #if defined(__rtems__)
+	/**
+	 * @brief Last data access timestamp.
+	 */
 	struct timespec st_atim;
+	/**
+	 * @brief Last data modification timestamp.
+	 */
 	struct timespec st_mtim;
+	/**
+	 * @brief Last file status change timestamp.
+	 */
 	struct timespec st_ctim;
+	/**
+	 * @brief A file system-specific preferred I/O block size.
+	 */
 	blksize_t st_blksize;
+	/**
+	 * @brief Number of blocks allocated for this object.
+	 */
 	blkcnt_t st_blocks;
 #else
 	/* SysV/sco doesn't have the rest... But Solaris, eabi does.  */
 #if defined(__svr4__) && !defined(__PPC__) && !defined(__sun__)
+	/**
+	 * @brief Last data access timestamp.
+	 */
 	time_t st_atime;
+	/**
+	 * @brief Last data modification timestamp.
+	 */
 	time_t st_mtime;
+	/**
+	 * @brief Last file status change timestamp.
+	 */
 	time_t st_ctime;
 #else
+	/**
+	 * @brief Last data access timestamp.
+	 */
 	struct timespec st_atim;
+	/**
+	 * @brief Last data modification timestamp.
+	 */
 	struct timespec st_mtim;
+	/**
+	 * @brief Last file status change timestamp.
+	 */
 	struct timespec st_ctim;
+	/**
+	 * @brief A file system-specific preferred I/O block size.
+	 */
 	blksize_t st_blksize;
+	/**
+	 * @brief Number of blocks allocated for this object.
+	 */
 	blkcnt_t st_blocks;
 #if !defined(__rtems__)
+	/**
+	 * @brief Reserved spare fields.
+	 */
 	long st_spare4[2];
 #endif
 #endif
@@ -109,41 +226,143 @@ struct stat {
 };
 
 #if !(defined(__svr4__) && !defined(__PPC__) && !defined(__sun__))
+/**
+ * @brief Last data access timestamp in seconds.
+ */
 #define st_atime st_atim.tv_sec
+
+/**
+ * @brief Last file status change timestamp in seconds.
+ */
 #define st_ctime st_ctim.tv_sec
+
+/**
+ * @brief Last data modification timestamp in seconds.
+ */
 #define st_mtime st_mtim.tv_sec
 #endif
 
 #endif
 
+/**
+ * @brief File type bit mask.
+ */
 #define _IFMT	0170000 /* type of file */
+
+/**
+ * @brief Directory file type bit.
+ */
 #define _IFDIR	0040000 /* directory */
+
+/**
+ * @brief Character special file type bit.
+ */
 #define _IFCHR	0020000 /* character special */
+
+/**
+ * @brief Block special file type bit.
+ */
 #define _IFBLK	0060000 /* block special */
+
+/**
+ * @brief Regular file type bit.
+ */
 #define _IFREG	0100000 /* regular */
+
+/**
+ * @brief Symbolic link file type bit.
+ */
 #define _IFLNK	0120000 /* symbolic link */
+
+/**
+ * @brief Socket file type bit.
+ */
 #define _IFSOCK 0140000 /* socket */
+
+/**
+ * @brief FIFO file type bit.
+ */
 #define _IFIFO	0010000 /* fifo */
 
+/**
+ * @brief Size of a block in bytes.
+ */
 #define S_BLKSIZE 1024 /* size of a block */
 
+/**
+ * @brief Set-user-ID on execution bit.
+ */
 #define S_ISUID 0004000 /* set user id on execution */
+
+/**
+ * @brief Set-group-ID on execution bit.
+ */
 #define S_ISGID 0002000 /* set group id on execution */
+
+/**
+ * @brief Sticky bit (restricted deletion).
+ */
 #define S_ISVTX 0001000 /* save swapped text even after use */
 #if __BSD_VISIBLE
+/**
+ * @brief Read permission for owner (BSD name for @c S_IRUSR).
+ */
 #define S_IREAD	 0000400 /* read permission, owner */
+
+/**
+ * @brief Write permission for owner (BSD name for @c S_IWUSR).
+ */
 #define S_IWRITE 0000200 /* write permission, owner */
+
+/**
+ * @brief Execute/search permission for owner (BSD name for @c S_IXUSR).
+ */
 #define S_IEXEC	 0000100 /* execute/search permission, owner */
+
+/**
+ * @brief Enforcement-mode record locking.
+ */
 #define S_ENFMT	 0002000 /* enforcement-mode locking */
 #endif			 /* !_BSD_VISIBLE */
 
+/**
+ * @brief Bit mask for the file type bits in st_mode.
+ */
 #define S_IFMT	 _IFMT
+
+/**
+ * @brief Directory.
+ */
 #define S_IFDIR	 _IFDIR
+
+/**
+ * @brief Character special file.
+ */
 #define S_IFCHR	 _IFCHR
+
+/**
+ * @brief Block special file.
+ */
 #define S_IFBLK	 _IFBLK
+
+/**
+ * @brief Regular file.
+ */
 #define S_IFREG	 _IFREG
+
+/**
+ * @brief Symbolic link.
+ */
 #define S_IFLNK	 _IFLNK
+
+/**
+ * @brief Socket.
+ */
 #define S_IFSOCK _IFSOCK
+
+/**
+ * @brief FIFO special file.
+ */
 #define S_IFIFO	 _IFIFO
 
 #ifdef _WIN32
@@ -151,71 +370,385 @@ struct stat {
  * The Windows header files define _S_ forms of these, so we do too
  * for easier portability.
  */
+
+/**
+ * @brief File type bit mask.
+ */
 #define _S_IFMT	  _IFMT
+
+/**
+ * @brief Directory file type bit.
+ */
 #define _S_IFDIR  _IFDIR
+
+/**
+ * @brief Character special file type bit.
+ */
 #define _S_IFCHR  _IFCHR
+
+/**
+ * @brief FIFO file type bit.
+ */
 #define _S_IFIFO  _IFIFO
+
+/**
+ * @brief Regular file type bit.
+ */
 #define _S_IFREG  _IFREG
+
+/**
+ * @brief Owner read permission bit.
+ */
 #define _S_IREAD  0000400
+
+/**
+ * @brief Owner write permission bit.
+ */
 #define _S_IWRITE 0000200
+
+/**
+ * @brief Owner execute permission bit.
+ */
 #define _S_IEXEC  0000100
 #endif
 
+/**
+ * @brief Read, write, execute/search permission for owner.
+ */
 #define S_IRWXU (S_IRUSR | S_IWUSR | S_IXUSR)
+
+/**
+ * @brief Read permission for owner.
+ */
 #define S_IRUSR 0000400 /* read permission, owner */
+
+/**
+ * @brief Write permission for owner.
+ */
 #define S_IWUSR 0000200 /* write permission, owner */
+
+/**
+ * @brief Execute/search permission for owner.
+ */
 #define S_IXUSR 0000100 /* execute/search permission, owner */
+
+/**
+ * @brief Read, write, execute/search permission for group.
+ */
 #define S_IRWXG (S_IRGRP | S_IWGRP | S_IXGRP)
+
+/**
+ * @brief Read permission for group.
+ */
 #define S_IRGRP 0000040 /* read permission, group */
+
+/**
+ * @brief Write permission for group.
+ */
 #define S_IWGRP 0000020 /* write permission, grougroup */
+
+/**
+ * @brief Execute/search permission for group.
+ */
 #define S_IXGRP 0000010 /* execute/search permission, group */
+
+/**
+ * @brief Read, write, execute/search permission for others.
+ */
 #define S_IRWXO (S_IROTH | S_IWOTH | S_IXOTH)
+
+/**
+ * @brief Read permission for others.
+ */
 #define S_IROTH 0000004 /* read permission, other */
+
+/**
+ * @brief Write permission for others.
+ */
 #define S_IWOTH 0000002 /* write permission, other */
+
+/**
+ * @brief Execute/search permission for others.
+ */
 #define S_IXOTH 0000001 /* execute/search permission, other */
 
 #if __BSD_VISIBLE
+/**
+ * @brief Access permission bits.
+ */
 #define ACCESSPERMS (S_IRWXU | S_IRWXG | S_IRWXO)				/* 0777 */
+
+/**
+ * @brief All file permission and mode bits.
+ */
 #define ALLPERMS    (S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO) /* 07777 */
+
+/**
+ * @brief Default file creation mode.
+ */
 #define DEFFILEMODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH) /* 0666 */
 #endif
 
+/**
+ * @brief Test whether @p m is a block special file.
+ */
 #define S_ISBLK(m)  (((m)&_IFMT) == _IFBLK)
+
+/**
+ * @brief Test whether @p m is a character special file.
+ */
 #define S_ISCHR(m)  (((m)&_IFMT) == _IFCHR)
+
+/**
+ * @brief Test whether @p m is a directory.
+ */
 #define S_ISDIR(m)  (((m)&_IFMT) == _IFDIR)
+
+/**
+ * @brief Test whether @p m is a FIFO.
+ */
 #define S_ISFIFO(m) (((m)&_IFMT) == _IFIFO)
+
+/**
+ * @brief Test whether @p m is a regular file.
+ */
 #define S_ISREG(m)  (((m)&_IFMT) == _IFREG)
+
+/**
+ * @brief Test whether @p m is a symbolic link.
+ */
 #define S_ISLNK(m)  (((m)&_IFMT) == _IFLNK)
+
+/**
+ * @brief Test whether @p m is a socket.
+ */
 #define S_ISSOCK(m) (((m)&_IFMT) == _IFSOCK)
 
 #if defined(__CYGWIN__) || defined(__rtems__)
+/**
+ * @brief Set file access and modification times.
+ *
+ * @posix_func{futimens}
+ */
 /* Special tv_nsec values for futimens(2) and utimensat(2). */
+
+/**
+ * @brief Set timestamp to the current time.
+ */
 #define UTIME_NOW  -2L
+
+/**
+ * @brief Leave timestamp unchanged.
+ */
 #define UTIME_OMIT -1L
 #endif
 
+/**
+ * @brief Change the mode of a file.
+ *
+ * @param __path Pathname of the file.
+ * @param __mode New file mode (S_I* file permission bits).
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{chmod}
+ */
 int chmod(const char *__path, mode_t __mode);
+
+/**
+ * @brief Change the mode of an open file.
+ *
+ * @param __fd   File descriptor of an open file.
+ * @param __mode New file mode (S_I* file permission bits).
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{fchmod}
+ */
 int fchmod(int __fd, mode_t __mode);
+
+/**
+ * @brief Get status of an open file.
+ *
+ * @param __fd   File descriptor of an open file.
+ * @param __sbuf Output: file status information.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{fstat}
+ */
 int fstat(int __fd, struct stat *__sbuf);
+
+/**
+ * @brief Create a directory.
+ *
+ * @param _path  Pathname of the directory to create.
+ * @param __mode Permission bits for the new directory (S_I* file permission bits).
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mkdir}
+ */
 int mkdir(const char *_path, mode_t __mode);
+
+/**
+ * @brief Create a FIFO special file.
+ *
+ * @param __path Pathname of the FIFO to create.
+ * @param __mode Permission bits for the new FIFO (S_I* file permission bits).
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mkfifo}
+ */
 int mkfifo(const char *__path, mode_t __mode);
+
+/**
+ * @brief Get status of a file by path (follows symbolic links).
+ *
+ * @param __path Pathname of the file.
+ * @param __sbuf Output: file status information.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{stat}
+ */
 int stat(const char *__restrict __path, struct stat *__restrict __sbuf);
+
+/**
+ * @brief Set the file mode creation mask.
+ *
+ * @param __mask New file mode creation mask (S_I* file permission bits).
+ *
+ * @return The previous value of the file mode creation mask.
+ *
+ * @posix_func{umask}
+ */
 mode_t umask(mode_t __mask);
 
 #if defined(__SPU__) || defined(__rtems__) || defined(__CYGWIN__) && !defined(__INSIDE_CYGWIN__)
+/**
+ * @brief Get status of a file (does not follow symbolic links).
+ *
+ * @param __path Pathname of the file.
+ * @param __buf  Output: file status information.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{lstat}
+ */
 int lstat(const char *__restrict __path, struct stat *__restrict __buf);
+
+/**
+ * @brief Create a special or regular file.
+ *
+ * @param __path Pathname of the file to create.
+ * @param __mode File type and permission bits for the new file.
+ * @param __dev  Device ID (for block or character special files).
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mknod}
+ */
 int mknod(const char *__path, mode_t __mode, dev_t __dev);
 #endif
 
 #if __ATFILE_VISIBLE && !defined(__INSIDE_CYGWIN__)
+/**
+ * @brief Change the mode of a file relative to a directory descriptor.
+ *
+ * @param __fd   Directory file descriptor that relative @p __path is resolved against.
+ * @param __path Pathname of the file.
+ * @param __mode New file mode (S_I* file permission bits).
+ * @param __flag Flags controlling pathname resolution, such as @c AT_SYMLINK_NOFOLLOW.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{fchmodat}
+ */
 int fchmodat(int __fd, const char *__path, mode_t __mode, int __flag);
+
+/**
+ * @brief Get status of a file relative to a directory descriptor.
+ *
+ * @param __fd   Directory file descriptor that relative @p __path is resolved against.
+ * @param __path Pathname of the file.
+ * @param __buf  Output: file status information.
+ * @param __flag Flags controlling pathname resolution, such as @c AT_SYMLINK_NOFOLLOW.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{fstatat}
+ */
 int fstatat(int __fd, const char *__restrict __path, struct stat *__restrict __buf, int __flag);
+
+/**
+ * @brief Create a directory relative to a directory descriptor.
+ *
+ * @param __fd   Directory file descriptor that relative @p __path is resolved against.
+ * @param __path Pathname of the directory to create.
+ * @param __mode Permission bits for the new directory (S_I* file permission bits).
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mkdirat}
+ */
 int mkdirat(int __fd, const char *__path, mode_t __mode);
+
+/**
+ * @brief Create a FIFO special file relative to a directory descriptor.
+ *
+ * @param __fd   Directory file descriptor that relative @p __path is resolved against.
+ * @param __path Pathname of the FIFO to create.
+ * @param __mode Permission bits for the new FIFO (S_I* file permission bits).
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mkfifoat}
+ */
 int mkfifoat(int __fd, const char *__path, mode_t __mode);
+
+/**
+ * @brief Create a special or regular file relative to a directory descriptor.
+ *
+ * @param __fd   Directory file descriptor that relative @p __path is resolved against.
+ * @param __path Pathname of the file to create.
+ * @param __mode File type and permission bits for the new file.
+ * @param __dev  Device ID (for block or character special files).
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mknodat}
+ */
 int mknodat(int __fd, const char *__path, mode_t __mode, dev_t __dev);
+
+/**
+ * @brief Set file access and modification times relative to a directory descriptor.
+ *
+ * @param __fd    Directory file descriptor that relative @p __path is resolved against.
+ * @param __path  Pathname of the file.
+ * @param __times Access and modification timestamps, or NULL to set both to the
+ *                current time; @c tv_nsec may be @c UTIME_NOW or @c UTIME_OMIT.
+ * @param __flag  Flags controlling pathname resolution, such as @c AT_SYMLINK_NOFOLLOW.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{utimensat}
+ */
 int utimensat(int __fd, const char *__path, const struct timespec __times[2], int __flag);
 #endif
 #if __POSIX_VISIBLE >= 200809 && !defined(__INSIDE_CYGWIN__)
+/**
+ * @brief Set file access and modification times of an open file.
+ *
+ * @param __fd    File descriptor of an open file.
+ * @param __times Access and modification timestamps, or NULL to set both to the
+ *                current time; @c tv_nsec may be @c UTIME_NOW or @c UTIME_OMIT.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{futimens}
+ */
 int futimens(int __fd, const struct timespec __times[2]);
 #endif
 
@@ -224,13 +757,23 @@ int futimens(int __fd, const struct timespec __times[2]);
  * provided in newlib for some compilers.
  */
 #ifdef _LIBC
+/** @cond INTERNAL_HIDDEN */
 int _fstat(int __fd, struct stat *__sbuf);
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 int _stat(const char *__restrict __path, struct stat *__restrict __sbuf);
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 int _mkdir(const char *_path, mode_t __mode);
+/** @endcond */
 #ifdef __LARGE64_FILES
 struct stat64;
+/** @cond INTERNAL_HIDDEN */
 int _stat64(const char *__restrict __path, struct stat64 *__restrict __sbuf);
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 int _fstat64(int __fd, struct stat64 *__sbuf);
+/** @endcond */
 #endif
 #endif
 

--- a/include/zephyr/posix/sys/sysconf.h
+++ b/include/zephyr/posix/sys/sysconf.h
@@ -4,6 +4,17 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief POSIX runtime configuration name declarations.
+ * @ingroup posix
+ *
+ * Provides the @c _SC_* name constants accepted by sysconf() and, when
+ * @c CONFIG_POSIX_SYSCONF_IMPL_MACRO is enabled, the macro implementation of
+ * sysconf() that resolves each variable at compile time.
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_SYSCONF_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_SYSCONF_H_
 
@@ -15,131 +26,509 @@
 extern "C" {
 #endif
 
+/**
+ * @brief sysconf() name constants.
+ */
 enum {
+	/**
+	 * @brief Advisory information option.
+	 */
 	_SC_ADVISORY_INFO,
+	/**
+	 * @brief Asynchronous I/O option.
+	 */
 	_SC_ASYNCHRONOUS_IO,
+	/**
+	 * @brief Barriers option.
+	 */
 	_SC_BARRIERS,
+	/**
+	 * @brief Clock Selection option.
+	 */
 	_SC_CLOCK_SELECTION,
+	/**
+	 * @brief Process CPU-Time Clocks option.
+	 */
 	_SC_CPUTIME,
+	/**
+	 * @brief File Synchronization option.
+	 */
 	_SC_FSYNC,
+	/**
+	 * @brief IPv6 option.
+	 */
 	_SC_IPV6,
+	/**
+	 * @brief Job control.
+	 */
 	_SC_JOB_CONTROL,
+	/**
+	 * @brief Mapped Files option.
+	 */
 	_SC_MAPPED_FILES,
+	/**
+	 * @brief Process Memory Locking option.
+	 */
 	_SC_MEMLOCK,
+	/**
+	 * @brief Range Memory Locking option.
+	 */
 	_SC_MEMLOCK_RANGE,
+	/**
+	 * @brief Memory Protection option.
+	 */
 	_SC_MEMORY_PROTECTION,
+	/**
+	 * @brief Message Passing option.
+	 */
 	_SC_MESSAGE_PASSING,
+	/**
+	 * @brief Monotonic Clock option.
+	 */
 	_SC_MONOTONIC_CLOCK,
+	/**
+	 * @brief Prioritized Input and Output option.
+	 */
 	_SC_PRIORITIZED_IO,
+	/**
+	 * @brief Process Scheduling option.
+	 */
 	_SC_PRIORITY_SCHEDULING,
+	/**
+	 * @brief Raw Sockets option.
+	 */
 	_SC_RAW_SOCKETS,
+	/**
+	 * @brief Maximum number of repeated occurrences in BRE.
+	 */
 	_SC_RE_DUP_MAX,
+	/**
+	 * @brief Read-Write Locks option.
+	 */
 	_SC_READER_WRITER_LOCKS,
+	/**
+	 * @brief Realtime Signals extension.
+	 */
 	_SC_REALTIME_SIGNALS,
+	/**
+	 * @brief Regular Expressions option.
+	 */
 	_SC_REGEXP,
+	/**
+	 * @brief Saved IDs option.
+	 */
 	_SC_SAVED_IDS,
+	/**
+	 * @brief Semaphores option.
+	 */
 	_SC_SEMAPHORES,
+	/**
+	 * @brief Shared Memory Objects option.
+	 */
 	_SC_SHARED_MEMORY_OBJECTS,
+	/**
+	 * @brief Shell option.
+	 */
 	_SC_SHELL,
+	/**
+	 * @brief Spawn option.
+	 */
 	_SC_SPAWN,
+	/**
+	 * @brief Spin Locks option.
+	 */
 	_SC_SPIN_LOCKS,
+	/**
+	 * @brief Process Sporadic Server option.
+	 */
 	_SC_SPORADIC_SERVER,
+	/**
+	 * @brief Maximum number of replenishments for SS.
+	 */
 	_SC_SS_REPL_MAX,
+	/**
+	 * @brief Synchronized Input and Output option.
+	 */
 	_SC_SYNCHRONIZED_IO,
+	/**
+	 * @brief Thread Stack Address Attribute option.
+	 */
 	_SC_THREAD_ATTR_STACKADDR,
+	/**
+	 * @brief Thread Stack Size Attribute option.
+	 */
 	_SC_THREAD_ATTR_STACKSIZE,
+	/**
+	 * @brief Thread CPU-Time Clocks option.
+	 */
 	_SC_THREAD_CPUTIME,
+	/**
+	 * @brief Thread Priority Inheritance option.
+	 */
 	_SC_THREAD_PRIO_INHERIT,
+	/**
+	 * @brief Thread Priority Protection option.
+	 */
 	_SC_THREAD_PRIO_PROTECT,
+	/**
+	 * @brief Thread Execution Scheduling option.
+	 */
 	_SC_THREAD_PRIORITY_SCHEDULING,
+	/**
+	 * @brief Thread Process-Shared Synchronization option.
+	 */
 	_SC_THREAD_PROCESS_SHARED,
+	/**
+	 * @brief Robust Mutex Priority Inheritance option.
+	 */
 	_SC_THREAD_ROBUST_PRIO_INHERIT,
+	/**
+	 * @brief Robust Mutex Priority Protection option.
+	 */
 	_SC_THREAD_ROBUST_PRIO_PROTECT,
+	/**
+	 * @brief Thread-Safe Functions option.
+	 */
 	_SC_THREAD_SAFE_FUNCTIONS,
+	/**
+	 * @brief Thread Sporadic Server option.
+	 */
 	_SC_THREAD_SPORADIC_SERVER,
+	/**
+	 * @brief Threads option.
+	 */
 	_SC_THREADS,
+	/**
+	 * @brief Timeouts option.
+	 */
 	_SC_TIMEOUTS,
+	/**
+	 * @brief Timers option.
+	 */
 	_SC_TIMERS,
+	/**
+	 * @brief Trace option.
+	 */
 	_SC_TRACE,
+	/**
+	 * @brief Trace Event Filter option.
+	 */
 	_SC_TRACE_EVENT_FILTER,
+	/**
+	 * @brief Maximum length of trace event names.
+	 */
 	_SC_TRACE_EVENT_NAME_MAX,
+	/**
+	 * @brief Trace Inherit option.
+	 */
 	_SC_TRACE_INHERIT,
+	/**
+	 * @brief Trace Log option.
+	 */
 	_SC_TRACE_LOG,
+	/**
+	 * @brief Maximum length of trace names.
+	 */
 	_SC_TRACE_NAME_MAX,
+	/**
+	 * @brief Maximum number of system trace streams.
+	 */
 	_SC_TRACE_SYS_MAX,
+	/**
+	 * @brief Maximum number of user trace event type identifiers.
+	 */
 	_SC_TRACE_USER_EVENT_MAX,
+	/**
+	 * @brief Typed Memory Objects option.
+	 */
 	_SC_TYPED_MEMORY_OBJECTS,
+	/**
+	 * @brief POSIX.1 standard version (@c _POSIX_VERSION).
+	 */
 	_SC_VERSION,
+	/**
+	 * @brief ILP32 data model, 32-bit offsets (POSIX.1-2008).
+	 */
 	_SC_V7_ILP32_OFF32,
+	/**
+	 * @brief ILP32 data model, large file offsets (POSIX.1-2008).
+	 */
 	_SC_V7_ILP32_OFFBIG,
+	/**
+	 * @brief LP64 data model, 64-bit offsets (POSIX.1-2008).
+	 */
 	_SC_V7_LP64_OFF64,
+	/**
+	 * @brief LPBIG data model, large offsets (POSIX.1-2008).
+	 */
 	_SC_V7_LPBIG_OFFBIG,
+	/**
+	 * @brief ILP32 data model, 32-bit offsets (POSIX.1-2001).
+	 */
 	_SC_V6_ILP32_OFF32,
+	/**
+	 * @brief ILP32 data model, large file offsets (POSIX.1-2001).
+	 */
 	_SC_V6_ILP32_OFFBIG,
+	/**
+	 * @brief LP64 data model, 64-bit offsets (POSIX.1-2001).
+	 */
 	_SC_V6_LP64_OFF64,
+	/**
+	 * @brief LPBIG data model, large offsets (POSIX.1-2001).
+	 */
 	_SC_V6_LPBIG_OFFBIG,
+	/**
+	 * @brief Maximum value of obase in bc.
+	 */
 	_SC_BC_BASE_MAX,
+	/**
+	 * @brief Maximum number of elements in bc arrays.
+	 */
 	_SC_BC_DIM_MAX,
+	/**
+	 * @brief Maximum value of scale in bc.
+	 */
 	_SC_BC_SCALE_MAX,
+	/**
+	 * @brief Maximum length of string in bc.
+	 */
 	_SC_BC_STRING_MAX,
+	/**
+	 * @brief C-Language Binding option.
+	 */
 	_SC_2_C_BIND,
+	/**
+	 * @brief C-Language Development Utilities option.
+	 */
 	_SC_2_C_DEV,
+	/**
+	 * @brief Terminal Characteristics option.
+	 */
 	_SC_2_CHAR_TERM,
+	/**
+	 * @brief Maximum weights in locale collating.
+	 */
 	_SC_COLL_WEIGHTS_MAX,
+	/**
+	 * @brief Maximum number of timer overruns.
+	 */
 	_SC_DELAYTIMER_MAX,
+	/**
+	 * @brief Maximum number of expr()s in expr.
+	 */
 	_SC_EXPR_NEST_MAX,
+	/**
+	 * @brief FORTRAN Development Utilities option.
+	 */
 	_SC_2_FORT_DEV,
+	/**
+	 * @brief FORTRAN Runtime Utilities option.
+	 */
 	_SC_2_FORT_RUN,
+	/**
+	 * @brief Maximum length of input line in utilities.
+	 */
 	_SC_LINE_MAX,
+	/**
+	 * @brief Locale Creation option.
+	 */
 	_SC_2_LOCALEDEF,
+	/**
+	 * @brief Batch Environment Services and Utilities option.
+	 */
 	_SC_2_PBS,
+	/**
+	 * @brief Batch Accounting option.
+	 */
 	_SC_2_PBS_ACCOUNTING,
+	/**
+	 * @brief Batch Checkpoint/Restart option.
+	 */
 	_SC_2_PBS_CHECKPOINT,
+	/**
+	 * @brief Locate Batch Job Request option.
+	 */
 	_SC_2_PBS_LOCATE,
+	/**
+	 * @brief Batch Job Message Request option.
+	 */
 	_SC_2_PBS_MESSAGE,
+	/**
+	 * @brief Track Batch Job Request option.
+	 */
 	_SC_2_PBS_TRACK,
+	/**
+	 * @brief Software Development Utilities option.
+	 */
 	_SC_2_SW_DEV,
+	/**
+	 * @brief User Portability Utilities option.
+	 */
 	_SC_2_UPE,
+	/**
+	 * @brief POSIX.2 standard version.
+	 */
 	_SC_2_VERSION,
+	/**
+	 * @brief Encryption option.
+	 */
 	_SC_XOPEN_CRYPT,
+	/**
+	 * @brief Enhanced Internationalization option.
+	 */
 	_SC_XOPEN_ENH_I18N,
+	/**
+	 * @brief X/Open Realtime option.
+	 */
 	_SC_XOPEN_REALTIME,
+	/**
+	 * @brief X/Open Realtime Threads option.
+	 */
 	_SC_XOPEN_REALTIME_THREADS,
+	/**
+	 * @brief Shared Memory option.
+	 */
 	_SC_XOPEN_SHM,
+	/**
+	 * @brief XSI STREAMS option.
+	 */
 	_SC_XOPEN_STREAMS,
+	/**
+	 * @brief XSI option.
+	 */
 	_SC_XOPEN_UNIX,
+	/**
+	 * @brief UUCP option.
+	 */
 	_SC_XOPEN_UUCP,
+	/**
+	 * @brief X/Open version.
+	 */
 	_SC_XOPEN_VERSION,
+	/**
+	 * @brief Number of clock ticks per second.
+	 */
 	_SC_CLK_TCK,
+	/**
+	 * @brief Suggested buffer size for getgrgid_r().
+	 */
 	_SC_GETGR_R_SIZE_MAX,
+	/**
+	 * @brief Suggested buffer size for getpwuid_r().
+	 */
 	_SC_GETPW_R_SIZE_MAX,
+	/**
+	 * @brief Maximum operations in a single lio_listio() call.
+	 */
 	_SC_AIO_LISTIO_MAX,
+	/**
+	 * @brief Maximum outstanding asynchronous I/O operations.
+	 */
 	_SC_AIO_MAX,
+	/**
+	 * @brief Maximum amount the AIO priority can be decreased.
+	 */
 	_SC_AIO_PRIO_DELTA_MAX,
+	/**
+	 * @brief Maximum length of argument to exec functions.
+	 */
 	_SC_ARG_MAX,
+	/**
+	 * @brief Maximum number of atexit() functions.
+	 */
 	_SC_ATEXIT_MAX,
+	/**
+	 * @brief Maximum number of simultaneous processes per user.
+	 */
 	_SC_CHILD_MAX,
+	/**
+	 * @brief Maximum length of a host name.
+	 */
 	_SC_HOST_NAME_MAX,
+	/**
+	 * @brief Maximum number of iovec structures for readv()/writev().
+	 */
 	_SC_IOV_MAX,
+	/**
+	 * @brief Maximum length of login name.
+	 */
 	_SC_LOGIN_NAME_MAX,
+	/**
+	 * @brief Maximum number of supplemental groups.
+	 */
 	_SC_NGROUPS_MAX,
+	/**
+	 * @brief Maximum number of open message queues.
+	 */
 	_SC_MQ_OPEN_MAX,
+	/**
+	 * @brief Maximum message priority.
+	 */
 	_SC_MQ_PRIO_MAX,
+	/**
+	 * @brief Maximum number of open file descriptors.
+	 */
 	_SC_OPEN_MAX,
+	/**
+	 * @brief System memory page size.
+	 */
 	_SC_PAGE_SIZE,
+	/**
+	 * @brief Alias for @c _SC_PAGE_SIZE.
+	 */
 	_SC_PAGESIZE,
+	/**
+	 * @brief Maximum TSD destructor iterations.
+	 */
 	_SC_THREAD_DESTRUCTOR_ITERATIONS,
+	/**
+	 * @brief Maximum number of thread-specific data keys.
+	 */
 	_SC_THREAD_KEYS_MAX,
+	/**
+	 * @brief Minimum thread stack size.
+	 */
 	_SC_THREAD_STACK_MIN,
+	/**
+	 * @brief Maximum number of threads per process.
+	 */
 	_SC_THREAD_THREADS_MAX,
+	/**
+	 * @brief Maximum number of real-time signals.
+	 */
 	_SC_RTSIG_MAX,
+	/**
+	 * @brief Maximum number of semaphores per process.
+	 */
 	_SC_SEM_NSEMS_MAX,
+	/**
+	 * @brief Maximum value of a semaphore.
+	 */
 	_SC_SEM_VALUE_MAX,
+	/**
+	 * @brief Maximum number of queued signals.
+	 */
 	_SC_SIGQUEUE_MAX,
+	/**
+	 * @brief Maximum number of open stdio streams.
+	 */
 	_SC_STREAM_MAX,
+	/**
+	 * @brief Maximum number of symbolic links to follow.
+	 */
 	_SC_SYMLOOP_MAX,
+	/**
+	 * @brief Maximum number of timer objects per process.
+	 */
 	_SC_TIMER_MAX,
+	/**
+	 * @brief Maximum length of terminal device name.
+	 */
 	_SC_TTY_NAME_MAX,
+	/**
+	 * @brief Maximum length of timezone name.
+	 */
 	_SC_TZNAME_MAX,
 };
 
@@ -149,171 +538,427 @@ enum {
  */
 
 /* clang-format off */
-
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_ADVISORY_INFO (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_ASYNCHRONOUS_IO                                                       \
 	COND_CODE_1(CONFIG_POSIX_ASYNCHRONOUS_IO, (_POSIX_ASYNCHRONOUS_IO), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_BARRIERS COND_CODE_1(CONFIG_POSIX_BARRIERS, (_POSIX_BARRIERS), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_CLOCK_SELECTION                                                       \
 	COND_CODE_1(CONFIG_POSIX_CLOCK_SELECTION, (_POSIX_CLOCK_SELECTION), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_CPUTIME \
 	COND_CODE_1(CONFIG_POSIX_CPUTIME, (_POSIX_CPUTIME), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_FSYNC                                                                 \
 	COND_CODE_1(CONFIG_POSIX_FSYNC, (_POSIX_FSYNC), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_IPV6              COND_CODE_1(CONFIG_NET_IPV6, (_POSIX_IPV6), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_JOB_CONTROL       (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_MAPPED_FILES                                                          \
 	COND_CODE_1(CONFIG_POSIX_MAPPED_FILES, (_POSIX_MAPPED_FILES), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_MEMLOCK                                                               \
 	COND_CODE_1(CONFIG_POSIX_MEMLOCK, (_POSIX_MEMLOCK), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_MEMLOCK_RANGE                                                         \
 	COND_CODE_1(CONFIG_POSIX_MEMLOCK_RANGE, (_POSIX_MEMLOCK_RANGE), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_MEMORY_PROTECTION                                                     \
 	COND_CODE_1(CONFIG_POSIX_MEMORY_PROTECTION, (_POSIX_MEMORY_PROTECTION), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_MESSAGE_PASSING                                                       \
 	COND_CODE_1(CONFIG_POSIX_MESSAGE_PASSING, (_POSIX_MESSAGE_PASSING), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_MONOTONIC_CLOCK                                                       \
 	COND_CODE_1(CONFIG_POSIX_MONOTONIC_CLOCK, (_POSIX_MONOTONIC_CLOCK), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_PRIORITIZED_IO (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_PRIORITY_SCHEDULING                                                   \
 	COND_CODE_1(CONFIG_POSIX_PRIORITY_SCHEDULING, (_POSIX_PRIORITY_SCHEDULING), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_RAW_SOCKETS                                                           \
 	COND_CODE_1(CONFIG_NET_SOCKETS_PACKET, (_POSIX_RAW_SOCKETS), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_RE_DUP_MAX _POSIX_RE_DUP_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_READER_WRITER_LOCKS                                                   \
 	COND_CODE_1(CONFIG_POSIX_RW_LOCKS, (_POSIX_READER_WRITER_LOCKS), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_REALTIME_SIGNALS      (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_REGEXP                (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_SAVED_IDS             (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_SEMAPHORES                                                            \
 	COND_CODE_1(CONFIG_POSIX_SEMAPHORES, (_POSIX_SEMAPHORES), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_SHARED_MEMORY_OBJECTS                                                 \
 	COND_CODE_1(CONFIG_POSIX_SHARED_MEMORY_OBJECTS, (_POSIX_SHARED_MEMORY_OBJECTS), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_SHELL                 (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_SPAWN                 (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_SPIN_LOCKS                                                            \
 	COND_CODE_1(CONFIG_POSIX_SPIN_LOCKS, (_POSIX_SPIN_LOCKS), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_SPORADIC_SERVER (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_SS_REPL_MAX     _POSIX_SS_REPL_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_SYNCHRONIZED_IO (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREAD_ATTR_STACKADDR                                                 \
 	COND_CODE_1(CONFIG_POSIX_THREAD_ATTR_STACKADDR, (_POSIX_THREAD_ATTR_STACKADDR), (-1))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREAD_ATTR_STACKSIZE                                                 \
 	COND_CODE_1(CONFIG_POSIX_THREAD_ATTR_STACKSIZE, (_POSIX_THREAD_ATTR_STACKSIZE), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREAD_CPUTIME (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREAD_PRIO_INHERIT                                                   \
 	COND_CODE_1(CONFIG_POSIX_THREAD_PRIO_INHERIT, (_POSIX_THREAD_PRIO_INHERIT), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREAD_PRIO_PROTECT        (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREAD_PRIORITY_SCHEDULING                                            \
 	COND_CODE_1(CONFIG_POSIX_THREAD_PRIORITY_SCHEDULING, (_POSIX_THREAD_PRIORITY_SCHEDULING),  \
 		    (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREAD_PROCESS_SHARED      (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREAD_ROBUST_PRIO_INHERIT (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREAD_ROBUST_PRIO_PROTECT (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREAD_SAFE_FUNCTIONS                                                 \
 	COND_CODE_1(CONFIG_POSIX_THREAD_SAFE_FUNCTIONS, (_POSIX_THREAD_SAFE_FUNCTIONS), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREAD_SPORADIC_SERVER       (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREADS                                                               \
 	COND_CODE_1(CONFIG_POSIX_THREADS, (_POSIX_THREADS), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_TIMEOUTS                                                              \
 	COND_CODE_1(CONFIG_POSIX_TIMEOUTS, (_POSIX_TIMEOUTS), (-1L))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_TIMERS                                                                \
 	COND_CODE_1(CONFIG_POSIX_TIMEOUTS, (_POSIX_TIMERS), (-1))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_TRACE                        (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_TRACE_EVENT_FILTER           (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_TRACE_EVENT_NAME_MAX         _POSIX_TRACE_NAME_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_TRACE_INHERIT                (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_TRACE_LOG                    (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_TRACE_NAME_MAX               _POSIX_TRACE_NAME_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_TRACE_SYS_MAX                _POSIX_TRACE_SYS_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_TRACE_USER_EVENT_MAX         _POSIX_TRACE_USER_EVENT_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_TYPED_MEMORY_OBJECTS         (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_VERSION                      _POSIX_VERSION
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_V6_ILP32_OFF32               (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_V6_ILP32_OFFBIG              (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_V6_LP64_OFF64                (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_V6_LPBIG_OFFBIG              (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_V7_ILP32_OFF32               (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_V7_ILP32_OFFBIG              (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_V7_LP64_OFF64                (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_V7_LPBIG_OFFBIG              (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_BC_BASE_MAX                  _POSIX2_BC_BASE_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_BC_DIM_MAX                   _POSIX2_BC_DIM_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_BC_SCALE_MAX                 _POSIX2_BC_SCALE_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_BC_STRING_MAX                _POSIX2_BC_STRING_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_2_C_BIND                     _POSIX2_C_BIND
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_2_C_DEV                                                               \
 	COND_CODE_1(_POSIX2_C_DEV > 0, (_POSIX2_C_DEV), (-1))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_2_CHAR_TERM                  (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_COLL_WEIGHTS_MAX             _POSIX2_COLL_WEIGHTS_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_DELAYTIMER_MAX                                                        \
 	COND_CODE_1(CONFIG_POSIX_TIMERS, (CONFIG_POSIX_DELAYTIMER_MAX), (0))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_EXPR_NEST_MAX                _POSIX2_EXPR_NEST_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_2_FORT_DEV                   (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_2_FORT_RUN                   (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_LINE_MAX                     (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_2_LOCALEDEF                  (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_2_PBS                        (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_2_PBS_ACCOUNTING             (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_2_PBS_CHECKPOINT             (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_2_PBS_LOCATE                 (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_2_PBS_MESSAGE                (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_2_PBS_TRACK                  (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_2_SW_DEV                     (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_2_UPE                        (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_2_VERSION                                                             \
 	COND_CODE_1(_POSIX2_VERSION > 0, (_POSIX2_VERSION), (-1))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_XOPEN_CRYPT                  (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_XOPEN_ENH_I18N               (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_XOPEN_REALTIME               (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_XOPEN_REALTIME_THREADS       (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_XOPEN_SHM                    (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_XOPEN_STREAMS                                                         \
 	COND_CODE_1(CONFIG_XOPEN_STREAMS, (_XOPEN_STREAMS), (-1))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_XOPEN_UNIX                   (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_XOPEN_UUCP                   (-1L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_XOPEN_VERSION                _XOPEN_VERSION
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_CLK_TCK                      (100L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_GETGR_R_SIZE_MAX             (0L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_GETPW_R_SIZE_MAX             (0L)
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_AIO_LISTIO_MAX               _POSIX_AIO_LISTIO_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_AIO_MAX                      _POSIX_AIO_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_AIO_PRIO_DELTA_MAX           0
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_ARG_MAX                      _POSIX_ARG_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_ATEXIT_MAX                   32
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_CHILD_MAX                    _POSIX_CHILD_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_HOST_NAME_MAX                                                         \
 	COND_CODE_1(CONFIG_POSIX_NETWORKING, (CONFIG_POSIX_HOST_NAME_MAX), (0))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_IOV_MAX                      16 /* _XOPEN_IOV_MAX */
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_LOGIN_NAME_MAX               _POSIX_LOGIN_NAME_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_NGROUPS_MAX                  _POSIX_NGROUPS_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_MQ_OPEN_MAX                                                           \
 	COND_CODE_1(CONFIG_POSIX_MESSAGE_PASSING, (CONFIG_POSIX_MQ_OPEN_MAX), (0))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_MQ_PRIO_MAX                  _POSIX_MQ_PRIO_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_OPEN_MAX                     CONFIG_POSIX_OPEN_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_PAGE_SIZE                    CONFIG_POSIX_PAGE_SIZE
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_PAGESIZE                     CONFIG_POSIX_PAGE_SIZE
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREAD_DESTRUCTOR_ITERATIONS _POSIX_THREAD_DESTRUCTOR_ITERATIONS
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREAD_KEYS_MAX                                                       \
 	COND_CODE_1(CONFIG_POSIX_THREADS, (CONFIG_POSIX_THREAD_KEYS_MAX), (0))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREAD_STACK_MIN             0
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_THREAD_THREADS_MAX                                                    \
 	COND_CODE_1(CONFIG_POSIX_THREADS, (CONFIG_POSIX_THREAD_THREADS_MAX), (0))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_RTSIG_MAX                                                             \
 	COND_CODE_1(CONFIG_POSIX_REALTIME_SIGNALS, (CONFIG_POSIX_RTSIG_MAX), (0))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_SEM_NSEMS_MAX                                                         \
 	COND_CODE_1(CONFIG_POSIX_SEMAPHORES, (CONFIG_POSIX_SEM_NSEMS_MAX), (0))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_SEM_VALUE_MAX                                                         \
 	COND_CODE_1(CONFIG_POSIX_SEMAPHORES, (CONFIG_POSIX_SEM_VALUE_MAX), (0))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_SIGQUEUE_MAX                 _POSIX_SIGQUEUE_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_STREAM_MAX                   _POSIX_STREAM_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_SYMLOOP_MAX                  _POSIX_SYMLOOP_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_TIMER_MAX                                                             \
 	COND_CODE_1(CONFIG_POSIX_TIMERS, (CONFIG_POSIX_TIMER_MAX), (0))
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_TTY_NAME_MAX                 _POSIX_TTY_NAME_MAX
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __z_posix_sysconf_SC_TZNAME_MAX                   _POSIX_TZNAME_MAX
+/** @endcond */
 
 #ifdef CONFIG_POSIX_SYSCONF_IMPL_MACRO
+/**
+ * @brief Get the value of a configurable system variable.
+ *
+ * @param x @c _SC_ constant naming the variable to query (e.g. @c _SC_PAGESIZE).
+ *
+ * @return Value of the variable, or -1 if the associated option or limit is unsupported.
+ */
 #define sysconf(x) (long)CONCAT(__z_posix_sysconf, x)
 #endif
 

--- a/include/zephyr/posix/sys/time.h
+++ b/include/zephyr/posix/sys/time.h
@@ -4,6 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Time types.
+ * @ingroup posix
+ *
+ * Provides the timeval structure and the gettimeofday() function for obtaining
+ * the current time with microsecond resolution.
+ *
+ * @posix_header{sys_time.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_TIME_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_TIME_H_
 
@@ -15,8 +26,18 @@
 #include <sys/_timeval.h>
 #else
 #include <sys/types.h>
+
+/**
+ * @brief Time interval in seconds and microseconds.
+ */
 struct timeval {
+	/**
+	 * @brief Seconds component.
+	 */
 	time_t tv_sec;
+	/**
+	 * @brief Microseconds component.
+	 */
 	suseconds_t tv_usec;
 };
 #endif
@@ -30,6 +51,17 @@ struct timeval {
 extern "C" {
 #endif
 
+/**
+ * @brief Get the date and time.
+ *
+ * @param tv Output: current time; @c tv_sec is seconds and @c tv_usec is microseconds
+ *           since the Epoch.
+ * @param tz Deprecated, must be NULL.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{gettimeofday}
+ */
 int gettimeofday(struct timeval *tv, void *tz);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/sys/times.h
+++ b/include/zephyr/posix/sys/times.h
@@ -4,6 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Process CPU time accounting.
+ * @ingroup posix
+ *
+ * Defines the tms structure reporting the user and system CPU time consumed by
+ * the calling process and its waited-for children, and the times() function
+ * that retrieves it.
+ *
+ * @posix_header{sys_times.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_TIMES_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_TIMES_H_
 
@@ -16,16 +28,45 @@ extern "C" {
 #if defined(_POSIX_MULTI_PROCESS) || defined(__DOXYGEN__)
 
 #if !defined(_TMS_DECLARED) && !defined(__tms_defined)
+/**
+ * @brief Process times.
+ */
 struct tms {
+	/**
+	 * @brief User CPU time of the process.
+	 */
 	clock_t tms_utime;
+	/**
+	 * @brief System CPU time of the process.
+	 */
 	clock_t tms_stime;
+	/**
+	 * @brief User CPU time of waited-for children.
+	 */
 	clock_t tms_cutime;
+	/**
+	 * @brief System CPU time of waited-for children.
+	 */
 	clock_t tms_cstime;
 };
+/** @cond INTERNAL_HIDDEN */
 #define _TMS_DECLARED
+/** @endcond */
+/** @cond INTERNAL_HIDDEN */
 #define __tms_defined
+/** @endcond */
 #endif
 
+/**
+ * @brief Get process and waited-for child process times.
+ *
+ * @param buf Output: filled with CPU times for the calling process.
+ *
+ * @return Elapsed real time in clock ticks since an arbitrary epoch, or
+ *         (clock_t)-1 with errno set on failure.
+ *
+ * @posix_func{times}
+ */
 clock_t times(struct tms *buf);
 
 #endif /* _POSIX_MULTI_PROCESS */

--- a/include/zephyr/posix/sys/utsname.h
+++ b/include/zephyr/posix/sys/utsname.h
@@ -3,6 +3,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief System name structure.
+ * @ingroup posix
+ *
+ * Defines the utsname structure identifying the operating system name, release,
+ * version, hostname, and hardware type, and the uname() function to retrieve it.
+ *
+ * @posix_header{sys_utsname.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_UTSNAME_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_UTSNAME_H_
 
@@ -13,19 +25,54 @@ extern "C" {
 #endif
 
 /* These are for compatibility / practicality */
+
+/**
+ * @brief Length of the nodename member.
+ */
 #define _UTSNAME_NODENAME_LENGTH                                                                   \
 	COND_CODE_1(CONFIG_POSIX_SINGLE_PROCESS, (CONFIG_POSIX_UNAME_VERSION_LEN), (0))
+
+/**
+ * @brief Length of the version member.
+ */
 #define _UTSNAME_VERSION_LENGTH                                                                    \
 	COND_CODE_1(CONFIG_POSIX_SINGLE_PROCESS, (CONFIG_POSIX_UNAME_VERSION_LEN), (0))
 
+/**
+ * @brief System identification information.
+ */
 struct utsname {
+	/**
+	 * @brief Operating system name.
+	 */
 	char sysname[sizeof("Zephyr")];
+	/**
+	 * @brief Network node hostname.
+	 */
 	char nodename[_UTSNAME_NODENAME_LENGTH + 1];
+	/**
+	 * @brief Operating system release level.
+	 */
 	char release[sizeof("99.99.99-rc1")];
+	/**
+	 * @brief Operating system version level.
+	 */
 	char version[_UTSNAME_VERSION_LENGTH + 1];
+	/**
+	 * @brief Hardware type name.
+	 */
 	char machine[sizeof(CONFIG_ARCH)];
 };
 
+/**
+ * @brief Get the name of the current system.
+ *
+ * @param name Output: system identification structure to fill in.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{uname}
+ */
 int uname(struct utsname *name);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/syslog.h
+++ b/include/zephyr/posix/syslog.h
@@ -3,59 +3,243 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Definitions for system error logging.
+ * @ingroup posix
+ *
+ * Provides the system logging functions along with the standard option,
+ * facility, and priority constants used to submit prioritized messages to
+ * the system log.
+ *
+ * @posix_header{syslog.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_SYSLOG_H_
 #define ZEPHYR_INCLUDE_POSIX_SYSLOG_H_
 
 #include <stdarg.h>
 
 /* option */
+
+/**
+ * @brief Include the process ID in each log message.
+ */
 #define LOG_PID    1
+
+/**
+ * @brief Log to the system console if the logger is unavailable.
+ */
 #define LOG_CONS   2
+
+/**
+ * @brief Open the connection to the logger immediately.
+ */
 #define LOG_NDELAY 4
+
+/**
+ * @brief Delay the connection until the first message is sent.
+ */
 #define LOG_ODELAY 8
+
+/**
+ * @brief Do not wait for child processes created by logging.
+ */
 #define LOG_NOWAIT 16
+
+/**
+ * @brief Also write messages to stderr.
+ */
 #define LOG_PERROR 32
 
 /* facility */
+
+/**
+ * @brief Kernel messages.
+ */
 #define LOG_KERN   0
+
+/**
+ * @brief Generic user-level messages.
+ */
 #define LOG_USER   1
+
+/**
+ * @brief Mail system messages.
+ */
 #define LOG_MAIL   2
+
+/**
+ * @brief News subsystem messages.
+ */
 #define LOG_NEWS   3
+
+/**
+ * @brief UUCP subsystem messages.
+ */
 #define LOG_UUCP   4
+
+/**
+ * @brief System daemon messages.
+ */
 #define LOG_DAEMON 5
+
+/**
+ * @brief Security/authorization messages.
+ */
 #define LOG_AUTH   6
+
+/**
+ * @brief Clock daemon messages.
+ */
 #define LOG_CRON   7
+
+/**
+ * @brief Printer subsystem messages.
+ */
 #define LOG_LPR    8
+
+/**
+ * @brief Reserved for local use (facility 0).
+ */
 #define LOG_LOCAL0 9
+
+/**
+ * @brief Reserved for local use (facility 1).
+ */
 #define LOG_LOCAL1 10
+
+/**
+ * @brief Reserved for local use (facility 2).
+ */
 #define LOG_LOCAL2 11
+
+/**
+ * @brief Reserved for local use (facility 3).
+ */
 #define LOG_LOCAL3 12
+
+/**
+ * @brief Reserved for local use (facility 4).
+ */
 #define LOG_LOCAL4 13
+
+/**
+ * @brief Reserved for local use (facility 5).
+ */
 #define LOG_LOCAL5 14
+
+/**
+ * @brief Reserved for local use (facility 6).
+ */
 #define LOG_LOCAL6 15
+
+/**
+ * @brief Reserved for local use (facility 7).
+ */
 #define LOG_LOCAL7 16
 
 /* priority */
+
+/**
+ * @brief A panic condition was reported to all processes.
+ */
 #define LOG_EMERG   0
+
+/**
+ * @brief A condition that should be corrected immediately.
+ */
 #define LOG_ALERT   1
+
+/**
+ * @brief A critical condition.
+ */
 #define LOG_CRIT    2
+
+/**
+ * @brief An error message.
+ */
 #define LOG_ERR     3
+
+/**
+ * @brief A warning message.
+ */
 #define LOG_WARNING 4
+
+/**
+ * @brief A condition requiring special handling.
+ */
 #define LOG_NOTICE  5
+
+/**
+ * @brief A general information message.
+ */
 #define LOG_INFO    6
+
+/**
+ * @brief A message useful for debugging programs.
+ */
 #define LOG_DEBUG   7
 
 /* generate a valid log mask */
+
+/**
+ * @brief Generate a log mask for the given priority.
+ */
 #define LOG_MASK(mask) ((mask) & BIT_MASK(LOG_DEBUG + 1))
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/**
+ * @brief Close the connection to the system logger.
+ *
+ * @posix_func{closelog}
+ */
 void closelog(void);
+
+/**
+ * @brief Open a connection to the system logger.
+ *
+ * @param ident    String prepended to each log message; typically the program name.
+ * @param logopt   Bitwise OR of logging options (@c LOG_PID, @c LOG_CONS, etc.).
+ * @param facility Default facility code (@c LOG_USER, @c LOG_DAEMON, etc.).
+ *
+ * @posix_func{openlog}
+ */
 void openlog(const char *ident, int logopt, int facility);
+
+/**
+ * @brief Set the log priority mask.
+ *
+ * @param maskpri New priority mask (generated with LOG_MASK()).
+ *
+ * @return The previous log priority mask.
+ *
+ * @posix_func{setlogmask}
+ */
 int setlogmask(int maskpri);
+
+/**
+ * @brief Write a message to the system logger.
+ *
+ * @param priority Priority code (@c LOG_EMERG through @c LOG_DEBUG).
+ * @param message  printf()-style format string.
+ * @param ...      Format arguments.
+ *
+ * @posix_func{syslog}
+ */
 void syslog(int priority, const char *message, ...);
+
+/**
+ * @brief Generate a system log message from a variable argument list.
+ *
+ * @param priority Priority code (@c LOG_EMERG through @c LOG_DEBUG).
+ * @param format   printf()-style format string.
+ * @param ap       Variable argument list.
+ */
 void vsyslog(int priority, const char *format, va_list ap);
 
 #ifdef __cplusplus

--- a/include/zephyr/posix/unistd.h
+++ b/include/zephyr/posix/unistd.h
@@ -3,6 +3,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/**
+ * @file
+ * @brief Standard symbolic constants and types.
+ * @ingroup posix
+ *
+ * Provides the POSIX miscellaneous functions: file I/O (read, write, close, lseek),
+ * file system operations, process identification, and process environment queries.
+ *
+ * @posix_header{unistd.h}
+ */
+
 #ifndef ZEPHYR_INCLUDE_POSIX_UNISTD_H_
 #define ZEPHYR_INCLUDE_POSIX_UNISTD_H_
 
@@ -25,51 +37,284 @@ extern "C" {
 
 #ifdef CONFIG_POSIX_API
 /* File related operations */
+
+/**
+ * @brief Close a file descriptor.
+ *
+ * @param file File descriptor to close.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{close}
+ */
 int close(int file);
+
+/**
+ * @brief Write to a file descriptor.
+ *
+ * @param file   File descriptor.
+ * @param buffer Buffer containing the data to write.
+ * @param count  Number of bytes to write.
+ *
+ * @return Number of bytes written on success, or -1 with errno set on failure.
+ *
+ * @posix_func{write}
+ */
 ssize_t write(int file, const void *buffer, size_t count);
+
+/**
+ * @brief Read from a file descriptor.
+ *
+ * @param file   File descriptor.
+ * @param buffer Buffer into which the data is read.
+ * @param count  Maximum number of bytes to read.
+ *
+ * @return Number of bytes read on success, 0 at end-of-file, or -1 with errno set on failure.
+ *
+ * @posix_func{read}
+ */
 ssize_t read(int file, void *buffer, size_t count);
+
+/**
+ * @brief Reposition the file offset of an open file descriptor.
+ *
+ * @param file   File descriptor.
+ * @param offset New offset, relative to the position selected by @p whence.
+ * @param whence One of @c SEEK_SET, @c SEEK_CUR, or @c SEEK_END.
+ *
+ * @return Resulting offset, in bytes from the beginning of the file, or -1 with errno set on
+ *         failure.
+ *
+ * @posix_func{lseek}
+ */
 off_t lseek(int file, off_t offset, int whence);
+
+/**
+ * @brief Synchronize an open file's data and metadata to storage.
+ *
+ * @param fd File descriptor.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{fsync}
+ */
 int fsync(int fd);
+
+/**
+ * @brief Truncate an open file to a specified length.
+ *
+ * @param fd     File descriptor open for writing.
+ * @param length New length of the file in bytes.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{ftruncate}
+ */
 int ftruncate(int fd, off_t length);
 
 #ifdef CONFIG_POSIX_SYNCHRONIZED_IO
+/**
+ * @brief Synchronize the data of an open file to storage (without metadata).
+ *
+ * @param fd File descriptor.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{fdatasync}
+ */
 int fdatasync(int fd);
 #endif /* CONFIG_POSIX_SYNCHRONIZED_IO */
 
 /* File System related operations */
+
+/**
+ * @brief Rename a file.
+ *
+ * @param old  Pathname of the file to rename.
+ * @param newp New pathname of the file.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{rename}
+ */
 int rename(const char *old, const char *newp);
+
+/**
+ * @brief Remove a directory entry.
+ *
+ * @param path Pathname of the file to remove.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{unlink}
+ */
 int unlink(const char *path);
+
+/**
+ * @brief Get file status.
+ *
+ * @param path Pathname of the file to query.
+ * @param buf  Structure filled in with the file status.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{stat}
+ */
 int stat(const char *path, struct stat *buf);
+
+/**
+ * @brief Make a directory.
+ *
+ * @param path Pathname of the directory to create.
+ * @param mode Permission bits of the new directory.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{mkdir}
+ */
 int mkdir(const char *path, mode_t mode);
+
+/**
+ * @brief Remove an empty directory.
+ *
+ * @param path Pathname of the directory to remove.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{rmdir}
+ */
 int rmdir(const char *path);
 
+/**
+ * @brief Terminate the calling process without calling atexit() handlers.
+ *
+ * This function does not return.
+ *
+ * @param status Exit status of the process.
+ *
+ * @posix_func{_exit}
+ */
 FUNC_NORETURN void _exit(int status);
 
+/**
+ * @brief Get the name of the current host.
+ *
+ * @param buf Buffer to receive the null-terminated host name.
+ * @param len Size of @p buf in bytes.
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{gethostname}
+ */
 int gethostname(char *buf, size_t len);
 
 #endif /* CONFIG_POSIX_API */
 
 #ifdef CONFIG_POSIX_C_LIB_EXT
+/**
+ * @brief Parse command-line options.
+ *
+ * @param argc      Argument count, as passed to main().
+ * @param argv      Argument array, as passed to main().
+ * @param optstring String of recognized option characters; a character followed by ':' takes
+ *                  an argument.
+ *
+ * @return The next option character, '?' or ':' on error, or -1 when option parsing is complete.
+ *
+ * @posix_func{getopt}
+ */
 int getopt(int argc, char *const argv[], const char *optstring);
 extern char *optarg;
 extern int opterr, optind, optopt;
 #endif
 
+/**
+ * @brief Fill a buffer with cryptographically secure random bytes.
+ * @ingroup posix_extensions
+ *
+ * @param buffer Buffer to fill with random bytes.
+ * @param length Number of bytes to write into @p buffer (at most 256).
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @compat_api{getentropy}
+ */
 int getentropy(void *buffer, size_t length);
+
+/**
+ * @brief Get the process ID of the calling process.
+ *
+ * @return Process ID of the calling process. This function is always successful.
+ *
+ * @posix_func{getpid}
+ */
 pid_t getpid(void);
+
+/**
+ * @brief Suspend execution for at least the specified number of seconds.
+ *
+ * @param seconds Number of seconds to sleep.
+ *
+ * @return 0 if the requested time has elapsed, or the number of unslept seconds if
+ *         interrupted by a signal.
+ *
+ * @posix_func{sleep}
+ */
 unsigned sleep(unsigned int seconds);
+
+/**
+ * @brief Suspend execution for at least the specified number of microseconds.
+ *
+ * @param useconds Number of microseconds to sleep (must be less than 1000000).
+ *
+ * @return 0 on success, or -1 with errno set on failure.
+ *
+ * @posix_func{usleep}
+ */
 int usleep(useconds_t useconds);
 #if _POSIX_C_SOURCE >= 2
+/**
+ * @brief Determine the value of a configurable system variable by name string.
+ *
+ * @param name Variable to query (@c _CS_* constant).
+ * @param buf  Buffer to receive the null-terminated value, or NULL.
+ * @param len  Size of @p buf in bytes.
+ *
+ * @return Size of the buffer needed to hold the entire value (including the terminating
+ *         null byte), or 0 if @p name is invalid or has no configuration-defined value.
+ *
+ * @posix_func{confstr}
+ */
 size_t confstr(int name, char *buf, size_t len);
 #endif
 
 #ifdef CONFIG_POSIX_SYSCONF_IMPL_MACRO
+/**
+ * @brief Get a configurable system variable.
+ */
 #define sysconf(x) (long)CONCAT(__z_posix_sysconf, x)
 #else
+/**
+ * @brief Get a configurable system variable.
+ *
+ * @param opt Variable to query (@c _SC_* constant).
+ *
+ * @return Value of the system variable, or -1 if @p opt is invalid or the value is
+ *         indeterminate.
+ *
+ * @posix_func{sysconf}
+ */
 long sysconf(int opt);
 #endif /* CONFIG_POSIX_SYSCONF_IMPL_FULL */
 
 #if _XOPEN_SOURCE >= 500
+/**
+ * @brief Get an identifier for the current host.
+ *
+ * @return 32-bit identifier for the current host.
+ *
+ * @posix_func{gethostid}
+ */
 long gethostid(void);
 #endif
 


### PR DESCRIPTION
uart drivers, that init in POST_KERNEL and
not in PRE_KERNEL_1 can't support
CONFIG_EARLY_CONSOLE, add a Kconfig for it.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>