### PR TITLE
Remove DWARF v4 workaround for pyelftools compatibility

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -254,10 +254,6 @@ set_compiler_property(PROPERTY linker_script -T)
 # Flags to not track macro expansion
 set_compiler_property(PROPERTY no_track_macro_expansion -ftrack-macro-expansion=0)
 
-# GCC 11 by default emits DWARF version 5 which cannot be parsed by
-# pyelftools. Can be removed once pyelftools supports v5.
-check_set_compiler_property(APPEND PROPERTY debug -gdwarf-4)
-
 set_compiler_property(PROPERTY no_common -fno-common)
 
 # GCC compiler flags for imacros. The specific header must be appended by user.

--- a/cmake/linker/ld/gcc/linker_flags.cmake
+++ b/cmake/linker/ld/gcc/linker_flags.cmake
@@ -9,10 +9,6 @@ endif()
 
 check_set_linker_property(TARGET linker APPEND PROPERTY gprof -pg)
 
-# GCC 11 by default emits DWARF version 5 which cannot be parsed by
-# pyelftools. Can be removed once pyelftools supports v5.
-add_link_options(-gdwarf-4)
-
 # Extra warnings options for twister run
 set_property(TARGET linker PROPERTY warnings_as_errors -Wl,--fatal-warnings)
 


### PR DESCRIPTION
This PR removes the workaround that forced GCC to emit DWARF version 4 debug information instead of the default DWARF version 5.

## Summary
The DWARF v4 enforcement was a temporary measure to work around pyelftools' inability to parse DWARF v5 format. This constraint is no longer necessary and has been removed from both the compiler and linker configurations.

## Changes Made
- Removed `-gdwarf-4` compiler flag from `cmake/compiler/gcc/compiler_flags.cmake`
- Removed `-gdwarf-4` linker option from `cmake/linker/ld/gcc/linker_flags.cmake`
- Removed associated comments explaining the pyelftools limitation

## Notes
This change allows GCC 11+ to use its default DWARF version 5 format, which provides improved debugging information. The removal assumes that pyelftools now supports DWARF v5 or that the project no longer depends on pyelftools for DWARF parsing.

https://claude.ai/code/session_01S3RbZSkMicDrshhPesdfUM