### PR TITLE
drivers: comparator: adopt driver_ops Doxygen convention

### DIFF
--- a/include/zephyr/drivers/comparator.h
+++ b/include/zephyr/drivers/comparator.h
@@ -49,24 +49,61 @@ enum comparator_trigger {
  */
 typedef void (*comparator_callback_t)(const struct device *dev, void *user_data);
 
-/** @cond INTERNAL_HIDDEN */
+/**
+ * @def_driverbackendgroup{Comparator,comparator_interface}
+ * @{
+ */
 
+/**
+ * @brief Get comparator's output state.
+ * See comparator_get_output() for argument description.
+ */
 typedef int (*comparator_api_get_output)(const struct device *dev);
+
+/**
+ * @brief Set comparator's trigger.
+ * See comparator_set_trigger() for argument description.
+ */
 typedef int (*comparator_api_set_trigger)(const struct device *dev,
 					  enum comparator_trigger trigger);
+
+/**
+ * @brief Set comparator's trigger callback.
+ * See comparator_set_trigger_callback() for argument description.
+ */
 typedef int (*comparator_api_set_trigger_callback)(const struct device *dev,
 						   comparator_callback_t callback,
 						   void *user_data);
+
+/**
+ * @brief Check if comparator's trigger is pending and clear it.
+ * See comparator_trigger_is_pending() for argument description.
+ */
 typedef int (*comparator_api_trigger_is_pending)(const struct device *dev);
 
+/**
+ * @driver_ops{Comparator}
+ */
 __subsystem struct comparator_driver_api {
+	/**
+	 * @driver_ops_mandatory @copybrief comparator_get_output
+	 */
 	comparator_api_get_output get_output;
+	/**
+	 * @driver_ops_mandatory @copybrief comparator_set_trigger
+	 */
 	comparator_api_set_trigger set_trigger;
+	/**
+	 * @driver_ops_mandatory @copybrief comparator_set_trigger_callback
+	 */
 	comparator_api_set_trigger_callback set_trigger_callback;
+	/**
+	 * @driver_ops_mandatory @copybrief comparator_trigger_is_pending
+	 */
 	comparator_api_trigger_is_pending trigger_is_pending;
 };
 
-/** @endcond */
+/** @} */
 
 /**
  * @brief Get comparator's output state

--- a/include/zephyr/drivers/coredump.h
+++ b/include/zephyr/drivers/coredump.h
@@ -56,51 +56,62 @@ struct coredump_mem_region_node {
 typedef void (*coredump_dump_callback_t)(uintptr_t dump_area, size_t dump_area_size);
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * For internal use only, skip these in public documentation.
+ * @def_driverbackendgroup{Coredump pseudo-device,coredump_device_interface}
+ * @{
  */
 
-/*
- * Type definition of coredump API function for adding specified
- * data into coredump
+/**
+ * @brief Add the device's data into the core dump being generated.
+ *
+ * Called by the coredump subsystem at dump time so the device can copy the
+ * registered memory regions and callback data into the core dump.
  */
 typedef void (*coredump_device_dump_t)(const struct device *dev);
 
-/*
- * Type definition of coredump API function for registering a memory
- * region
+/**
+ * @brief Register a memory region to be stored in the core dump.
+ * See coredump_device_register_memory() for argument description.
  */
 typedef bool (*coredump_device_register_memory_t)(const struct device *dev,
 	struct coredump_mem_region_node *region);
 
-/*
- * Type definition of coredump API function for unregistering a memory
- * region
+/**
+ * @brief Unregister a memory region from being stored in the core dump.
+ * See coredump_device_unregister_memory() for argument description.
  */
 typedef bool (*coredump_device_unregister_memory_t)(const struct device *dev,
 	struct coredump_mem_region_node *region);
 
-/*
- * Type definition of coredump API function for registering a dump
- * callback
+/**
+ * @brief Register a callback to be invoked at dump time.
+ * See coredump_device_register_callback() for argument description.
  */
 typedef bool (*coredump_device_register_callback_t)(const struct device *dev,
 	coredump_dump_callback_t callback);
 
-/*
- * API which a coredump pseudo-device driver should expose
+/**
+ * @driver_ops{Coredump pseudo-device}
  */
 __subsystem struct coredump_driver_api {
+	/**
+	 * @driver_ops_mandatory Add the device's data into the core dump being generated.
+	 */
 	coredump_device_dump_t              dump;
+	/**
+	 * @driver_ops_mandatory @copybrief coredump_device_register_memory
+	 */
 	coredump_device_register_memory_t   register_memory;
+	/**
+	 * @driver_ops_mandatory @copybrief coredump_device_unregister_memory
+	 */
 	coredump_device_unregister_memory_t unregister_memory;
+	/**
+	 * @driver_ops_mandatory @copybrief coredump_device_register_callback
+	 */
 	coredump_device_register_callback_t register_callback;
 };
 
-/**
- * @endcond
- */
+/** @} */
 
 /**
  * @brief Register a region of memory to be stored in core dump at the

--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -443,38 +443,35 @@ struct dac_dt_spec {
 	DAC_DT_SPEC_GET_OR(DT_DRV_INST(inst), default_value)
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * For internal use only, skip these in public documentation.
+ * @def_driverbackendgroup{DAC,dac_interface}
+ * @{
  */
 
-/*
- * Type definition of DAC API function for configuring a channel.
+/**
+ * @brief Type definition of DAC API function for configuring a channel.
  * See dac_channel_setup() for argument descriptions.
  */
 typedef int (*dac_api_channel_setup)(const struct device *dev,
 				     const struct dac_channel_cfg *channel_cfg);
 
-/*
- * Type definition of DAC API function for setting a write request.
+/**
+ * @brief Type definition of DAC API function for setting a write request.
  * See dac_write_value() for argument descriptions.
  */
 typedef int (*dac_api_write_value)(const struct device *dev,
 				    uint8_t channel, uint32_t value);
 
-/*
- * DAC driver API
- *
- * This is the mandatory API any DAC driver needs to expose.
+/**
+ * @driver_ops{DAC}
  */
 __subsystem struct dac_driver_api {
+	/** @driver_ops_mandatory @copybrief dac_channel_setup */
 	dac_api_channel_setup channel_setup;
+	/** @driver_ops_mandatory @copybrief dac_write_value */
 	dac_api_write_value   write_value;
 };
 
-/**
- * @endcond
- */
+/** @} */
 
 /**
  * @brief Configure a DAC channel.

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -313,14 +313,21 @@ struct dma_context {
 #define DMA_MAGIC 0x47494749
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * These are for internal use only, so skip these in
- * public documentation.
+ * @def_driverbackendgroup{DMA,dma_interface}
+ * @{
+ */
+
+/**
+ * @brief Configure individual channel for DMA transfer.
+ * See dma_config() for argument descriptions.
  */
 typedef int (*dma_api_config)(const struct device *dev, uint32_t channel,
 			      struct dma_config *config);
 
+/**
+ * @brief Reload buffer(s) for a DMA channel.
+ * See dma_reload() for argument descriptions.
+ */
 #ifdef CONFIG_DMA_64BIT
 typedef int (*dma_api_reload)(const struct device *dev, uint32_t channel,
 			      uint64_t src, uint64_t dst, size_t size);
@@ -329,17 +336,41 @@ typedef int (*dma_api_reload)(const struct device *dev, uint32_t channel,
 			      uint32_t src, uint32_t dst, size_t size);
 #endif
 
+/**
+ * @brief Enable DMA channel and start the transfer.
+ * See dma_start() for argument descriptions.
+ */
 typedef int (*dma_api_start)(const struct device *dev, uint32_t channel);
 
+/**
+ * @brief Stop the DMA transfer and disable the channel.
+ * See dma_stop() for argument descriptions.
+ */
 typedef int (*dma_api_stop)(const struct device *dev, uint32_t channel);
 
+/**
+ * @brief Suspend a DMA channel transfer.
+ * See dma_suspend() for argument descriptions.
+ */
 typedef int (*dma_api_suspend)(const struct device *dev, uint32_t channel);
 
+/**
+ * @brief Resume a DMA channel transfer.
+ * See dma_resume() for argument descriptions.
+ */
 typedef int (*dma_api_resume)(const struct device *dev, uint32_t channel);
 
+/**
+ * @brief Get current runtime status of DMA transfer.
+ * See dma_get_status() for argument descriptions.
+ */
 typedef int (*dma_api_get_status)(const struct device *dev, uint32_t channel,
 				  struct dma_status *status);
 
+/**
+ * @brief Get attribute of a DMA controller.
+ * See dma_get_attribute() for argument descriptions.
+ */
 typedef int (*dma_api_get_attribute)(const struct device *dev, uint32_t type, uint32_t *value);
 
 /**
@@ -370,21 +401,37 @@ typedef bool (*dma_api_chan_filter)(const struct device *dev,
 typedef void (*dma_api_chan_release)(const struct device *dev,
 				     uint32_t channel);
 
+/**
+ * @driver_ops{DMA}
+ */
 __subsystem struct dma_driver_api {
+	/** @driver_ops_mandatory @copybrief dma_config */
 	dma_api_config config;
+	/** @driver_ops_optional @copybrief dma_reload */
 	dma_api_reload reload;
+	/** @driver_ops_mandatory @copybrief dma_start */
 	dma_api_start start;
+	/** @driver_ops_optional @copybrief dma_stop */
 	dma_api_stop stop;
+	/** @driver_ops_optional @copybrief dma_suspend */
 	dma_api_suspend suspend;
+	/** @driver_ops_optional @copybrief dma_resume */
 	dma_api_resume resume;
+	/** @driver_ops_optional @copybrief dma_get_status */
 	dma_api_get_status get_status;
+	/** @driver_ops_optional @copybrief dma_get_attribute */
 	dma_api_get_attribute get_attribute;
+	/** @driver_ops_optional @copybrief dma_chan_filter */
 	dma_api_chan_filter chan_filter;
+	/**
+	 * @driver_ops_optional Release channel resources allocated during the
+	 * request phase.
+	 * See dma_release_channel() for details.
+	 */
 	dma_api_chan_release chan_release;
 };
-/**
- * @endcond
- */
+
+/** @} */
 
 /**
  * @brief Configure individual channel for DMA transfer.

--- a/include/zephyr/drivers/edac.h
+++ b/include/zephyr/drivers/edac.h
@@ -41,46 +41,145 @@ enum edac_error_type {
 };
 
 /**
- * @cond INTERNAL_HIDDEN
+ * @brief Notification callback function signature for memory error exceptions.
  *
- * For internal use only, skip these in public documentation.
+ * @param dev Pointer to the device structure
+ * @param data Pointer to the callback data
  */
-
 typedef void (*edac_notify_callback_f)(const struct device *dev, void *data);
 
 /**
- * @brief EDAC driver API
- *
- * This is the mandatory API any EDAC driver needs to expose.
+ * @def_driverbackendgroup{EDAC,edac_interface}
+ * @{
+ */
+
+/**
+ * @brief Callback API to set injection parameter param1.
+ * See edac_inject_set_param1() for argument description.
+ */
+typedef int (*edac_inject_set_param1_f)(const struct device *dev, uint64_t value);
+
+/**
+ * @brief Callback API to get injection parameter param1.
+ * See edac_inject_get_param1() for argument description.
+ */
+typedef int (*edac_inject_get_param1_f)(const struct device *dev, uint64_t *value);
+
+/**
+ * @brief Callback API to set injection parameter param2.
+ * See edac_inject_set_param2() for argument description.
+ */
+typedef int (*edac_inject_set_param2_f)(const struct device *dev, uint64_t value);
+
+/**
+ * @brief Callback API to get injection parameter param2.
+ * See edac_inject_get_param2() for argument description.
+ */
+typedef int (*edac_inject_get_param2_f)(const struct device *dev, uint64_t *value);
+
+/**
+ * @brief Callback API to set the error type to be injected.
+ * See edac_inject_set_error_type() for argument description.
+ */
+typedef int (*edac_inject_set_error_type_f)(const struct device *dev, uint32_t value);
+
+/**
+ * @brief Callback API to get the error type to be injected.
+ * See edac_inject_get_error_type() for argument description.
+ */
+typedef int (*edac_inject_get_error_type_f)(const struct device *dev, uint32_t *value);
+
+/**
+ * @brief Callback API to trigger error injection.
+ * See edac_inject_error_trigger() for argument description.
+ */
+typedef int (*edac_inject_error_trigger_f)(const struct device *dev);
+
+/**
+ * @brief Callback API to read the ECC Error Log.
+ * See edac_ecc_error_log_get() for argument description.
+ */
+typedef int (*edac_ecc_error_log_get_f)(const struct device *dev, uint64_t *value);
+
+/**
+ * @brief Callback API to clear the ECC Error Log.
+ * See edac_ecc_error_log_clear() for argument description.
+ */
+typedef int (*edac_ecc_error_log_clear_f)(const struct device *dev);
+
+/**
+ * @brief Callback API to read the Parity Error Log.
+ * See edac_parity_error_log_get() for argument description.
+ */
+typedef int (*edac_parity_error_log_get_f)(const struct device *dev, uint64_t *value);
+
+/**
+ * @brief Callback API to clear the Parity Error Log.
+ * See edac_parity_error_log_clear() for argument description.
+ */
+typedef int (*edac_parity_error_log_clear_f)(const struct device *dev);
+
+/**
+ * @brief Callback API to get the number of correctable errors.
+ * See edac_errors_cor_get() for argument description.
+ */
+typedef int (*edac_errors_cor_get_f)(const struct device *dev);
+
+/**
+ * @brief Callback API to get the number of uncorrectable errors.
+ * See edac_errors_uc_get() for argument description.
+ */
+typedef int (*edac_errors_uc_get_f)(const struct device *dev);
+
+/**
+ * @brief Callback API to register a notification callback for memory error exceptions.
+ * See edac_notify_callback_set() for argument description.
+ */
+typedef int (*edac_notify_cb_set_f)(const struct device *dev,
+				    edac_notify_callback_f cb);
+
+/**
+ * @driver_ops{EDAC}
  */
 __subsystem struct edac_driver_api {
 	/* Error Injection API is disabled by default */
-	int (*inject_set_param1)(const struct device *dev, uint64_t value);
-	int (*inject_get_param1)(const struct device *dev, uint64_t *value);
-	int (*inject_set_param2)(const struct device *dev, uint64_t value);
-	int (*inject_get_param2)(const struct device *dev, uint64_t *value);
-	int (*inject_set_error_type)(const struct device *dev, uint32_t value);
-	int (*inject_get_error_type)(const struct device *dev, uint32_t *value);
-	int (*inject_error_trigger)(const struct device *dev);
+	/** @driver_ops_optional @copybrief edac_inject_set_param1 */
+	edac_inject_set_param1_f inject_set_param1;
+	/** @driver_ops_optional @copybrief edac_inject_get_param1 */
+	edac_inject_get_param1_f inject_get_param1;
+	/** @driver_ops_optional @copybrief edac_inject_set_param2 */
+	edac_inject_set_param2_f inject_set_param2;
+	/** @driver_ops_optional @copybrief edac_inject_get_param2 */
+	edac_inject_get_param2_f inject_get_param2;
+	/** @driver_ops_optional @copybrief edac_inject_set_error_type */
+	edac_inject_set_error_type_f inject_set_error_type;
+	/** @driver_ops_optional @copybrief edac_inject_get_error_type */
+	edac_inject_get_error_type_f inject_get_error_type;
+	/** @driver_ops_optional @copybrief edac_inject_error_trigger */
+	edac_inject_error_trigger_f inject_error_trigger;
 
 	/* Error Logging  API */
-	int (*ecc_error_log_get)(const struct device *dev, uint64_t *value);
-	int (*ecc_error_log_clear)(const struct device *dev);
-	int (*parity_error_log_get)(const struct device *dev, uint64_t *value);
-	int (*parity_error_log_clear)(const struct device *dev);
+	/** @driver_ops_optional @copybrief edac_ecc_error_log_get */
+	edac_ecc_error_log_get_f ecc_error_log_get;
+	/** @driver_ops_optional @copybrief edac_ecc_error_log_clear */
+	edac_ecc_error_log_clear_f ecc_error_log_clear;
+	/** @driver_ops_optional @copybrief edac_parity_error_log_get */
+	edac_parity_error_log_get_f parity_error_log_get;
+	/** @driver_ops_optional @copybrief edac_parity_error_log_clear */
+	edac_parity_error_log_clear_f parity_error_log_clear;
 
 	/* Error stats API */
-	int (*errors_cor_get)(const struct device *dev);
-	int (*errors_uc_get)(const struct device *dev);
+	/** @driver_ops_optional @copybrief edac_errors_cor_get */
+	edac_errors_cor_get_f errors_cor_get;
+	/** @driver_ops_optional @copybrief edac_errors_uc_get */
+	edac_errors_uc_get_f errors_uc_get;
 
 	/* Notification callback API */
-	int (*notify_cb_set)(const struct device *dev,
-			     edac_notify_callback_f cb);
+	/** @driver_ops_optional @copybrief edac_notify_callback_set */
+	edac_notify_cb_set_f notify_cb_set;
 };
 
-/**
- * INTERNAL_HIDDEN @endcond
- */
+/** @} */
 
 /**
  * @name Optional interfaces

--- a/include/zephyr/drivers/espi.h
+++ b/include/zephyr/drivers/espi.h
@@ -622,77 +622,151 @@ struct espi_callback {
 /** @endcond */
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * eSPI driver API definition and system call entry points
- *
- * (Internal use only.)
+ * @def_driverbackendgroup{eSPI,espi_interface}
+ * @{
+ */
+
+/**
+ * @brief Configure operation of a eSPI hardware.
+ * See espi_config() for argument description.
  */
 typedef int (*espi_api_config)(const struct device *dev, struct espi_cfg *cfg);
+/**
+ * @brief Query whether a logical channel is ready.
+ * See espi_get_channel_status() for argument description.
+ */
 typedef bool (*espi_api_get_channel_status)(const struct device *dev,
 					    enum espi_channel ch);
 /* Logical Channel 0 APIs */
+/**
+ * @brief Send a memory, I/O or message read request over eSPI.
+ * See espi_read_request() for argument description.
+ */
 typedef int (*espi_api_read_request)(const struct device *dev,
 				     struct espi_request_packet *req);
+/**
+ * @brief Send a memory, I/O or message write request over eSPI.
+ * See espi_write_request() for argument description.
+ */
 typedef int (*espi_api_write_request)(const struct device *dev,
 				      struct espi_request_packet *req);
+/**
+ * @brief Read from a LPC peripheral registers.
+ * See espi_read_lpc_request() for argument description.
+ */
 typedef int (*espi_api_lpc_read_request)(const struct device *dev,
 					 enum lpc_peripheral_opcode op,
 					 uint32_t *data);
+/**
+ * @brief Write to a LPC peripheral registers.
+ * See espi_write_lpc_request() for argument description.
+ */
 typedef int (*espi_api_lpc_write_request)(const struct device *dev,
 					  enum lpc_peripheral_opcode op,
 					  uint32_t *data);
 /* Logical Channel 1 APIs */
+/**
+ * @brief Send a virtual wire packet over eSPI.
+ * See espi_send_vwire() for argument description.
+ */
 typedef int (*espi_api_send_vwire)(const struct device *dev,
 				   enum espi_vwire_signal vw,
 				   uint8_t level);
+/**
+ * @brief Retrieve the level of a virtual wire signal.
+ * See espi_receive_vwire() for argument description.
+ */
 typedef int (*espi_api_receive_vwire)(const struct device *dev,
 				      enum espi_vwire_signal vw,
 				      uint8_t *level);
 /* Logical Channel 2 APIs */
+/**
+ * @brief Send a SMBus transaction (out-of-band) packet over eSPI.
+ * See espi_send_oob() for argument description.
+ */
 typedef int (*espi_api_send_oob)(const struct device *dev,
 				 struct espi_oob_packet *pckt);
+/**
+ * @brief Receive a SMBus transaction (out-of-band) packet from eSPI.
+ * See espi_receive_oob() for argument description.
+ */
 typedef int (*espi_api_receive_oob)(const struct device *dev,
 				    struct espi_oob_packet *pckt);
 /* Logical Channel 3 APIs */
+/**
+ * @brief Send a read request for a flash region shared over eSPI.
+ * See espi_read_flash() for argument description.
+ */
 typedef int (*espi_api_flash_read)(const struct device *dev,
 				   struct espi_flash_packet *pckt);
+/**
+ * @brief Send a write request for a flash region shared over eSPI.
+ * See espi_write_flash() for argument description.
+ */
 typedef int (*espi_api_flash_write)(const struct device *dev,
 				    struct espi_flash_packet *pckt);
+/**
+ * @brief Send an erase request for a flash region shared over eSPI.
+ * See espi_flash_erase() for argument description.
+ */
 typedef int (*espi_api_flash_erase)(const struct device *dev,
 				    struct espi_flash_packet *pckt);
 
 /* Callbacks and traffic intercept */
+/**
+ * @brief Add or remove an application callback.
+ * See espi_add_callback() and espi_remove_callback() for argument description.
+ */
 typedef int (*espi_api_manage_callback)(const struct device *dev,
 					struct espi_callback *callback,
 					bool set);
 
 /* eSPI interrupt control */
+/**
+ * @brief Control eSPI interrupts.
+ * See espi_interrupt_config() for argument description.
+ */
 typedef int (*espi_api_interrupt_configure)(const struct device *dev,
 					    uint32_t espi_interrupt_flags,
 					    uint32_t espi_interrupt_vendor);
 
+/**
+ * @driver_ops{eSPI}
+ */
 __subsystem struct espi_driver_api {
+	/** @driver_ops_mandatory @copybrief espi_config */
 	espi_api_config config;
+	/** @driver_ops_mandatory @copybrief espi_get_channel_status */
 	espi_api_get_channel_status get_channel_status;
+	/** @driver_ops_optional @copybrief espi_read_request */
 	espi_api_read_request read_request;
+	/** @driver_ops_optional @copybrief espi_write_request */
 	espi_api_write_request write_request;
+	/** @driver_ops_optional @copybrief espi_read_lpc_request */
 	espi_api_lpc_read_request read_lpc_request;
+	/** @driver_ops_optional @copybrief espi_write_lpc_request */
 	espi_api_lpc_write_request write_lpc_request;
+	/** @driver_ops_mandatory @copybrief espi_send_vwire */
 	espi_api_send_vwire send_vwire;
+	/** @driver_ops_mandatory @copybrief espi_receive_vwire */
 	espi_api_receive_vwire receive_vwire;
+	/** @driver_ops_optional @copybrief espi_send_oob */
 	espi_api_send_oob send_oob;
+	/** @driver_ops_optional @copybrief espi_receive_oob */
 	espi_api_receive_oob receive_oob;
+	/** @driver_ops_optional @copybrief espi_read_flash */
 	espi_api_flash_read flash_read;
+	/** @driver_ops_optional @copybrief espi_write_flash */
 	espi_api_flash_write flash_write;
+	/** @driver_ops_optional @copybrief espi_flash_erase */
 	espi_api_flash_erase flash_erase;
+	/** @driver_ops_optional Add or remove an application callback. */
 	espi_api_manage_callback manage_callback;
+	/** @driver_ops_optional @copybrief espi_interrupt_config */
 	espi_api_interrupt_configure interrupt_config;
 };
 
-/**
- * @endcond
- */
+/** @} */
 
 /**
  * @brief Configure operation of a eSPI hardware.

--- a/include/zephyr/drivers/espi_saf.h
+++ b/include/zephyr/drivers/espi_saf.h
@@ -122,51 +122,94 @@ struct espi_saf_packet {
  */
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * eSPI driver API definition and system call entry points
- *
- * (Internal use only.)
+ * @def_driverbackendgroup{eSPI SAF,espi_saf_interface}
+ * @{
+ */
+
+/**
+ * @brief Callback API to configure the eSPI SAF controller.
+ * See espi_saf_config() for argument description.
  */
 typedef int (*espi_saf_api_config)(const struct device *dev,
 				   const struct espi_saf_cfg *cfg);
 
+/**
+ * @brief Callback API to set one or more SAF protection regions.
+ * See espi_saf_set_protection_regions() for argument description.
+ */
 typedef int (*espi_saf_api_set_protection_regions)(
 				const struct device *dev,
 				const struct espi_saf_protection *pr);
 
+/**
+ * @brief Callback API to activate the SAF block.
+ * See espi_saf_activate() for argument description.
+ */
 typedef int (*espi_saf_api_activate)(const struct device *dev);
 
+/**
+ * @brief Callback API to query if SAF is ready.
+ * See espi_saf_get_channel_status() for argument description.
+ */
 typedef bool (*espi_saf_api_get_channel_status)(const struct device *dev);
 
+/**
+ * @brief Callback API to send a read request for slave attached flash.
+ * See espi_saf_flash_read() for argument description.
+ */
 typedef int (*espi_saf_api_flash_read)(const struct device *dev,
 				       struct espi_saf_packet *pckt);
+/**
+ * @brief Callback API to send a write request for slave attached flash.
+ * See espi_saf_flash_write() for argument description.
+ */
 typedef int (*espi_saf_api_flash_write)(const struct device *dev,
 					struct espi_saf_packet *pckt);
+/**
+ * @brief Callback API to send an erase request for slave attached flash.
+ * See espi_saf_flash_erase() for argument description.
+ */
 typedef int (*espi_saf_api_flash_erase)(const struct device *dev,
 					struct espi_saf_packet *pckt);
+/**
+ * @brief Callback API to respond unsuccessful completion for slave attached flash.
+ * See espi_saf_flash_unsuccess() for argument description.
+ */
 typedef int (*espi_saf_api_flash_unsuccess)(const struct device *dev,
 					struct espi_saf_packet *pckt);
-/* Callbacks and traffic intercept */
+/**
+ * @brief Callback API to manage (add or remove) application callbacks.
+ * See espi_saf_add_callback() and espi_saf_remove_callback() for argument description.
+ */
 typedef int (*espi_saf_api_manage_callback)(const struct device *dev,
 					    struct espi_callback *callback,
 					    bool set);
 
+/**
+ * @driver_ops{eSPI SAF}
+ */
 __subsystem struct espi_saf_driver_api {
+	/** @driver_ops_mandatory @copybrief espi_saf_config */
 	espi_saf_api_config config;
+	/** @driver_ops_mandatory @copybrief espi_saf_set_protection_regions */
 	espi_saf_api_set_protection_regions set_protection_regions;
+	/** @driver_ops_mandatory @copybrief espi_saf_activate */
 	espi_saf_api_activate activate;
+	/** @driver_ops_mandatory @copybrief espi_saf_get_channel_status */
 	espi_saf_api_get_channel_status get_channel_status;
+	/** @driver_ops_optional @copybrief espi_saf_flash_read */
 	espi_saf_api_flash_read flash_read;
+	/** @driver_ops_optional @copybrief espi_saf_flash_write */
 	espi_saf_api_flash_write flash_write;
+	/** @driver_ops_optional @copybrief espi_saf_flash_erase */
 	espi_saf_api_flash_erase flash_erase;
+	/** @driver_ops_optional @copybrief espi_saf_flash_unsuccess */
 	espi_saf_api_flash_unsuccess flash_unsuccess;
+	/** @driver_ops_optional Manage (add or remove) application callbacks. */
 	espi_saf_api_manage_callback manage_callback;
 };
 
-/**
- * @endcond
- */
+/** @} */
 
 /**
  * @brief Configure operation of a eSPI controller.

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -763,84 +763,193 @@ struct gpio_callback {
 };
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * For internal use only, skip these in public documentation.
+ * @def_driverbackendgroup{GPIO,gpio_interface}
+ * @{
  */
 
-/* Used by driver api function pin_interrupt_configure, these are defined
+/**
+ * @brief Interrupt modes for the pin_interrupt_configure driver operation.
+ *
+ * Used by driver api function pin_interrupt_configure, these are defined
  * in terms of the public flags so we can just mask and pass them
- * through to the driver api
+ * through to the driver api.
  */
 enum gpio_int_mode {
+	/** Disable pin interrupt. */
 	GPIO_INT_MODE_DISABLED = GPIO_INT_DISABLE,
+	/** Enable level-triggered pin interrupt. */
 	GPIO_INT_MODE_LEVEL = GPIO_INT_ENABLE,
+	/** Enable edge-triggered pin interrupt. */
 	GPIO_INT_MODE_EDGE = GPIO_INT_ENABLE | GPIO_INT_EDGE,
-#ifdef CONFIG_GPIO_ENABLE_DISABLE_INTERRUPT
+#if defined(CONFIG_GPIO_ENABLE_DISABLE_INTERRUPT) || defined(__DOXYGEN__)
+	/**
+	 * Disable a previously configured pin interrupt without deconfiguring it.
+	 * @kconfig_dep{CONFIG_GPIO_ENABLE_DISABLE_INTERRUPT}
+	 */
 	GPIO_INT_MODE_DISABLE_ONLY = GPIO_INT_DISABLE | GPIO_INT_ENABLE_DISABLE_ONLY,
+	/**
+	 * Re-enable a previously configured pin interrupt.
+	 * @kconfig_dep{CONFIG_GPIO_ENABLE_DISABLE_INTERRUPT}
+	 */
 	GPIO_INT_MODE_ENABLE_ONLY = GPIO_INT_ENABLE | GPIO_INT_ENABLE_DISABLE_ONLY,
 #endif /* CONFIG_GPIO_ENABLE_DISABLE_INTERRUPT */
 };
 
+/**
+ * @brief Interrupt triggers for the pin_interrupt_configure driver operation.
+ */
 enum gpio_int_trig {
-	/* Trigger detection when input state is (or transitions to)
+	/** Trigger detection when input state is (or transitions to)
 	 * physical low. (Edge Falling or Active Low)
 	 */
 	GPIO_INT_TRIG_LOW = GPIO_INT_LOW_0,
-	/* Trigger detection when input state is (or transitions to)
+	/** Trigger detection when input state is (or transitions to)
 	 * physical high. (Edge Rising or Active High) */
 	GPIO_INT_TRIG_HIGH = GPIO_INT_HIGH_1,
-	/* Trigger detection on pin rising or falling edge. */
+	/** Trigger detection on pin rising or falling edge. */
 	GPIO_INT_TRIG_BOTH = GPIO_INT_LOW_0 | GPIO_INT_HIGH_1,
-	/* Trigger a system wakeup. */
+	/** Trigger a system wakeup. */
 	GPIO_INT_TRIG_WAKE = GPIO_INT_WAKEUP,
-	/* Trigger a system wakeup when input state is (or transitions to)
+	/** Trigger a system wakeup when input state is (or transitions to)
 	 * physical low. (Edge Falling or Active Low)
 	 */
 	GPIO_INT_TRIG_WAKE_LOW = GPIO_INT_LOW_0 | GPIO_INT_WAKEUP,
-	/* Trigger a system wakeup when input state is (or transitions to)
+	/** Trigger a system wakeup when input state is (or transitions to)
 	 * physical high. (Edge Rising or Active High)
 	 */
 	GPIO_INT_TRIG_WAKE_HIGH = GPIO_INT_HIGH_1 | GPIO_INT_WAKEUP,
-	/* Trigger a system wakeup on pin rising or falling edge. */
+	/** Trigger a system wakeup on pin rising or falling edge. */
 	GPIO_INT_TRIG_WAKE_BOTH = GPIO_INT_LOW_0 | GPIO_INT_HIGH_1 | GPIO_INT_WAKEUP,
 };
 
+/**
+ * @brief Callback API to configure a single pin.
+ * See gpio_pin_configure() for argument description.
+ */
+typedef int (*gpio_api_pin_configure_t)(const struct device *port, gpio_pin_t pin,
+					gpio_flags_t flags);
+
+#if defined(CONFIG_GPIO_GET_CONFIG) || defined(__DOXYGEN__)
+/**
+ * @brief Callback API to get the configuration of a single pin.
+ * See gpio_pin_get_config() for argument description.
+ */
+typedef int (*gpio_api_pin_get_config_t)(const struct device *port, gpio_pin_t pin,
+					 gpio_flags_t *flags);
+#endif /* CONFIG_GPIO_GET_CONFIG */
+
+/**
+ * @brief Callback API to get the physical level of all input pins in a port.
+ * See gpio_port_get_raw() for argument description.
+ */
+typedef int (*gpio_api_port_get_raw_t)(const struct device *port,
+				       gpio_port_value_t *value);
+
+/**
+ * @brief Callback API to set the physical level of selected output pins in a port.
+ * See gpio_port_set_masked_raw() for argument description.
+ */
+typedef int (*gpio_api_port_set_masked_raw_t)(const struct device *port,
+					      gpio_port_pins_t mask,
+					      gpio_port_value_t value);
+
+/**
+ * @brief Callback API to set the physical level of selected output pins to high.
+ * See gpio_port_set_bits_raw() for argument description.
+ */
+typedef int (*gpio_api_port_set_bits_raw_t)(const struct device *port,
+					    gpio_port_pins_t pins);
+
+/**
+ * @brief Callback API to set the physical level of selected output pins to low.
+ * See gpio_port_clear_bits_raw() for argument description.
+ */
+typedef int (*gpio_api_port_clear_bits_raw_t)(const struct device *port,
+					      gpio_port_pins_t pins);
+
+/**
+ * @brief Callback API to toggle the level of selected output pins.
+ * See gpio_port_toggle_bits() for argument description.
+ */
+typedef int (*gpio_api_port_toggle_bits_t)(const struct device *port,
+					   gpio_port_pins_t pins);
+
+/**
+ * @brief Callback API to configure a pin interrupt.
+ * See gpio_pin_interrupt_configure() for argument description, noting that the
+ * public @c GPIO_INT_* flags are decomposed into @p mode and @p trig before
+ * being passed to the driver.
+ */
+typedef int (*gpio_api_pin_interrupt_configure_t)(const struct device *port,
+						  gpio_pin_t pin,
+						  enum gpio_int_mode mode,
+						  enum gpio_int_trig trig);
+
+/**
+ * @brief Callback API to add or remove an application callback.
+ * See gpio_add_callback() and gpio_remove_callback() for argument description.
+ */
+typedef int (*gpio_api_manage_callback_t)(const struct device *port,
+					  struct gpio_callback *cb,
+					  bool set);
+
+/**
+ * @brief Callback API to get pending interrupts.
+ * See gpio_get_pending_int() for argument description.
+ */
+typedef uint32_t (*gpio_api_get_pending_int_t)(const struct device *dev);
+
+#if defined(CONFIG_GPIO_GET_DIRECTION) || defined(__DOXYGEN__)
+/**
+ * @brief Callback API to get the direction of selected pins in a port.
+ * See gpio_port_get_direction() for argument description.
+ */
+typedef int (*gpio_api_port_get_direction_t)(const struct device *port, gpio_port_pins_t map,
+					     gpio_port_pins_t *inputs, gpio_port_pins_t *outputs);
+#endif /* CONFIG_GPIO_GET_DIRECTION */
+
+/**
+ * @driver_ops{GPIO}
+ */
 __subsystem struct gpio_driver_api {
-	int (*pin_configure)(const struct device *port, gpio_pin_t pin,
-			     gpio_flags_t flags);
-#ifdef CONFIG_GPIO_GET_CONFIG
-	int (*pin_get_config)(const struct device *port, gpio_pin_t pin,
-			      gpio_flags_t *flags);
+	/** @driver_ops_mandatory @copybrief gpio_pin_configure */
+	gpio_api_pin_configure_t pin_configure;
+#if defined(CONFIG_GPIO_GET_CONFIG) || defined(__DOXYGEN__)
+	/**
+	 * @driver_ops_optional @copybrief gpio_pin_get_config
+	 * @kconfig_dep{CONFIG_GPIO_GET_CONFIG}
+	 */
+	gpio_api_pin_get_config_t pin_get_config;
 #endif
-	int (*port_get_raw)(const struct device *port,
-			    gpio_port_value_t *value);
-	int (*port_set_masked_raw)(const struct device *port,
-				   gpio_port_pins_t mask,
-				   gpio_port_value_t value);
-	int (*port_set_bits_raw)(const struct device *port,
-				 gpio_port_pins_t pins);
-	int (*port_clear_bits_raw)(const struct device *port,
-				   gpio_port_pins_t pins);
-	int (*port_toggle_bits)(const struct device *port,
-				gpio_port_pins_t pins);
-	int (*pin_interrupt_configure)(const struct device *port,
-				       gpio_pin_t pin,
-				       enum gpio_int_mode mode,
-				       enum gpio_int_trig trig);
-	int (*manage_callback)(const struct device *port,
-			       struct gpio_callback *cb,
-			       bool set);
-	uint32_t (*get_pending_int)(const struct device *dev);
-#ifdef CONFIG_GPIO_GET_DIRECTION
-	int (*port_get_direction)(const struct device *port, gpio_port_pins_t map,
-				  gpio_port_pins_t *inputs, gpio_port_pins_t *outputs);
+	/** @driver_ops_mandatory @copybrief gpio_port_get_raw */
+	gpio_api_port_get_raw_t port_get_raw;
+	/** @driver_ops_mandatory @copybrief gpio_port_set_masked_raw */
+	gpio_api_port_set_masked_raw_t port_set_masked_raw;
+	/** @driver_ops_mandatory @copybrief gpio_port_set_bits_raw */
+	gpio_api_port_set_bits_raw_t port_set_bits_raw;
+	/** @driver_ops_mandatory @copybrief gpio_port_clear_bits_raw */
+	gpio_api_port_clear_bits_raw_t port_clear_bits_raw;
+	/** @driver_ops_mandatory @copybrief gpio_port_toggle_bits */
+	gpio_api_port_toggle_bits_t port_toggle_bits;
+	/** @driver_ops_optional @copybrief gpio_pin_interrupt_configure */
+	gpio_api_pin_interrupt_configure_t pin_interrupt_configure;
+	/**
+	 * @driver_ops_optional Add or remove an application callback.
+	 * See gpio_add_callback() and gpio_remove_callback().
+	 */
+	gpio_api_manage_callback_t manage_callback;
+	/** @driver_ops_optional @copybrief gpio_get_pending_int */
+	gpio_api_get_pending_int_t get_pending_int;
+#if defined(CONFIG_GPIO_GET_DIRECTION) || defined(__DOXYGEN__)
+	/**
+	 * @driver_ops_optional @copybrief gpio_port_get_direction
+	 * @kconfig_dep{CONFIG_GPIO_GET_DIRECTION}
+	 */
+	gpio_api_port_get_direction_t port_get_direction;
 #endif /* CONFIG_GPIO_GET_DIRECTION */
 };
 
-/**
- * @endcond
- */
+/** @} */
 
 /**
  * @brief Validate that GPIO port is ready.

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -219,28 +219,55 @@ struct i2c_msg {
  */
 typedef void (*i2c_callback_t)(const struct device *dev, int result, void *data);
 
-/**
- * @cond INTERNAL_HIDDEN
- *
- * These are for internal use only, so skip these in
- * public documentation.
- */
 struct i2c_target_config;
 
+/**
+ * @def_driverbackendgroup{I2C,i2c_interface}
+ * @{
+ */
+
+/**
+ * @brief Callback API to configure the I2C controller.
+ * See i2c_configure() for argument description.
+ */
 typedef int (*i2c_api_configure_t)(const struct device *dev,
 				   uint32_t dev_config);
+
+/**
+ * @brief Callback API to get the current configuration of the I2C controller.
+ * See i2c_get_config() for argument description.
+ */
 typedef int (*i2c_api_get_config_t)(const struct device *dev,
 				    uint32_t *dev_config);
+
+/**
+ * @brief Callback API to transfer messages on the I2C bus in controller mode.
+ * See i2c_transfer() for argument description.
+ */
 typedef int (*i2c_api_full_io_t)(const struct device *dev,
 				 struct i2c_msg *msgs,
 				 uint8_t num_msgs,
 				 uint16_t addr);
+
+/**
+ * @brief Callback API to register a target device on the I2C controller.
+ * See i2c_target_register() for argument description.
+ */
 typedef int (*i2c_api_target_register_t)(const struct device *dev,
 					struct i2c_target_config *cfg);
+
+/**
+ * @brief Callback API to unregister a target device from the I2C controller.
+ * See i2c_target_unregister() for argument description.
+ */
 typedef int (*i2c_api_target_unregister_t)(const struct device *dev,
 					  struct i2c_target_config *cfg);
 
-#ifdef CONFIG_I2C_CALLBACK
+#if defined(CONFIG_I2C_CALLBACK) || defined(__DOXYGEN__)
+/**
+ * @brief Callback API to transfer messages on the I2C bus asynchronously.
+ * See i2c_transfer_cb() for argument description.
+ */
 typedef int (*i2c_api_transfer_cb_t)(const struct device *dev,
 				 struct i2c_msg *msgs,
 				 uint8_t num_msgs,
@@ -249,39 +276,76 @@ typedef int (*i2c_api_transfer_cb_t)(const struct device *dev,
 				 void *userdata);
 #endif /* CONFIG_I2C_CALLBACK */
 
-#ifdef CONFIG_I2C_RTIO
+#if defined(CONFIG_I2C_RTIO) || defined(__DOXYGEN__)
+/**
+ * @brief Callback API to submit an RTIO request to the I2C controller.
+ * See i2c_iodev_submit() for argument description.
+ */
 typedef void (*i2c_api_iodev_submit)(const struct device *dev,
 				     struct rtio_iodev_sqe *iodev_sqe);
 #endif /* CONFIG_I2C_RTIO */
 
+/**
+ * @brief Callback API to recover the I2C bus.
+ * See i2c_recover_bus() for argument description.
+ */
 typedef int (*i2c_api_recover_bus_t)(const struct device *dev);
 
+/**
+ * @driver_ops{I2C}
+ */
 __subsystem struct i2c_driver_api {
+	/** @driver_ops_mandatory @copybrief i2c_configure */
 	i2c_api_configure_t configure;
+	/** @driver_ops_optional @copybrief i2c_get_config */
 	i2c_api_get_config_t get_config;
+	/** @driver_ops_mandatory @copybrief i2c_transfer */
 	i2c_api_full_io_t transfer;
+	/** @driver_ops_optional @copybrief i2c_target_register */
 	i2c_api_target_register_t target_register;
+	/** @driver_ops_optional @copybrief i2c_target_unregister */
 	i2c_api_target_unregister_t target_unregister;
-#ifdef CONFIG_I2C_CALLBACK
+#if defined(CONFIG_I2C_CALLBACK) || defined(__DOXYGEN__)
+	/**
+	 * @driver_ops_optional @copybrief i2c_transfer_cb
+	 * @kconfig_dep{CONFIG_I2C_CALLBACK}
+	 */
 	i2c_api_transfer_cb_t transfer_cb;
 #endif
-#ifdef CONFIG_I2C_RTIO
+#if defined(CONFIG_I2C_RTIO) || defined(__DOXYGEN__)
+	/**
+	 * @driver_ops_optional @copybrief i2c_iodev_submit
+	 * @kconfig_dep{CONFIG_I2C_RTIO}
+	 */
 	i2c_api_iodev_submit iodev_submit;
 #endif
+	/** @driver_ops_optional @copybrief i2c_recover_bus */
 	i2c_api_recover_bus_t recover_bus;
 };
 
+/**
+ * @brief Callback API to instruct the I2C target device to register itself.
+ * See i2c_target_driver_register() for argument description.
+ */
 typedef int (*i2c_target_api_register_t)(const struct device *dev);
+
+/**
+ * @brief Callback API to instruct the I2C target device to unregister itself.
+ * See i2c_target_driver_unregister() for argument description.
+ */
 typedef int (*i2c_target_api_unregister_t)(const struct device *dev);
 
+/**
+ * @driver_ops{I2C Target}
+ */
 __subsystem struct i2c_target_driver_api {
+	/** @driver_ops_mandatory @copybrief i2c_target_driver_register */
 	i2c_target_api_register_t driver_register;
+	/** @driver_ops_mandatory @copybrief i2c_target_driver_unregister */
 	i2c_target_api_unregister_t driver_unregister;
 };
 
-/**
- * @endcond
- */
+/** @} */
 
 /** Target device responds to 10-bit addressing. */
 #define I2C_TARGET_FLAGS_ADDR_10_BITS	BIT(0)

--- a/include/zephyr/drivers/i3c.h
+++ b/include/zephyr/drivers/i3c.h
@@ -544,9 +544,198 @@ struct i3c_i2c_device_desc;
 struct i3c_target_config;
 struct i3c_config_target;
 
+/** @endcond */
+
+/**
+ * @def_driverbackendgroup{I3C,i3c_interface}
+ * @{
+ */
+
+/**
+ * @brief Configure the I3C hardware.
+ * See i3c_configure() for argument description.
+ */
+typedef int (*i3c_api_configure_t)(const struct device *dev,
+				   enum i3c_config_type type, void *config);
+
+/**
+ * @brief Get configuration of the I3C hardware.
+ * See i3c_config_get() for argument description.
+ */
+typedef int (*i3c_api_config_get_t)(const struct device *dev,
+				    enum i3c_config_type type, void *config);
+
+/**
+ * @brief Attempt bus recovery on the I3C bus.
+ * See i3c_recover_bus() for argument description.
+ */
+typedef int (*i3c_api_recover_bus_t)(const struct device *dev);
+
+/**
+ * @brief Attach an I3C device to the controller.
+ * See i3c_attach_i3c_device() for argument description.
+ */
+typedef int (*i3c_api_attach_i3c_device_t)(const struct device *dev,
+					   struct i3c_device_desc *target);
+
+/**
+ * @brief Reattach an I3C device to the controller after an address change.
+ * See i3c_reattach_i3c_device() for argument description.
+ */
+typedef int (*i3c_api_reattach_i3c_device_t)(const struct device *dev,
+					     struct i3c_device_desc *target,
+					     uint8_t old_dyn_addr);
+
+/**
+ * @brief Detach an I3C device from the controller.
+ * See i3c_detach_i3c_device() for argument description.
+ */
+typedef int (*i3c_api_detach_i3c_device_t)(const struct device *dev,
+					   struct i3c_device_desc *target);
+
+/**
+ * @brief Attach an I2C device to the controller.
+ * See i3c_attach_i2c_device() for argument description.
+ */
+typedef int (*i3c_api_attach_i2c_device_t)(const struct device *dev,
+					   struct i3c_i2c_device_desc *target);
+
+/**
+ * @brief Detach an I2C device from the controller.
+ * See i3c_detach_i2c_device() for argument description.
+ */
+typedef int (*i3c_api_detach_i2c_device_t)(const struct device *dev,
+					   struct i3c_i2c_device_desc *target);
+
+/**
+ * @brief Perform Dynamic Address Assignment via ENTDAA.
+ * See i3c_do_daa() for argument description.
+ */
+typedef int (*i3c_api_do_daa_t)(const struct device *dev);
+
+/**
+ * @brief Send a Common Command Code (CCC) to the bus.
+ * See i3c_do_ccc() for argument description.
+ */
+typedef int (*i3c_api_do_ccc_t)(const struct device *dev,
+				struct i3c_ccc_payload *payload);
+
+/**
+ * @brief Transfer messages in I3C mode.
+ * See i3c_transfer() for argument description.
+ */
+typedef int (*i3c_api_i3c_xfers_t)(const struct device *dev,
+				   struct i3c_device_desc *target,
+				   struct i3c_msg *msgs,
+				   uint8_t num_msgs);
+
+/**
+ * @brief Send an async Common Command Code (CCC) with a callback.
+ * See i3c_do_ccc_cb() for argument description.
+ */
+typedef int (*i3c_api_do_ccc_cb_t)(const struct device *dev,
+				   struct i3c_ccc_payload *payload,
+				   i3c_callback_t cb,
+				   void *userdata);
+
+/**
+ * @brief Transfer async messages in I3C mode with a callback.
+ * See i3c_transfer_cb() for argument description.
+ */
+typedef int (*i3c_api_i3c_xfers_cb_t)(const struct device *dev,
+				      struct i3c_device_desc *target,
+				      struct i3c_msg *msgs,
+				      uint8_t num_msgs,
+				      i3c_callback_t cb,
+				      void *userdata);
+
+/**
+ * @brief Find a registered I3C target device.
+ * See i3c_device_find() for argument description.
+ */
+typedef struct i3c_device_desc *(*i3c_api_i3c_device_find_t)(const struct device *dev,
+							     const struct i3c_device_id *id);
+
+/**
+ * @brief Raise an In-Band Interrupt (IBI).
+ * See i3c_ibi_raise() for argument description.
+ */
+typedef int (*i3c_api_ibi_raise_t)(const struct device *dev,
+				   struct i3c_ibi *request);
+
+/**
+ * @brief ACK or NACK In-Band Interrupt Hot-Join (HJ) requests.
+ * See i3c_ibi_hj_response() for argument description.
+ */
+typedef int (*i3c_api_ibi_hj_response_t)(const struct device *dev,
+					 bool ack);
+
+/**
+ * @brief ACK or NACK In-Band Interrupt Controller Role Requests.
+ * See i3c_ibi_crr_response() for argument description.
+ */
+typedef int (*i3c_api_ibi_crr_response_t)(struct i3c_device_desc *target,
+					  bool ack);
+
+/**
+ * @brief Enable receiving IBI from a target.
+ * See i3c_ibi_enable() for argument description.
+ */
+typedef int (*i3c_api_ibi_enable_t)(const struct device *dev,
+				    struct i3c_device_desc *target);
+
+/**
+ * @brief Disable receiving IBI from a target.
+ * See i3c_ibi_disable() for argument description.
+ */
+typedef int (*i3c_api_ibi_disable_t)(const struct device *dev,
+				     struct i3c_device_desc *target);
+
+/**
+ * @brief Register config as target device of a controller.
+ * See i3c_target_register() for argument description.
+ */
+typedef int (*i3c_api_target_register_t)(const struct device *dev,
+					 struct i3c_target_config *cfg);
+
+/**
+ * @brief Unregister config as target device of a controller.
+ * See i3c_target_unregister() for argument description.
+ */
+typedef int (*i3c_api_target_unregister_t)(const struct device *dev,
+					   struct i3c_target_config *cfg);
+
+/**
+ * @brief Write to the target's TX FIFO.
+ * See i3c_target_tx_write() for argument description.
+ */
+typedef int (*i3c_api_target_tx_write_t)(const struct device *dev,
+					 uint8_t *buf, uint16_t len, uint8_t hdr_mode);
+
+/**
+ * @brief Accept or decline controller handoffs.
+ * See i3c_target_controller_handoff() for argument description.
+ */
+typedef int (*i3c_api_target_controller_handoff_t)(const struct device *dev,
+						   bool accept);
+
+/**
+ * @brief Submit request(s) to the I3C controller with RTIO.
+ * See i3c_iodev_submit() for argument description.
+ */
+typedef void (*i3c_api_iodev_submit_t)(const struct device *dev,
+				       struct rtio_iodev_sqe *iodev_sqe);
+
+/**
+ * @driver_ops{I3C}
+ */
 __subsystem struct i3c_driver_api {
 	/**
-	 * For backward compatibility to I2C API.
+	 * @driver_ops_optional I2C driver operations, for backward
+	 * compatibility to the I2C API.
+	 *
+	 * Must be implemented for the controller to communicate with
+	 * I2C devices on the I3C bus.
 	 *
 	 * @see i2c_driver_api for more information.
 	 *
@@ -557,396 +746,176 @@ __subsystem struct i3c_driver_api {
 	struct i2c_driver_api i2c_api;
 
 	/**
-	 * Configure the I3C hardware.
-	 *
-	 * @see i3c_configure()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 * @param type Type of configuration parameters being passed
-	 *             in @p config.
-	 * @param config Pointer to the configuration parameters.
-	 *
-	 * @return See i3c_configure()
+	 * @driver_ops_optional @copybrief i3c_configure
 	 */
-	int (*configure)(const struct device *dev,
-			 enum i3c_config_type type, void *config);
+	i3c_api_configure_t configure;
 
 	/**
-	 * Get configuration of the I3C hardware.
-	 *
-	 * @see i3c_config_get()
-	 *
-	 * @param[in] dev Pointer to controller device driver instance.
-	 * @param[in] type Type of configuration parameters being passed
-	 *                 in @p config.
-	 * @param[in, out] config Pointer to the configuration parameters.
-	 *
-	 * @return See i3c_config_get()
+	 * @driver_ops_optional @copybrief i3c_config_get
 	 */
-	int (*config_get)(const struct device *dev,
-			  enum i3c_config_type type, void *config);
+	i3c_api_config_get_t config_get;
 #if defined(CONFIG_I3C_CONTROLLER) || defined(__DOXYGEN__)
 	/**
-	 * Perform bus recovery
-	 *
-	 * Controller only API.
-	 *
-	 * @see i3c_recover_bus()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 *
-	 * @return See i3c_recover_bus()
+	 * @driver_ops_optional @copybrief i3c_recover_bus
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 */
-	int (*recover_bus)(const struct device *dev);
+	i3c_api_recover_bus_t recover_bus;
 
 	/**
-	 * I3C Device Attach
-	 *
-	 * Optional API.
-	 *
-	 * @see i3c_attach_i3c_device()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 * @param target Pointer to target device descriptor.
-	 *
-	 * @return See i3c_attach_i3c_device()
+	 * @driver_ops_optional @copybrief i3c_attach_i3c_device
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 */
-	int (*attach_i3c_device)(const struct device *dev,
-				 struct i3c_device_desc *target);
+	i3c_api_attach_i3c_device_t attach_i3c_device;
 
 	/**
-	 * I3C Address Update
-	 *
-	 * Optional API.
-	 *
-	 * @see i3c_reattach_i3c_device()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 * @param target Pointer to target device descriptor.
-	 * @param old_dyn_addr Old dynamic address
-	 *
-	 * @return See i3c_reattach_i3c_device()
+	 * @driver_ops_optional @copybrief i3c_reattach_i3c_device
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 */
-	int (*reattach_i3c_device)(const struct device *dev,
-				   struct i3c_device_desc *target,
-				   uint8_t old_dyn_addr);
+	i3c_api_reattach_i3c_device_t reattach_i3c_device;
 
 	/**
-	 * I3C Device Detach
-	 *
-	 * Optional API.
-	 *
-	 * @see i3c_detach_i3c_device()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 * @param target Pointer to target device descriptor.
-	 *
-	 * @return See i3c_detach_i3c_device()
+	 * @driver_ops_optional @copybrief i3c_detach_i3c_device
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 */
-	int (*detach_i3c_device)(const struct device *dev,
-				 struct i3c_device_desc *target);
+	i3c_api_detach_i3c_device_t detach_i3c_device;
 
 	/**
-	 * I2C Device Attach
-	 *
-	 * Optional API.
-	 *
-	 * @see i3c_attach_i2c_device()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 * @param target Pointer to target device descriptor.
-	 *
-	 * @return See i3c_attach_i2c_device()
+	 * @driver_ops_optional @copybrief i3c_attach_i2c_device
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 */
-	int (*attach_i2c_device)(const struct device *dev,
-				 struct i3c_i2c_device_desc *target);
+	i3c_api_attach_i2c_device_t attach_i2c_device;
 
 	/**
-	 * I2C Device Detach
-	 *
-	 * Optional API.
-	 *
-	 * @see i3c_detach_i2c_device()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 * @param target Pointer to target device descriptor.
-	 *
-	 * @return See i3c_detach_i2c_device()
+	 * @driver_ops_optional @copybrief i3c_detach_i2c_device
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 */
-	int (*detach_i2c_device)(const struct device *dev,
-				 struct i3c_i2c_device_desc *target);
+	i3c_api_detach_i2c_device_t detach_i2c_device;
 
 	/**
-	 * Perform Dynamic Address Assignment via ENTDAA.
-	 *
-	 * Controller only API.
-	 *
-	 * @see i3c_do_daa()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 *
-	 * @return See i3c_do_daa()
+	 * @driver_ops_optional @copybrief i3c_do_daa
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 */
-	int (*do_daa)(const struct device *dev);
+	i3c_api_do_daa_t do_daa;
 
 	/**
-	 * Send Common Command Code (CCC).
-	 *
-	 * Controller only API.
-	 *
-	 * @see i3c_do_ccc()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 * @param payload Pointer to the CCC payload.
-	 *
-	 * @return See i3c_do_ccc()
+	 * @driver_ops_optional @copybrief i3c_do_ccc
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 */
-	int (*do_ccc)(const struct device *dev,
-		      struct i3c_ccc_payload *payload);
+	i3c_api_do_ccc_t do_ccc;
 
 	/**
-	 * Transfer messages in I3C mode.
-	 *
-	 * @see i3c_transfer()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 * @param target Pointer to target device descriptor.
-	 * @param msg Pointer to I3C messages.
-	 * @param num_msgs Number of messages to transfer.
-	 *
-	 * @return See i3c_transfer()
+	 * @driver_ops_mandatory @copybrief i3c_transfer
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 */
-	int (*i3c_xfers)(const struct device *dev,
-			 struct i3c_device_desc *target,
-			 struct i3c_msg *msgs,
-			 uint8_t num_msgs);
+	i3c_api_i3c_xfers_t i3c_xfers;
 #if defined(CONFIG_I3C_CALLBACK) || defined(__DOXYGEN__)
 	/**
-	 * Send async Common Command Code (CCC) with a callback.
-	 *
-	 * Controller only API.
-	 *
-	 * @see i3c_do_ccc_cb()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 * @param payload Pointer to the CCC payload.
-	 * @param cb Function pointer for completion callback.
-	 * @param userdata Userdata passed to callback.
-	 *
-	 * @return See i3c_do_ccc_cb()
+	 * @driver_ops_optional @copybrief i3c_do_ccc_cb
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER,CONFIG_I3C_CALLBACK}
 	 */
-	int (*do_ccc_cb)(const struct device *dev,
-			 struct i3c_ccc_payload *payload,
-			 i3c_callback_t cb,
-			 void *userdata);
+	i3c_api_do_ccc_cb_t do_ccc_cb;
 
 	/**
-	 * Transfer async messages in I3C mode with a callback.
-	 *
-	 * @see i3c_transfer_cb()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 * @param target Pointer to target device descriptor.
-	 * @param msg Pointer to I3C messages.
-	 * @param num_msgs Number of messages to transfer.
-	 * @param cb Function pointer for completion callback.
-	 * @param userdata Userdata passed to callback.
-	 *
-	 * @return See i3c_transfer_cb()
+	 * @driver_ops_optional @copybrief i3c_transfer_cb
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER,CONFIG_I3C_CALLBACK}
 	 */
-	int (*i3c_xfers_cb)(const struct device *dev,
-			    struct i3c_device_desc *target,
-			    struct i3c_msg *msgs,
-			    uint8_t num_msgs,
-			    i3c_callback_t cb,
-			    void *userdata);
+	i3c_api_i3c_xfers_cb_t i3c_xfers_cb;
 #endif
 	/**
-	 * Find a registered I3C target device.
-	 *
-	 * Controller only API.
-	 *
-	 * This returns the I3C device descriptor of the I3C device
-	 * matching the incoming @p id.
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 * @param id Pointer to I3C device ID.
-	 *
-	 * @return See i3c_device_find().
+	 * @driver_ops_optional Find a registered I3C target device.
+	 * @kconfig_dep{CONFIG_I3C_CONTROLLER}
 	 */
-	struct i3c_device_desc *(*i3c_device_find)(const struct device *dev,
-						   const struct i3c_device_id *id);
+	i3c_api_i3c_device_find_t i3c_device_find;
 #endif /* CONFIG_I3C_CONTROLLER */
-#ifdef CONFIG_I3C_USE_IBI
+#if defined(CONFIG_I3C_USE_IBI) || defined(__DOXYGEN__)
 #if defined(CONFIG_I3C_TARGET) || defined(__DOXYGEN__)
 	/**
-	 * Raise In-Band Interrupt (IBI).
-	 *
-	 * Target device only API.
-	 *
-	 * @see i3c_ibi_request()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 * @param request Pointer to IBI request struct.
-	 *
-	 * @return See i3c_ibi_request()
+	 * @driver_ops_optional @copybrief i3c_ibi_raise
+	 * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_TARGET}
 	 */
-	int (*ibi_raise)(const struct device *dev,
-			 struct i3c_ibi *request);
+	i3c_api_ibi_raise_t ibi_raise;
 #endif /* CONFIG_I3C_TARGET */
 #if defined(CONFIG_I3C_CONTROLLER) || defined(__DOXYGEN__)
 	/**
-	 * ACK or NACK IBI HJ Requests
-	 *
-	 * @see ibi_hj_response()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 * @param ack True to ack, False to nack
-	 *
-	 * @return See ibi_hj_response()
+	 * @driver_ops_optional @copybrief i3c_ibi_hj_response
+	 * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_CONTROLLER}
 	 */
-	int (*ibi_hj_response)(const struct device *dev,
-			       bool ack);
+	i3c_api_ibi_hj_response_t ibi_hj_response;
 
 	/**
-	 * ACK or NACK IBI Controller Role Requests
-	 *
-	 * @see i3c_ibi_crr_response()
-	 *
-	 * @param target Pointer to target device descriptor.
-	 * @param ack True to ack, False to nack
-	 *
-	 * @return See i3c_ibi_crr_response()
+	 * @driver_ops_optional @copybrief i3c_ibi_crr_response
+	 * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_CONTROLLER}
 	 */
-	int (*ibi_crr_response)(struct i3c_device_desc *target,
-				bool ack);
+	i3c_api_ibi_crr_response_t ibi_crr_response;
 
 	/**
-	 * Enable receiving IBI from a target.
-	 *
-	 * Controller only API.
-	 *
-	 * @see i3c_ibi_enable()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 * @param target Pointer to target device descriptor.
-	 *
-	 * @return See i3c_ibi_enable()
+	 * @driver_ops_optional @copybrief i3c_ibi_enable
+	 * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_CONTROLLER}
 	 */
-	int (*ibi_enable)(const struct device *dev,
-			  struct i3c_device_desc *target);
+	i3c_api_ibi_enable_t ibi_enable;
 
 	/**
-	 * Disable receiving IBI from a target.
-	 *
-	 * Controller only API.
-	 *
-	 * @see i3c_ibi_disable()
-	 *
-	 * @param dev Pointer to controller device driver instance.
-	 * @param target Pointer to target device descriptor.
-	 *
-	 * @return See i3c_ibi_disable()
+	 * @driver_ops_optional @copybrief i3c_ibi_disable
+	 * @kconfig_dep{CONFIG_I3C_USE_IBI,CONFIG_I3C_CONTROLLER}
 	 */
-	int (*ibi_disable)(const struct device *dev,
-			   struct i3c_device_desc *target);
+	i3c_api_ibi_disable_t ibi_disable;
 #endif /* CONFIG_I3C_CONTROLLER */
 #endif /* CONFIG_I3C_USE_IBI */
 #if defined(CONFIG_I3C_TARGET) || defined(__DOXYGEN__)
 	/**
-	 * Register config as target device of a controller.
+	 * @driver_ops_optional @copybrief i3c_target_register
 	 *
 	 * This tells the controller to act as a target device
 	 * on the I3C bus.
 	 *
-	 * Target device only API.
-	 *
-	 * @see i3c_target_register()
-	 *
-	 * @param dev Pointer to the controller device driver instance.
-	 * @param cfg I3C target device configuration
-	 *
-	 * @return See i3c_target_register()
+	 * @kconfig_dep{CONFIG_I3C_TARGET}
 	 */
-	int (*target_register)(const struct device *dev,
-			       struct i3c_target_config *cfg);
+	i3c_api_target_register_t target_register;
 
 	/**
-	 * Unregister config as target device of a controller.
+	 * @driver_ops_optional @copybrief i3c_target_unregister
 	 *
 	 * This tells the controller to stop acting as a target device
 	 * on the I3C bus.
 	 *
-	 * Target device only API.
-	 *
-	 * @see i3c_target_unregister()
-	 *
-	 * @param dev Pointer to the controller device driver instance.
-	 * @param cfg I3C target device configuration
-	 *
-	 * @return See i3c_target_unregister()
+	 * @kconfig_dep{CONFIG_I3C_TARGET}
 	 */
-	int (*target_unregister)(const struct device *dev,
-				 struct i3c_target_config *cfg);
+	i3c_api_target_unregister_t target_unregister;
 
 	/**
-	 * Write to the TX FIFO
-	 *
-	 * This writes to the target tx fifo
-	 *
-	 * Target device only API.
-	 *
-	 * @see i3c_target_tx_write()
-	 *
-	 * @param dev Pointer to the controller device driver instance.
-	 * @param buf Pointer to the buffer
-	 * @param len Length of the buffer
-	 * @param hdr_mode HDR mode
-	 *
-	 * @return See i3c_target_tx_write()
+	 * @driver_ops_optional @copybrief i3c_target_tx_write
+	 * @kconfig_dep{CONFIG_I3C_TARGET}
 	 */
-	int (*target_tx_write)(const struct device *dev,
-			       uint8_t *buf, uint16_t len, uint8_t hdr_mode);
+	i3c_api_target_tx_write_t target_tx_write;
 
 	/**
-	 * ACK or NACK controller handoffs
+	 * @driver_ops_optional @copybrief i3c_target_controller_handoff
 	 *
 	 * This will tell the target to ACK or NACK controller handoffs
-	 * from the CCC GETACCCR
+	 * from the CCC GETACCCR.
 	 *
-	 * Target device only API.
-	 *
-	 * @see i3c_target_controller_handoff()
-	 *
-	 * @param dev Pointer to the controller device driver instance.
-	 * @param accept True to ACK controller handoffs, False to NACK.
-	 *
-	 * @return See i3c_target_controller_handoff()
+	 * @kconfig_dep{CONFIG_I3C_TARGET}
 	 */
-	int (*target_controller_handoff)(const struct device *dev,
-					 bool accept);
+	i3c_api_target_controller_handoff_t target_controller_handoff;
 #endif /* CONFIG_I3C_TARGET */
 #if defined(CONFIG_I3C_RTIO) || defined(__DOXYGEN__)
 	/**
-	 * RTIO
+	 * @driver_ops_optional @copybrief i3c_iodev_submit
 	 *
-	 * @see i3c_iodev_submit()
+	 * Drivers without native RTIO support may set this to
+	 * i3c_iodev_submit_fallback().
 	 *
-	 * @param dev Pointer to the controller device driver instance.
-	 * @param iodev_sqe Pointer to the
-	 *
-	 * @return See i3c_iodev_submit()
+	 * @kconfig_dep{CONFIG_I3C_RTIO}
 	 */
-	void (*iodev_submit)(const struct device *dev,
-			     struct rtio_iodev_sqe *iodev_sqe);
+	i3c_api_iodev_submit_t iodev_submit;
 #endif /* CONFIG_I3C_RTIO */
 };
 
-DEVICE_API_EXTENDS(i3c, i2c, i2c_api);
+/** @} */
 
-/**
- * @endcond
- */
+/** @cond INTERNAL_HIDDEN */
+DEVICE_API_EXTENDS(i3c, i2c, i2c_api);
+/** @endcond */
 
 /**
  * @brief Structure used for matching I3C devices.

--- a/include/zephyr/drivers/i3c/target_device.h
+++ b/include/zephyr/drivers/i3c/target_device.h
@@ -267,10 +267,38 @@ struct i3c_target_callbacks {
 	int (*controller_handoff_cb)(struct i3c_target_config *config);
 };
 
+/**
+ * @def_driverbackendgroup{I3C Target Device,i3c_target_device}
+ * @{
+ */
+
+/**
+ * @brief Instruct the I3C target device driver to register itself with its bus controller.
+ */
+typedef int (*i3c_target_api_driver_register_t)(const struct device *dev);
+
+/**
+ * @brief Instruct the I3C target device driver to unregister itself from its bus controller.
+ */
+typedef int (*i3c_target_api_driver_unregister_t)(const struct device *dev);
+
+/**
+ * @driver_ops{I3C Target Device}
+ */
 __subsystem struct i3c_target_driver_api {
-	int (*driver_register)(const struct device *dev);
-	int (*driver_unregister)(const struct device *dev);
+	/**
+	 * @driver_ops_mandatory Instruct the I3C target device driver to register itself with
+	 * its bus controller.
+	 */
+	i3c_target_api_driver_register_t driver_register;
+	/**
+	 * @driver_ops_mandatory Instruct the I3C target device driver to unregister itself from
+	 * its bus controller.
+	 */
+	i3c_target_api_driver_unregister_t driver_unregister;
 };
+
+/** @} */
 
 /**
  * @brief Accept or Decline Controller Handoffs

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -53,6 +53,11 @@ struct led_info {
 };
 
 /**
+ * @def_driverbackendgroup{LED,led_interface}
+ * @{
+ */
+
+/**
  * @brief Callback API for blinking an LED
  *
  * @see led_blink() for argument descriptions.
@@ -100,7 +105,7 @@ typedef int (*led_api_off)(const struct device *dev, uint32_t led);
 /**
  * @brief Callback API for writing a strip of LED channels
  *
- * @see led_api_write_channels() for arguments descriptions.
+ * @see led_write_channels() for arguments descriptions.
  */
 typedef int (*led_api_write_channels)(const struct device *dev,
 				      uint32_t start_channel,
@@ -108,19 +113,43 @@ typedef int (*led_api_write_channels)(const struct device *dev,
 				      const uint8_t *buf);
 
 /**
- * @brief LED driver API
+ * @driver_ops{LED}
+ *
+ * @note A driver must implement at least @ref led_driver_api.set_brightness, or both
+ * @ref led_driver_api.on and @ref led_driver_api.off. The subsystem emulates each of these
+ * operations with the other(s) when it is not provided.
  */
 __subsystem struct led_driver_api {
-	/* Mandatory callbacks, either on/off or set_brightness. */
+	/**
+	 * @driver_ops_optional @copybrief led_on
+	 *
+	 * Mandatory if @ref led_driver_api.set_brightness is not implemented.
+	 */
 	led_api_on on;
+	/**
+	 * @driver_ops_optional @copybrief led_off
+	 *
+	 * Mandatory if @ref led_driver_api.set_brightness is not implemented.
+	 */
 	led_api_off off;
+	/**
+	 * @driver_ops_optional @copybrief led_set_brightness
+	 *
+	 * Mandatory if @ref led_driver_api.on and @ref led_driver_api.off are not
+	 * implemented.
+	 */
 	led_api_set_brightness set_brightness;
-	/* Optional callbacks. */
+	/** @driver_ops_optional @copybrief led_blink */
 	led_api_blink blink;
+	/** @driver_ops_optional @copybrief led_get_info */
 	led_api_get_info get_info;
+	/** @driver_ops_optional @copybrief led_set_color */
 	led_api_set_color set_color;
+	/** @driver_ops_optional @copybrief led_write_channels */
 	led_api_write_channels write_channels;
 };
+
+/** @} */
 
 /**
  * @brief Blink an LED

--- a/include/zephyr/drivers/mdio.h
+++ b/include/zephyr/drivers/mdio.h
@@ -29,30 +29,57 @@ extern "C" {
 #endif
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * These are for internal use only, so skip these in
- * public documentation.
+ * @def_driverbackendgroup{MDIO,mdio_interface}
+ * @{
+ */
+
+/**
+ * @brief Read data from MDIO bus.
+ * See mdio_read() for argument description.
+ */
+typedef int (*mdio_api_read_t)(const struct device *dev, uint8_t prtad, uint8_t regad,
+			       uint16_t *data);
+
+/**
+ * @brief Write data to MDIO bus.
+ * See mdio_write() for argument description.
+ */
+typedef int (*mdio_api_write_t)(const struct device *dev, uint8_t prtad, uint8_t regad,
+				uint16_t data);
+
+/**
+ * @brief Read data from MDIO bus using Clause 45 access.
+ * See mdio_read_c45() for argument description.
+ */
+typedef int (*mdio_api_read_c45_t)(const struct device *dev, uint8_t prtad, uint8_t devad,
+				   uint16_t regad, uint16_t *data);
+
+/**
+ * @brief Write data to MDIO bus using Clause 45 access.
+ * See mdio_write_c45() for argument description.
+ */
+typedef int (*mdio_api_write_c45_t)(const struct device *dev, uint8_t prtad, uint8_t devad,
+				    uint16_t regad, uint16_t data);
+
+/**
+ * @driver_ops{MDIO}
  */
 __subsystem struct mdio_driver_api {
-	/** Read data from MDIO bus */
-	int (*read)(const struct device *dev, uint8_t prtad, uint8_t regad,
-		    uint16_t *data);
+	/** @driver_ops_optional @copybrief mdio_read */
+	mdio_api_read_t read;
 
-	/** Write data to MDIO bus */
-	int (*write)(const struct device *dev, uint8_t prtad, uint8_t regad,
-		     uint16_t data);
+	/** @driver_ops_optional @copybrief mdio_write */
+	mdio_api_write_t write;
 
-	/** Read data from MDIO bus using Clause 45 access */
-	int (*read_c45)(const struct device *dev, uint8_t prtad, uint8_t devad,
-			uint16_t regad, uint16_t *data);
+	/** @driver_ops_optional @copybrief mdio_read_c45 */
+	mdio_api_read_c45_t read_c45;
 
-	/** Write data to MDIO bus using Clause 45 access */
-	int (*write_c45)(const struct device *dev, uint8_t prtad, uint8_t devad,
-			 uint16_t regad, uint16_t data);
+	/** @driver_ops_optional @copybrief mdio_write_c45 */
+	mdio_api_write_c45_t write_c45;
 };
+
 /**
- * @endcond
+ * @}
  */
 
 /**

--- a/include/zephyr/drivers/mipi_dsi.h
+++ b/include/zephyr/drivers/mipi_dsi.h
@@ -121,15 +121,47 @@ struct mipi_dsi_msg {
 	void *user_data;
 };
 
-/** MIPI-DSI host driver API. */
+/**
+ * @def_driverbackendgroup{MIPI-DSI,mipi_dsi_interface}
+ * @{
+ */
+
+/**
+ * @brief Attach a new device to the MIPI-DSI bus.
+ * See mipi_dsi_attach() for argument description.
+ */
+typedef int (*mipi_dsi_api_attach_t)(const struct device *dev, uint8_t channel,
+				     const struct mipi_dsi_device *mdev);
+
+/**
+ * @brief Transfer data to/from a device attached to the MIPI-DSI bus.
+ * See mipi_dsi_transfer() for argument description.
+ */
+typedef ssize_t (*mipi_dsi_api_transfer_t)(const struct device *dev, uint8_t channel,
+					   struct mipi_dsi_msg *msg);
+
+/**
+ * @brief Detach a device from the MIPI-DSI bus.
+ * See mipi_dsi_detach() for argument description.
+ */
+typedef int (*mipi_dsi_api_detach_t)(const struct device *dev, uint8_t channel,
+				     const struct mipi_dsi_device *mdev);
+
+/**
+ * @driver_ops{MIPI-DSI}
+ */
 __subsystem struct mipi_dsi_driver_api {
-	int (*attach)(const struct device *dev, uint8_t channel,
-		      const struct mipi_dsi_device *mdev);
-	ssize_t (*transfer)(const struct device *dev, uint8_t channel,
-			    struct mipi_dsi_msg *msg);
-	int (*detach)(const struct device *dev, uint8_t channel,
-		      const struct mipi_dsi_device *mdev);
+	/** @driver_ops_mandatory @copybrief mipi_dsi_attach */
+	mipi_dsi_api_attach_t attach;
+	/** @driver_ops_mandatory @copybrief mipi_dsi_transfer */
+	mipi_dsi_api_transfer_t transfer;
+	/** @driver_ops_optional @copybrief mipi_dsi_detach */
+	mipi_dsi_api_detach_t detach;
 };
+
+/**
+ * @}
+ */
 
 /**
  * @brief Attach a new device to the MIPI-DSI bus.

--- a/include/zephyr/drivers/mspi.h
+++ b/include/zephyr/drivers/mspi.h
@@ -481,49 +481,96 @@ typedef void (*mspi_callback_handler_t)(struct mspi_callback_context *mspi_cb_ct
 /** @} */
 
 /**
- * MSPI driver API definition and system call entry points
+ * @def_driverbackendgroup{MSPI,mspi_interface}
+ * @{
+ */
+
+/**
+ * @brief Configure a MSPI controller.
+ * See mspi_config() for argument description.
  */
 typedef int (*mspi_api_config)(const struct mspi_dt_spec *spec);
 
+/**
+ * @brief Configure a MSPI controller with device specific parameters.
+ * See mspi_dev_config() for argument description.
+ */
 typedef int (*mspi_api_dev_config)(const struct device *controller,
 				   const struct mspi_dev_id *dev_id,
 				   const enum mspi_dev_cfg_mask param_mask,
 				   const struct mspi_dev_cfg *cfg);
 
+/**
+ * @brief Query to see if it a channel is ready.
+ * See mspi_get_channel_status() for argument description.
+ */
 typedef int (*mspi_api_get_channel_status)(const struct device *controller, uint8_t ch);
 
+/**
+ * @brief Transfer request over MSPI.
+ * See mspi_transceive() for argument description.
+ */
 typedef int (*mspi_api_transceive)(const struct device *controller,
 				   const struct mspi_dev_id *dev_id,
 				   const struct mspi_xfer *req);
 
+/**
+ * @brief Register the mspi callback functions.
+ * See mspi_register_callback() for argument description.
+ */
 typedef int (*mspi_api_register_callback)(const struct device *controller,
 					  const struct mspi_dev_id *dev_id,
 					  const enum mspi_bus_event evt_type,
 					  mspi_callback_handler_t cb,
 					  struct mspi_callback_context *ctx);
 
+/**
+ * @brief Configure a MSPI XIP settings.
+ * See mspi_xip_config() for argument description.
+ */
 typedef int (*mspi_api_xip_config)(const struct device *controller,
 				   const struct mspi_dev_id *dev_id,
 				   const struct mspi_xip_cfg *xip_cfg);
 
+/**
+ * @brief Configure a MSPI scrambling settings.
+ * See mspi_scramble_config() for argument description.
+ */
 typedef int (*mspi_api_scramble_config)(const struct device *controller,
 					const struct mspi_dev_id *dev_id,
 					const struct mspi_scramble_cfg *scramble_cfg);
 
+/**
+ * @brief Configure a MSPI timing settings.
+ * See mspi_timing_config() for argument description.
+ */
 typedef int (*mspi_api_timing_config)(const struct device *controller,
 				      const struct mspi_dev_id *dev_id, const uint32_t param_mask,
 				      void *timing_cfg);
 
+/**
+ * @driver_ops{MSPI}
+ */
 __subsystem struct mspi_driver_api {
+	/** @driver_ops_mandatory @copybrief mspi_config */
 	mspi_api_config                config;
+	/** @driver_ops_mandatory @copybrief mspi_dev_config */
 	mspi_api_dev_config            dev_config;
+	/** @driver_ops_mandatory @copybrief mspi_get_channel_status */
 	mspi_api_get_channel_status    get_channel_status;
+	/** @driver_ops_optional @copybrief mspi_transceive */
 	mspi_api_transceive            transceive;
+	/** @driver_ops_optional @copybrief mspi_register_callback */
 	mspi_api_register_callback     register_callback;
+	/** @driver_ops_optional @copybrief mspi_xip_config */
 	mspi_api_xip_config            xip_config;
+	/** @driver_ops_optional @copybrief mspi_scramble_config */
 	mspi_api_scramble_config       scramble_config;
+	/** @driver_ops_optional @copybrief mspi_timing_config */
 	mspi_api_timing_config         timing_config;
 };
+
+/** @} */
 
 /**
  * @addtogroup mspi_configure_api

--- a/include/zephyr/drivers/peci.h
+++ b/include/zephyr/drivers/peci.h
@@ -244,27 +244,49 @@ struct peci_msg {
 };
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * PECI driver API definition and system call entry points
- *
- * (Internal use only.)
+ * @def_driverbackendgroup{PECI,peci_interface}
+ * @{
+ */
+
+/**
+ * @brief Callback API to configure the PECI interface.
+ * See peci_config() for argument description.
  */
 typedef int (*peci_config_t)(const struct device *dev, uint32_t bitrate);
+
+/**
+ * @brief Callback API to perform a PECI transaction.
+ * See peci_transfer() for argument description.
+ */
 typedef int (*peci_transfer_t)(const struct device *dev, struct peci_msg *msg);
+
+/**
+ * @brief Callback API to disable the PECI interface.
+ * See peci_disable() for argument description.
+ */
 typedef int (*peci_disable_t)(const struct device *dev);
+
+/**
+ * @brief Callback API to enable the PECI interface.
+ * See peci_enable() for argument description.
+ */
 typedef int (*peci_enable_t)(const struct device *dev);
 
+/**
+ * @driver_ops{PECI}
+ */
 __subsystem struct peci_driver_api {
+	/** @driver_ops_mandatory @copybrief peci_config */
 	peci_config_t config;
+	/** @driver_ops_mandatory @copybrief peci_disable */
 	peci_disable_t disable;
+	/** @driver_ops_mandatory @copybrief peci_enable */
 	peci_enable_t enable;
+	/** @driver_ops_mandatory @copybrief peci_transfer */
 	peci_transfer_t transfer;
 };
 
-/**
- * @endcond
- */
+/** @} */
 
 /**
  * @brief Configures the PECI interface.

--- a/include/zephyr/drivers/psi5/psi5.h
+++ b/include/zephyr/drivers/psi5/psi5.h
@@ -94,7 +94,10 @@ typedef void (*psi5_tx_callback_t)(const struct device *dev, uint8_t channel, in
 typedef void (*psi5_rx_frame_callback_t)(const struct device *dev, uint8_t channel,
 					 uint32_t num_frame, void *user_data);
 
-/** @cond INTERNAL_HIDDEN */
+/**
+ * @def_driverbackendgroup{PSI5,psi5_interface}
+ * @{
+ */
 
 /**
  * @brief Callback API upon starting sync PSI5
@@ -146,14 +149,21 @@ struct psi5_rx_callback_configs {
 typedef int (*psi5_register_callback_t)(const struct device *dev, uint8_t channel,
 					struct psi5_rx_callback_configs callback_configs);
 
+/**
+ * @driver_ops{PSI5}
+ */
 __subsystem struct psi5_driver_api {
+	/** @driver_ops_optional @copybrief psi5_start_sync */
 	psi5_start_sync_t start_sync;
+	/** @driver_ops_optional @copybrief psi5_stop_sync */
 	psi5_stop_sync_t stop_sync;
+	/** @driver_ops_optional @copybrief psi5_send */
 	psi5_send_t send;
+	/** @driver_ops_optional @copybrief psi5_register_callback */
 	psi5_register_callback_t register_callback;
 };
 
-/** @endcond */
+/** @} */
 
 /**
  * @brief Start the sync pulse generator on a specific channel

--- a/include/zephyr/drivers/ptp_clock.h
+++ b/include/zephyr/drivers/ptp_clock.h
@@ -35,12 +35,58 @@ extern "C" {
 #define PTP_CLOCK_NAME "PTP_CLOCK"
 #endif
 
+/**
+ * @def_driverbackendgroup{PTP Clock,ptp_clock_interface}
+ * @{
+ */
+
+/**
+ * @brief Set the time of the PTP clock.
+ * See ptp_clock_set() for argument description.
+ */
+typedef int (*ptp_clock_api_set_t)(const struct device *dev, struct net_ptp_time *tm);
+
+/**
+ * @brief Get the time of the PTP clock.
+ * See ptp_clock_get() for argument description.
+ */
+typedef int (*ptp_clock_api_get_t)(const struct device *dev, struct net_ptp_time *tm);
+
+/**
+ * @brief Adjust the PTP clock time.
+ * See ptp_clock_adjust() for argument description.
+ */
+typedef int (*ptp_clock_api_adjust_t)(const struct device *dev, int increment);
+
+/**
+ * @brief Adjust the PTP clock rate ratio based on its nominal frequency.
+ * See ptp_clock_rate_adjust() for argument description.
+ */
+typedef int (*ptp_clock_api_rate_adjust_t)(const struct device *dev, double ratio);
+
+/**
+ * @driver_ops{PTP Clock}
+ */
 __subsystem struct ptp_clock_driver_api {
-	int (*set)(const struct device *dev, struct net_ptp_time *tm);
-	int (*get)(const struct device *dev, struct net_ptp_time *tm);
-	int (*adjust)(const struct device *dev, int increment);
-	int (*rate_adjust)(const struct device *dev, double ratio);
+	/**
+	 * @driver_ops_mandatory @copybrief ptp_clock_set
+	 */
+	ptp_clock_api_set_t set;
+	/**
+	 * @driver_ops_mandatory @copybrief ptp_clock_get
+	 */
+	ptp_clock_api_get_t get;
+	/**
+	 * @driver_ops_mandatory @copybrief ptp_clock_adjust
+	 */
+	ptp_clock_api_adjust_t adjust;
+	/**
+	 * @driver_ops_mandatory @copybrief ptp_clock_rate_adjust
+	 */
+	ptp_clock_api_rate_adjust_t rate_adjust;
 };
+
+/** @} */
 
 /**
  * @brief Set the time of the PTP clock.

--- a/include/zephyr/drivers/regulator.h
+++ b/include/zephyr/drivers/regulator.h
@@ -96,67 +96,183 @@ typedef void (*regulator_callback_t)(const struct device *dev,
 				     const struct regulator_event *const evt,
 				     const void *const user_data);
 
-/** @cond INTERNAL_HIDDEN */
+/**
+ * @def_driverbackendgroup{Regulator,regulator_interface}
+ * @{
+ */
 
+/**
+ * @brief Set a DVS state.
+ * See regulator_parent_dvs_state_set() for argument description.
+ */
 typedef int (*regulator_dvs_state_set_t)(const struct device *dev,
 					 regulator_dvs_state_t state);
 
+/**
+ * @brief Enter ship mode.
+ * See regulator_parent_ship_mode() for argument description.
+ */
 typedef int (*regulator_ship_mode_t)(const struct device *dev);
 
-/** @brief Driver-specific API functions to support parent regulator control. */
+/**
+ * @driver_ops{Regulator Parent}
+ */
 __subsystem struct regulator_parent_driver_api {
+	/** @driver_ops_optional @copybrief regulator_parent_dvs_state_set */
 	regulator_dvs_state_set_t dvs_state_set;
+	/** @driver_ops_optional @copybrief regulator_parent_ship_mode */
 	regulator_ship_mode_t ship_mode;
 };
 
+/**
+ * @brief Enable a regulator.
+ * See regulator_enable() for argument description.
+ */
 typedef int (*regulator_enable_t)(const struct device *dev);
+
+/**
+ * @brief Disable a regulator.
+ * See regulator_disable() for argument description.
+ */
 typedef int (*regulator_disable_t)(const struct device *dev);
+
+/**
+ * @brief Obtain the number of supported voltage levels.
+ * See regulator_count_voltages() for argument description.
+ */
 typedef unsigned int (*regulator_count_voltages_t)(const struct device *dev);
+
+/**
+ * @brief Obtain the value of a voltage given an index.
+ * See regulator_list_voltage() for argument description.
+ */
 typedef int (*regulator_list_voltage_t)(const struct device *dev,
 					unsigned int idx, int32_t *volt_uv);
+
+/**
+ * @brief Set the output voltage.
+ * See regulator_set_voltage() for argument description.
+ */
 typedef int (*regulator_set_voltage_t)(const struct device *dev, int32_t min_uv,
 				       int32_t max_uv);
+
+/**
+ * @brief Obtain output voltage.
+ * See regulator_get_voltage() for argument description.
+ */
 typedef int (*regulator_get_voltage_t)(const struct device *dev,
 				       int32_t *volt_uv);
+
+/**
+ * @brief Obtain the number of supported current limit levels.
+ * See regulator_count_current_limits() for argument description.
+ */
 typedef unsigned int (*regulator_count_current_limits_t)(const struct device *dev);
+
+/**
+ * @brief Obtain the value of a current limit given an index.
+ * See regulator_list_current_limit() for argument description.
+ */
 typedef int (*regulator_list_current_limit_t)(const struct device *dev,
 					      unsigned int idx, int32_t *current_ua);
+
+/**
+ * @brief Set output current limit.
+ * See regulator_set_current_limit() for argument description.
+ */
 typedef int (*regulator_set_current_limit_t)(const struct device *dev,
 					     int32_t min_ua, int32_t max_ua);
+
+/**
+ * @brief Get output current limit.
+ * See regulator_get_current_limit() for argument description.
+ */
 typedef int (*regulator_get_current_limit_t)(const struct device *dev,
 					     int32_t *curr_ua);
+
+/**
+ * @brief Set mode.
+ * See regulator_set_mode() for argument description.
+ */
 typedef int (*regulator_set_mode_t)(const struct device *dev,
 				    regulator_mode_t mode);
+
+/**
+ * @brief Get mode.
+ * See regulator_get_mode() for argument description.
+ */
 typedef int (*regulator_get_mode_t)(const struct device *dev,
 				    regulator_mode_t *mode);
+
+/**
+ * @brief Set active discharge setting.
+ * See regulator_set_active_discharge() for argument description.
+ */
 typedef int (*regulator_set_active_discharge_t)(const struct device *dev,
 				    bool active_discharge);
+
+/**
+ * @brief Get active discharge setting.
+ * See regulator_get_active_discharge() for argument description.
+ */
 typedef int (*regulator_get_active_discharge_t)(const struct device *dev,
 				    bool *active_discharge);
+
+/**
+ * @brief Get active error flags.
+ * See regulator_get_error_flags() for argument description.
+ */
 typedef int (*regulator_get_error_flags_t)(
 	const struct device *dev, regulator_error_flags_t *flags);
+
+/**
+ * @brief Set event handler function.
+ * See regulator_set_callback() for argument description.
+ */
 typedef int (*regulator_set_callback_t)(const struct device *dev,
 	regulator_callback_t cb, const void *const user_data);
 
-/** @brief Driver-specific API functions to support regulator control. */
+/**
+ * @driver_ops{Regulator}
+ */
 __subsystem struct regulator_driver_api {
+	/** @driver_ops_optional @copybrief regulator_enable */
 	regulator_enable_t enable;
+	/** @driver_ops_optional @copybrief regulator_disable */
 	regulator_disable_t disable;
+	/** @driver_ops_optional @copybrief regulator_count_voltages */
 	regulator_count_voltages_t count_voltages;
+	/** @driver_ops_optional @copybrief regulator_list_voltage */
 	regulator_list_voltage_t list_voltage;
+	/** @driver_ops_optional @copybrief regulator_set_voltage */
 	regulator_set_voltage_t set_voltage;
+	/** @driver_ops_optional @copybrief regulator_get_voltage */
 	regulator_get_voltage_t get_voltage;
+	/** @driver_ops_optional @copybrief regulator_count_current_limits */
 	regulator_count_current_limits_t count_current_limits;
+	/** @driver_ops_optional @copybrief regulator_list_current_limit */
 	regulator_list_current_limit_t list_current_limit;
+	/** @driver_ops_optional @copybrief regulator_set_current_limit */
 	regulator_set_current_limit_t set_current_limit;
+	/** @driver_ops_optional @copybrief regulator_get_current_limit */
 	regulator_get_current_limit_t get_current_limit;
+	/** @driver_ops_optional @copybrief regulator_set_mode */
 	regulator_set_mode_t set_mode;
+	/** @driver_ops_optional @copybrief regulator_get_mode */
 	regulator_get_mode_t get_mode;
+	/** @driver_ops_optional @copybrief regulator_set_active_discharge */
 	regulator_set_active_discharge_t set_active_discharge;
+	/** @driver_ops_optional @copybrief regulator_get_active_discharge */
 	regulator_get_active_discharge_t get_active_discharge;
+	/** @driver_ops_optional @copybrief regulator_get_error_flags */
 	regulator_get_error_flags_t get_error_flags;
+	/** @driver_ops_optional @copybrief regulator_set_callback */
 	regulator_set_callback_t set_callback;
 };
+
+/** @} */
+
+/** @cond INTERNAL_HIDDEN */
 
 /**
  * @name Regulator flags

--- a/include/zephyr/drivers/sent/sent.h
+++ b/include/zephyr/drivers/sent/sent.h
@@ -95,7 +95,10 @@ struct sent_frame {
 typedef void (*sent_rx_frame_callback_t)(const struct device *dev, uint8_t channel,
 					 uint32_t num_frame, void *user_data);
 
-/** @cond INTERNAL_HIDDEN */
+/**
+ * @def_driverbackendgroup{SENT,sent_interface}
+ * @{
+ */
 
 /**
  * @brief Callback API upon starting receive frame
@@ -140,13 +143,21 @@ struct sent_rx_callback_configs {
 typedef int (*sent_register_callback_t)(const struct device *dev, uint8_t channel,
 					struct sent_rx_callback_configs callback_configs);
 
+/**
+ * @driver_ops{SENT}
+ */
 __subsystem struct sent_driver_api {
+	/** @driver_ops_optional @copybrief sent_start_listening */
 	sent_start_listening_t start_listening;
+	/** @driver_ops_optional @copybrief sent_stop_listening */
 	sent_stop_listening_t stop_listening;
+	/** @driver_ops_optional @copybrief sent_register_callback */
 	sent_register_callback_t register_callback;
 };
 
-/** @endcond */
+/**
+ * @}
+ */
 
 /**
  * @brief Enable a specific channel to start receiving from the bus

--- a/include/zephyr/drivers/smbus.h
+++ b/include/zephyr/drivers/smbus.h
@@ -333,75 +333,151 @@ struct smbus_dt_spec {
 #define SMBUS_DT_SPEC_INST_GET(inst) SMBUS_DT_SPEC_GET(DT_DRV_INST(inst))
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * These are for internal use only, so skip these in
- * public documentation.
+ * @def_driverbackendgroup{SMBus,smbus_interface}
+ * @{
  */
 
+/**
+ * @brief Configure operation of a SMBus host controller.
+ * See smbus_configure() for argument description.
+ */
 typedef int (*smbus_api_configure_t)(const struct device *dev,
 				     uint32_t dev_config);
+/**
+ * @brief Get configuration of a SMBus host controller.
+ * See smbus_get_config() for argument description.
+ */
 typedef int (*smbus_api_get_config_t)(const struct device *dev,
 				      uint32_t *dev_config);
+/**
+ * @brief Perform SMBus Quick operation.
+ * See smbus_quick() for argument description.
+ */
 typedef int (*smbus_api_quick_t)(const struct device *dev,
 				 uint16_t addr, enum smbus_direction);
+/**
+ * @brief Perform SMBus Byte Write operation.
+ * See smbus_byte_write() for argument description.
+ */
 typedef int (*smbus_api_byte_write_t)(const struct device *dev,
 				      uint16_t addr, uint8_t byte);
+/**
+ * @brief Perform SMBus Byte Read operation.
+ * See smbus_byte_read() for argument description.
+ */
 typedef int (*smbus_api_byte_read_t)(const struct device *dev,
 				     uint16_t addr, uint8_t *byte);
+/**
+ * @brief Perform SMBus Byte Data Write operation.
+ * See smbus_byte_data_write() for argument description.
+ */
 typedef int (*smbus_api_byte_data_write_t)(const struct device *dev,
 					   uint16_t addr, uint8_t cmd,
 					   uint8_t byte);
+/**
+ * @brief Perform SMBus Byte Data Read operation.
+ * See smbus_byte_data_read() for argument description.
+ */
 typedef int (*smbus_api_byte_data_read_t)(const struct device *dev,
 					  uint16_t addr, uint8_t cmd,
 					  uint8_t *byte);
+/**
+ * @brief Perform SMBus Word Data Write operation.
+ * See smbus_word_data_write() for argument description.
+ */
 typedef int (*smbus_api_word_data_write_t)(const struct device *dev,
 					   uint16_t addr, uint8_t cmd,
 					   uint16_t word);
+/**
+ * @brief Perform SMBus Word Data Read operation.
+ * See smbus_word_data_read() for argument description.
+ */
 typedef int (*smbus_api_word_data_read_t)(const struct device *dev,
 					  uint16_t addr, uint8_t cmd,
 					  uint16_t *word);
+/**
+ * @brief Perform SMBus Process Call operation.
+ * See smbus_pcall() for argument description.
+ */
 typedef int (*smbus_api_pcall_t)(const struct device *dev,
 				 uint16_t addr, uint8_t cmd,
 				 uint16_t send_word, uint16_t *recv_word);
+/**
+ * @brief Perform SMBus Block Write operation.
+ * See smbus_block_write() for argument description.
+ */
 typedef int (*smbus_api_block_write_t)(const struct device *dev,
 				       uint16_t addr, uint8_t cmd,
 				       uint8_t count, uint8_t *buf);
+/**
+ * @brief Perform SMBus Block Read operation.
+ * See smbus_block_read() for argument description.
+ */
 typedef int (*smbus_api_block_read_t)(const struct device *dev,
 				      uint16_t addr, uint8_t cmd,
 				      uint8_t *count, uint8_t *buf);
+/**
+ * @brief Perform SMBus Block Process Call operation.
+ * See smbus_block_pcall() for argument description.
+ */
 typedef int (*smbus_api_block_pcall_t)(const struct device *dev,
 				       uint16_t addr, uint8_t cmd,
 				       uint8_t send_count, uint8_t *send_buf,
 				       uint8_t *recv_count, uint8_t *recv_buf);
+/**
+ * @brief Add or remove a SMBALERT callback.
+ * See smbus_smbalert_set_cb() and smbus_smbalert_remove_cb() for argument description.
+ */
 typedef int (*smbus_api_smbalert_cb_t)(const struct device *dev,
 				       struct smbus_callback *cb);
+/**
+ * @brief Add or remove a Host Notify callback.
+ * See smbus_host_notify_set_cb() and smbus_host_notify_remove_cb() for argument description.
+ */
 typedef int (*smbus_api_host_notify_cb_t)(const struct device *dev,
 					  struct smbus_callback *cb);
 
+/**
+ * @driver_ops{SMBus}
+ */
 __subsystem struct smbus_driver_api {
+	/** @driver_ops_mandatory @copybrief smbus_configure */
 	smbus_api_configure_t configure;
+	/** @driver_ops_optional @copybrief smbus_get_config */
 	smbus_api_get_config_t get_config;
+	/** @driver_ops_optional Perform SMBus Quick operation. */
 	smbus_api_quick_t smbus_quick;
+	/** @driver_ops_optional Perform SMBus Byte Write operation. */
 	smbus_api_byte_write_t smbus_byte_write;
+	/** @driver_ops_optional Perform SMBus Byte Read operation. */
 	smbus_api_byte_read_t smbus_byte_read;
+	/** @driver_ops_optional Perform SMBus Byte Data Write operation. */
 	smbus_api_byte_data_write_t smbus_byte_data_write;
+	/** @driver_ops_optional Perform SMBus Byte Data Read operation. */
 	smbus_api_byte_data_read_t smbus_byte_data_read;
+	/** @driver_ops_optional Perform SMBus Word Data Write operation. */
 	smbus_api_word_data_write_t smbus_word_data_write;
+	/** @driver_ops_optional Perform SMBus Word Data Read operation. */
 	smbus_api_word_data_read_t smbus_word_data_read;
+	/** @driver_ops_optional Perform SMBus Process Call operation. */
 	smbus_api_pcall_t smbus_pcall;
+	/** @driver_ops_optional Perform SMBus Block Write operation. */
 	smbus_api_block_write_t smbus_block_write;
+	/** @driver_ops_optional Perform SMBus Block Read operation. */
 	smbus_api_block_read_t smbus_block_read;
+	/** @driver_ops_optional Perform SMBus Block Process Call operation. */
 	smbus_api_block_pcall_t smbus_block_pcall;
+	/** @driver_ops_optional Add SMBUSALERT callback for a SMBus host controller. */
 	smbus_api_smbalert_cb_t smbus_smbalert_set_cb;
+	/** @driver_ops_optional Remove SMBUSALERT callback from a SMBus host controller. */
 	smbus_api_smbalert_cb_t smbus_smbalert_remove_cb;
+	/** @driver_ops_optional Add Host Notify callback for a SMBus host controller. */
 	smbus_api_host_notify_cb_t smbus_host_notify_set_cb;
+	/** @driver_ops_optional Remove Host Notify callback from a SMBus host controller. */
 	smbus_api_host_notify_cb_t smbus_host_notify_remove_cb;
 };
 
-/**
- * @endcond
- */
+/** @} */
 
 #if defined(CONFIG_SMBUS_STATS) || defined(__DOXYGEN__)
 

--- a/include/zephyr/drivers/tee.h
+++ b/include/zephyr/drivers/tee.h
@@ -255,10 +255,15 @@ struct tee_shm {
 };
 
 /**
+ * @def_driverbackendgroup{TEE,tee_interface}
+ * @{
+ */
+
+/**
  *
  * @brief Callback API to get current tee version
  *
- * See @a tee_version_get() for argument definitions.
+ * See @a tee_get_version() for argument definitions.
  */
 typedef int (*tee_get_version_t)(const struct device *dev, struct tee_version_info *info);
 
@@ -329,17 +334,31 @@ typedef int (*tee_suppl_recv_t)(const struct device *dev, uint32_t *func, unsign
 typedef int (*tee_suppl_send_t)(const struct device *dev, unsigned int ret, unsigned int num_params,
 				struct tee_param *param);
 
+/**
+ * @driver_ops{TEE}
+ */
 __subsystem struct tee_driver_api {
+	/** @driver_ops_optional @copybrief tee_get_version */
 	tee_get_version_t get_version;
+	/** @driver_ops_optional @copybrief tee_open_session */
 	tee_open_session_t open_session;
+	/** @driver_ops_optional @copybrief tee_close_session */
 	tee_close_session_t close_session;
+	/** @driver_ops_optional @copybrief tee_cancel */
 	tee_cancel_t cancel;
+	/** @driver_ops_optional @copybrief tee_invoke_func */
 	tee_invoke_func_t invoke_func;
+	/** @driver_ops_optional @copybrief tee_shm_register */
 	tee_shm_register_t shm_register;
+	/** @driver_ops_optional @copybrief tee_shm_unregister */
 	tee_shm_unregister_t shm_unregister;
+	/** @driver_ops_optional @copybrief tee_suppl_recv */
 	tee_suppl_recv_t suppl_recv;
+	/** @driver_ops_optional @copybrief tee_suppl_send */
 	tee_suppl_send_t suppl_send;
 };
+
+/** @} */
 
 /**
  * @brief Get the current TEE version info

--- a/include/zephyr/drivers/usb/usb_bc12.h
+++ b/include/zephyr/drivers/usb/usb_bc12.h
@@ -134,17 +134,38 @@ typedef void (*bc12_callback_t)(const struct device *dev, struct bc12_partner_st
 				void *user_data);
 
 /**
- * @cond INTERNAL_HIDDEN
- *
- * These are for internal use only, so skip these in public documentation.
+ * @def_driverbackendgroup{BC1.2,b12_interface}
+ * @{
+ */
+
+/**
+ * @brief Set the BC1.2 role.
+ * See bc12_set_role() for argument description.
+ */
+typedef int (*bc12_api_set_role_t)(const struct device *dev, enum bc12_role role);
+
+/**
+ * @brief Register a callback for BC1.2 results.
+ * See bc12_set_result_cb() for argument description.
+ */
+typedef int (*bc12_api_set_result_cb_t)(const struct device *dev, bc12_callback_t cb,
+					void *user_data);
+
+/**
+ * @driver_ops{BC1.2}
  */
 __subsystem struct bc12_driver_api {
-	int (*set_role)(const struct device *dev, enum bc12_role role);
-	int (*set_result_cb)(const struct device *dev, bc12_callback_t cb, void *user_data);
+	/**
+	 * @driver_ops_mandatory @copybrief bc12_set_role
+	 */
+	bc12_api_set_role_t set_role;
+	/**
+	 * @driver_ops_mandatory @copybrief bc12_set_result_cb
+	 */
+	bc12_api_set_result_cb_t set_result_cb;
 };
-/**
- * @endcond
- */
+
+/** @} */
 
 /**
  * @brief Set the BC1.2 role.

--- a/include/zephyr/drivers/virtio.h
+++ b/include/zephyr/drivers/virtio.h
@@ -39,21 +39,85 @@ typedef uint16_t (*virtio_enumerate_queues)(
 );
 
 /**
- * @brief Virtio api structure
+ * @def_driverbackendgroup{VIRTIO,virtio_interface}
+ * @{
+ */
+
+/**
+ * @brief Get virtqueue at given index.
+ * See virtio_get_virtqueue() for argument description.
+ */
+typedef struct virtq *(*virtio_api_get_virtqueue_t)(const struct device *dev, uint16_t queue_idx);
+
+/**
+ * @brief Notify virtqueue.
+ * See virtio_notify_virtqueue() for argument description.
+ */
+typedef void (*virtio_api_notify_virtqueue_t)(const struct device *dev, uint16_t queue_idx);
+
+/**
+ * @brief Get device specific config.
+ * See virtio_get_device_specific_config() for argument description.
+ */
+typedef void *(*virtio_api_get_device_specific_config_t)(const struct device *dev);
+
+/**
+ * @brief Read feature bit offered by the virtio device.
+ * See virtio_read_device_feature_bit() for argument description.
+ */
+typedef bool (*virtio_api_read_device_feature_bit_t)(const struct device *dev, int bit);
+
+/**
+ * @brief Set driver feature bit.
+ * See virtio_write_driver_feature_bit() for argument description.
+ */
+typedef int (*virtio_api_write_driver_feature_bit_t)(const struct device *dev, int bit,
+						     bool value);
+
+/**
+ * @brief Commit feature bits.
+ * See virtio_commit_feature_bits() for argument description.
+ */
+typedef int (*virtio_api_commit_feature_bits_t)(const struct device *dev);
+
+/**
+ * @brief Initialize virtqueues.
+ * See virtio_init_virtqueues() for argument description.
+ */
+typedef int (*virtio_api_init_virtqueues_t)(const struct device *dev, uint16_t num_queues,
+					    virtio_enumerate_queues cb, void *opaque);
+
+/**
+ * @brief Finalize initialization of the virtio device.
+ * See virtio_finalize_init() for argument description.
+ */
+typedef void (*virtio_api_finalize_init_t)(const struct device *dev);
+
+/**
+ * @driver_ops{VIRTIO}
  */
 __subsystem struct virtio_driver_api {
-	struct virtq *(*get_virtqueue)(const struct device *dev, uint16_t queue_idx);
-	void (*notify_virtqueue)(const struct device *dev, uint16_t queue_idx);
-	void *(*get_device_specific_config)(const struct device *dev);
-	bool (*read_device_feature_bit)(const struct device *dev, int bit);
-	int (*write_driver_feature_bit)(const struct device *dev, int bit, bool value);
-	int (*commit_feature_bits)(const struct device *dev);
-	int (*init_virtqueues)(
-		const struct device *dev, uint16_t num_queues, virtio_enumerate_queues cb,
-		void *opaque
-	);
-	void (*finalize_init)(const struct device *dev);
+	/** @driver_ops_mandatory @copybrief virtio_get_virtqueue */
+	virtio_api_get_virtqueue_t get_virtqueue;
+	/** @driver_ops_mandatory @copybrief virtio_notify_virtqueue */
+	virtio_api_notify_virtqueue_t notify_virtqueue;
+	/** @driver_ops_mandatory @copybrief virtio_get_device_specific_config */
+	virtio_api_get_device_specific_config_t get_device_specific_config;
+	/** @driver_ops_mandatory @copybrief virtio_read_device_feature_bit */
+	virtio_api_read_device_feature_bit_t read_device_feature_bit;
+	/** @driver_ops_mandatory @copybrief virtio_write_driver_feature_bit */
+	virtio_api_write_driver_feature_bit_t write_driver_feature_bit;
+	/** @driver_ops_mandatory @copybrief virtio_commit_feature_bits */
+	virtio_api_commit_feature_bits_t commit_feature_bits;
+	/** @driver_ops_mandatory @copybrief virtio_init_virtqueues */
+	virtio_api_init_virtqueues_t init_virtqueues;
+	/** @driver_ops_mandatory @copybrief virtio_finalize_init */
+	virtio_api_finalize_init_t finalize_init;
 };
+
+/**
+ * @}
+ */
 
 /**
  * Returns virtqueue at given idx

--- a/include/zephyr/drivers/virtualization/ivshmem.h
+++ b/include/zephyr/drivers/virtualization/ivshmem.h
@@ -26,60 +26,151 @@ extern "C" {
 #define IVSHMEM_V2_PROTO_UNDEFINED	0x0000
 #define IVSHMEM_V2_PROTO_NET		0x0001
 
+/**
+ * @def_driverbackendgroup{Inter-VM Shared Memory,ivshmem}
+ * @{
+ */
+
+/**
+ * @brief Callback API to get the inter-VM shared memory.
+ * See ivshmem_get_mem() for argument description.
+ */
 typedef size_t (*ivshmem_get_mem_f)(const struct device *dev,
 				    uintptr_t *memmap);
 
+/**
+ * @brief Callback API to get our VM ID.
+ * See ivshmem_get_id() for argument description.
+ */
 typedef uint32_t (*ivshmem_get_id_f)(const struct device *dev);
 
+/**
+ * @brief Callback API to get the number of interrupt vectors we can use.
+ * See ivshmem_get_vectors() for argument description.
+ */
 typedef uint16_t (*ivshmem_get_vectors_f)(const struct device *dev);
 
+/**
+ * @brief Callback API to interrupt another VM.
+ * See ivshmem_int_peer() for argument description.
+ */
 typedef int (*ivshmem_int_peer_f)(const struct device *dev,
 				  uint32_t peer_id, uint16_t vector);
 
+/**
+ * @brief Callback API to register a vector notification (interrupt) handler.
+ * See ivshmem_register_handler() for argument description.
+ */
 typedef int (*ivshmem_register_handler_f)(const struct device *dev,
 					  struct k_poll_signal *signal,
 					  uint16_t vector);
 
-#ifdef CONFIG_IVSHMEM_V2
+#if defined(CONFIG_IVSHMEM_V2) || defined(__DOXYGEN__)
 
+/**
+ * @brief Callback API to get the ivshmem read/write section.
+ * See ivshmem_get_rw_mem_section() for argument description.
+ */
 typedef size_t (*ivshmem_get_rw_mem_section_f)(const struct device *dev,
 					       uintptr_t *memmap);
 
+/**
+ * @brief Callback API to get the ivshmem output section for a peer.
+ * See ivshmem_get_output_mem_section() for argument description.
+ */
 typedef size_t (*ivshmem_get_output_mem_section_f)(const struct device *dev,
 						   uint32_t peer_id,
 						   uintptr_t *memmap);
 
+/**
+ * @brief Callback API to get the state value of a peer.
+ * See ivshmem_get_state() for argument description.
+ */
 typedef uint32_t (*ivshmem_get_state_f)(const struct device *dev,
 					uint32_t peer_id);
 
+/**
+ * @brief Callback API to set our state.
+ * See ivshmem_set_state() for argument description.
+ */
 typedef int (*ivshmem_set_state_f)(const struct device *dev,
 				   uint32_t state);
 
+/**
+ * @brief Callback API to get the maximum number of peers supported.
+ * See ivshmem_get_max_peers() for argument description.
+ */
 typedef uint32_t (*ivshmem_get_max_peers_f)(const struct device *dev);
 
+/**
+ * @brief Callback API to get the protocol used by this ivshmem instance.
+ * See ivshmem_get_protocol() for argument description.
+ */
 typedef uint16_t (*ivshmem_get_protocol_f)(const struct device *dev);
 
+/**
+ * @brief Callback API to set the interrupt enablement for our VM.
+ * See ivshmem_enable_interrupts() for argument description.
+ */
 typedef int (*ivshmem_enable_interrupts_f)(const struct device *dev,
 					   bool enable);
 
 #endif /* CONFIG_IVSHMEM_V2 */
 
+/**
+ * @driver_ops{Inter-VM Shared Memory}
+ */
 __subsystem struct ivshmem_driver_api {
+	/** @driver_ops_mandatory @copybrief ivshmem_get_mem */
 	ivshmem_get_mem_f get_mem;
+	/** @driver_ops_mandatory @copybrief ivshmem_get_id */
 	ivshmem_get_id_f get_id;
+	/** @driver_ops_mandatory @copybrief ivshmem_get_vectors */
 	ivshmem_get_vectors_f get_vectors;
+	/** @driver_ops_mandatory @copybrief ivshmem_int_peer */
 	ivshmem_int_peer_f int_peer;
+	/** @driver_ops_mandatory @copybrief ivshmem_register_handler */
 	ivshmem_register_handler_f register_handler;
-#ifdef CONFIG_IVSHMEM_V2
+#if defined(CONFIG_IVSHMEM_V2) || defined(__DOXYGEN__)
+	/**
+	 * @driver_ops_mandatory @copybrief ivshmem_get_rw_mem_section
+	 * @kconfig_dep{CONFIG_IVSHMEM_V2}
+	 */
 	ivshmem_get_rw_mem_section_f get_rw_mem_section;
+	/**
+	 * @driver_ops_mandatory @copybrief ivshmem_get_output_mem_section
+	 * @kconfig_dep{CONFIG_IVSHMEM_V2}
+	 */
 	ivshmem_get_output_mem_section_f get_output_mem_section;
+	/**
+	 * @driver_ops_mandatory @copybrief ivshmem_get_state
+	 * @kconfig_dep{CONFIG_IVSHMEM_V2}
+	 */
 	ivshmem_get_state_f get_state;
+	/**
+	 * @driver_ops_mandatory @copybrief ivshmem_set_state
+	 * @kconfig_dep{CONFIG_IVSHMEM_V2}
+	 */
 	ivshmem_set_state_f set_state;
+	/**
+	 * @driver_ops_mandatory @copybrief ivshmem_get_max_peers
+	 * @kconfig_dep{CONFIG_IVSHMEM_V2}
+	 */
 	ivshmem_get_max_peers_f get_max_peers;
+	/**
+	 * @driver_ops_mandatory @copybrief ivshmem_get_protocol
+	 * @kconfig_dep{CONFIG_IVSHMEM_V2}
+	 */
 	ivshmem_get_protocol_f get_protocol;
+	/**
+	 * @driver_ops_mandatory @copybrief ivshmem_enable_interrupts
+	 * @kconfig_dep{CONFIG_IVSHMEM_V2}
+	 */
 	ivshmem_enable_interrupts_f enable_interrupts;
 #endif
 };
+
+/** @} */
 
 /**
  * @brief Get the inter-VM shared memory
@@ -176,7 +267,7 @@ static inline int z_impl_ivshmem_register_handler(const struct device *dev,
 	return DEVICE_API_GET(ivshmem, dev)->register_handler(dev, signal, vector);
 }
 
-#ifdef CONFIG_IVSHMEM_V2
+#if defined(CONFIG_IVSHMEM_V2) || defined(__DOXYGEN__)
 
 /**
  * @brief Get the ivshmem read/write section (ivshmem-v2 only)

--- a/include/zephyr/drivers/w1.h
+++ b/include/zephyr/drivers/w1.h
@@ -70,46 +70,125 @@ enum w1_settings_type {
 	W1_SETINGS_TYPE_COUNT,
 };
 
-/**  @cond INTERNAL_HIDDEN */
+/**
+ * @def_driverbackendgroup{1-Wire,w1_interface}
+ * @{
+ */
 
 /** Configuration common to all 1-Wire master implementations. */
 struct w1_master_config {
-	/* Number of connected slaves */
+	/** Number of connected slaves */
 	uint16_t slave_count;
 };
 
 /** Data common to all 1-Wire master implementations. */
 struct w1_master_data {
-	/* The mutex used by w1_lock_bus and w1_unlock_bus methods */
+	/** The mutex used by w1_lock_bus and w1_unlock_bus methods */
 	struct k_mutex bus_lock;
 };
 
+/**
+ * @brief Reset the 1-Wire bus to prepare slaves for communication.
+ * See w1_reset_bus() for argument description.
+ */
 typedef int (*w1_reset_bus_t)(const struct device *dev);
+
+/**
+ * @brief Read a single bit from the 1-Wire bus.
+ * See w1_read_bit() for argument description.
+ */
 typedef int (*w1_read_bit_t)(const struct device *dev);
+
+/**
+ * @brief Write a single bit to the 1-Wire bus.
+ * See w1_write_bit() for argument description.
+ */
 typedef int (*w1_write_bit_t)(const struct device *dev, bool bit);
+
+/**
+ * @brief Read a single byte from the 1-Wire bus.
+ * See w1_read_byte() for argument description.
+ */
 typedef int (*w1_read_byte_t)(const struct device *dev);
+
+/**
+ * @brief Write a single byte to the 1-Wire bus.
+ * See w1_write_byte() for argument description.
+ */
 typedef int (*w1_write_byte_t)(const struct device *dev, const uint8_t byte);
+
+/**
+ * @brief Read a block of data from the 1-Wire bus.
+ * See w1_read_block() for argument description.
+ */
 typedef int (*w1_read_block_t)(const struct device *dev, uint8_t *buffer,
 			       size_t len);
+
+/**
+ * @brief Write a block of data to the 1-Wire bus.
+ * See w1_write_block() for argument description.
+ */
 typedef int (*w1_write_block_t)(const struct device *dev, const uint8_t *buffer,
 				size_t len);
+
+/**
+ * @brief Get the number of slaves on the bus.
+ * See w1_get_slave_count() for argument description.
+ */
 typedef size_t (*w1_get_slave_count_t)(const struct device *dev);
+
+/**
+ * @brief Configure parameters of the 1-Wire master.
+ * See w1_configure() for argument description.
+ */
 typedef int (*w1_configure_t)(const struct device *dev,
 			      enum w1_settings_type type, uint32_t value);
+
+/**
+ * @brief Lock or unlock the 1-Wire bus.
+ * See w1_lock_bus() and w1_unlock_bus() for details.
+ */
 typedef int (*w1_change_bus_lock_t)(const struct device *dev, bool lock);
 
+/**
+ * @driver_ops{1-Wire}
+ */
 __subsystem struct w1_driver_api {
+	/** @driver_ops_mandatory @copybrief w1_reset_bus */
 	w1_reset_bus_t reset_bus;
+	/** @driver_ops_mandatory @copybrief w1_read_bit */
 	w1_read_bit_t read_bit;
+	/** @driver_ops_mandatory @copybrief w1_write_bit */
 	w1_write_bit_t write_bit;
+	/** @driver_ops_mandatory @copybrief w1_read_byte */
 	w1_read_byte_t read_byte;
+	/** @driver_ops_mandatory @copybrief w1_write_byte */
 	w1_write_byte_t write_byte;
+	/**
+	 * @driver_ops_optional @copybrief w1_read_block
+	 *
+	 * If not implemented, the subsystem falls back to repeated
+	 * @ref w1_driver_api.read_byte calls.
+	 */
 	w1_read_block_t read_block;
+	/**
+	 * @driver_ops_optional @copybrief w1_write_block
+	 *
+	 * If not implemented, the subsystem falls back to repeated
+	 * @ref w1_driver_api.write_byte calls.
+	 */
 	w1_write_block_t write_block;
+	/** @driver_ops_mandatory @copybrief w1_configure */
 	w1_configure_t configure;
+	/**
+	 * @driver_ops_optional Lock or unlock bus access.
+	 *
+	 * If not implemented, the subsystem falls back to a mutex-based lock.
+	 */
 	w1_change_bus_lock_t change_bus_lock;
 };
-/** @endcond */
+
+/** @} */
 
 /** @cond INTERNAL_HIDDEN */
 __syscall int w1_change_bus_lock(const struct device *dev, bool lock);


### PR DESCRIPTION
Group the comparator driver backend definitions in a dedicated
backend API group and document the driver API structure with the
driver_ops Doxygen commands, tagging each operation as mandatory.

Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>