### PR TITLE
samples: usb: add i2c-tiny-usb bridge sample

### DIFF
--- a/samples/subsys/usb/i2c_tiny_usb/CMakeLists.txt
+++ b/samples/subsys/usb/i2c_tiny_usb/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(i2c_tiny_usb)
+
+include(${ZEPHYR_BASE}/samples/subsys/usb/common/common.cmake)
+target_sources(app PRIVATE
+  src/main.c
+  src/i2c_tiny_usb.c
+)

--- a/samples/subsys/usb/i2c_tiny_usb/Kconfig
+++ b/samples/subsys/usb/i2c_tiny_usb/Kconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 The Zephyr Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Source common USB sample options used to initialize new experimental USB
+# device stack. The scope of these options is limited to USB samples in project
+# tree, you cannot use them in your own application.
+source "samples/subsys/usb/common/Kconfig.sample_usbd"
+
+source "Kconfig.zephyr"

--- a/samples/subsys/usb/i2c_tiny_usb/README.rst
+++ b/samples/subsys/usb/i2c_tiny_usb/README.rst
@@ -1,0 +1,91 @@
+.. zephyr:code-sample:: i2c-tiny-usb
+   :name: I2C-Tiny-USB bridge
+   :relevant-api: usbd_api i2c_interface
+
+   Expose a Zephyr I2C controller to a host as a USB to I2C adapter.
+
+Overview
+********
+
+This sample implements the vendor request protocol of the
+`I2C-Tiny-USB project <https://github.com/harbaum/I2C-Tiny-USB>`_ on top of the USB device support
+and the I2C driver API. It turns a Zephyr board into a USB to I2C adapter that can be used with the
+Linux ``i2c-tiny-usb`` bus driver (``drivers/i2c/busses/i2c-tiny-usb.c``), making the I2C bus of the
+board accessible from the host through the ``i2c-dev`` interface and tools like ``i2cdetect``,
+``i2cget``, or ``i2cset``.
+
+All communication is done through vendor requests on the default control pipe. The commands to
+perform I2C transfers are handled using vendor request nodes, while the commands to get the adapter
+capabilities and transfer status are handled by a minimal USB function with a vendor specific
+interface and no endpoints. I2C messages belonging to the same transaction are collected and
+executed in a single I2C transfer, which preserves repeated start conditions between the messages.
+
+Any I2C controller driver can be used, including the GPIO bit-banging driver
+:dtcompatible:`gpio-i2c` on boards without a free hardware I2C controller. The I2C controller is
+selected with the ``zephyr_i2c`` devicetree node label, which many boards already provide. For
+boards without it, an overlay can attach the label to any I2C controller, see the overlays in the
+:zephyr_file:`samples/subsys/usb/i2c_tiny_usb/boards` directory.
+
+Requirements
+************
+
+This project requires a USB device controller driver using the UDC API and an I2C controller.
+
+On the host side you need:
+
+* A Linux kernel with the ``i2c-tiny-usb`` driver (``CONFIG_I2C_TINY_USB``), which is enabled in
+  most distribution kernels.
+* The ``i2c-tools`` package, which provides the ``i2cdetect``, ``i2cget``, and ``i2cset`` commands
+  used below. On Debian and Ubuntu install it with ``sudo apt install i2c-tools``, on Fedora with
+  ``sudo dnf install i2c-tools``.
+
+Building and Running
+********************
+
+Build and flash the sample with:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/subsys/usb/i2c_tiny_usb
+   :board: nrf52840dk/nrf52840
+   :goals: flash
+   :compact:
+
+The sample uses the vendor and product ID of the original I2C-Tiny-USB project, so the
+``i2c-tiny-usb`` driver binds to the device automatically when it is connected and registers a new
+I2C adapter:
+
+.. code-block:: console
+
+   $ sudo dmesg | grep i2c-tiny-usb
+   i2c-tiny-usb 1-2.1:1.0: version 1.05 found at bus 001 address 016
+   i2c i2c-20: connected i2c-tiny-usb device
+
+   $ i2cdetect -l | grep tiny
+   i2c-20  i2c   i2c-tiny-usb at bus 001 device 016    I2C adapter
+
+The adapter shows up as ``i2c-N``, where ``N`` is a bus number the kernel assigns dynamically
+(``i2c-20`` in the output above, but it may differ on your system and can change when the device is
+re-plugged). That number ``N`` is what you pass to the ``i2c-tools`` commands as the bus argument.
+Substitute your own number for ``20`` in the examples below.
+
+Now the I2C bus of the board can be used from the host, for example to scan for connected devices or
+to read the manufacturer ID register of a sensor found at address 0x1c:
+
+.. code-block:: console
+
+   $ sudo i2cdetect -y 20
+        0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
+   00:                         -- -- -- -- -- -- -- --
+   10: -- -- -- -- -- -- -- -- -- -- -- -- 1c -- -- --
+   ...
+
+   $ sudo i2cget -y 20 0x1c 0x0d
+   0xc7
+
+Limitations
+***********
+
+The transfers of a transaction are only executed when the host announces the last message or
+requests read data. A NAK from a deferred write is therefore reported with the status of the whole
+transaction rather than with the message that caused it. Transactions addressing multiple different
+targets are not supported, such transactions are rejected and reported as failed.

--- a/samples/subsys/usb/i2c_tiny_usb/boards/frdm_k64f.overlay
+++ b/samples/subsys/usb/i2c_tiny_usb/boards/frdm_k64f.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+zephyr_i2c: &arduino_i2c {};

--- a/samples/subsys/usb/i2c_tiny_usb/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/subsys/usb/i2c_tiny_usb/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+zephyr_i2c: &arduino_i2c {};

--- a/samples/subsys/usb/i2c_tiny_usb/boards/nucleo_f413zh.overlay
+++ b/samples/subsys/usb/i2c_tiny_usb/boards/nucleo_f413zh.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026 The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+zephyr_i2c: &arduino_i2c {};

--- a/samples/subsys/usb/i2c_tiny_usb/prj.conf
+++ b/samples/subsys/usb/i2c_tiny_usb/prj.conf
@@ -1,0 +1,14 @@
+CONFIG_USB_DEVICE_STACK_NEXT=y
+CONFIG_USBD_VREQ_SUPPORT=y
+
+CONFIG_I2C=y
+
+CONFIG_LOG=y
+CONFIG_USBD_LOG_LEVEL_WRN=y
+CONFIG_UDC_DRIVER_LOG_LEVEL_WRN=y
+
+# Vendor and product ID of the original I2C-Tiny-USB project, matched by the
+# Linux i2c-tiny-usb driver.
+CONFIG_SAMPLE_USBD_VID=0x0403
+CONFIG_SAMPLE_USBD_PID=0xc631
+CONFIG_SAMPLE_USBD_PRODUCT="Zephyr i2c-tiny-usb bridge"

--- a/samples/subsys/usb/i2c_tiny_usb/sample.yaml
+++ b/samples/subsys/usb/i2c_tiny_usb/sample.yaml
@@ -1,0 +1,14 @@
+sample:
+  name: i2c-tiny-usb bridge
+tests:
+  sample.subsys.usb.i2c_tiny_usb:
+    depends_on:
+      - usbd
+      - i2c
+    filter: dt_nodelabel_enabled("zephyr_i2c")
+    tags:
+      - usb
+      - i2c
+    build_only: true
+    integration_platforms:
+      - adafruit_feather_rp2040

--- a/samples/subsys/usb/i2c_tiny_usb/src/i2c_tiny_usb.c
+++ b/samples/subsys/usb/i2c_tiny_usb/src/i2c_tiny_usb.c
@@ -1,0 +1,419 @@
+/*
+ * Copyright (c) 2026 The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "i2c_tiny_usb.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/net_buf.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/minmax.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/usb/usbd.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(i2c_tiny_usb, LOG_LEVEL_INF);
+
+/*
+ * This file implements a USB function compatible with the i2c-tiny-usb
+ * protocol, https://github.com/harbaum/I2C-Tiny-USB, understood by the Linux
+ * i2c-tiny-usb bus driver (drivers/i2c/busses/i2c-tiny-usb.c). All
+ * communication is done through vendor requests on the default control pipe,
+ * the interface has no other endpoints.
+ *
+ * The bRequest field of a vendor request encodes the command. For CMD_I2C_IO
+ * commands, wValue carries the Linux I2C message flags, wIndex the target
+ * address, and the data stage the message payload. The host announces the
+ * first and last message of an I2C transaction with the BEGIN and END bits.
+ */
+#define CMD_ECHO		0
+#define CMD_GET_FUNC		1
+#define CMD_SET_DELAY		2
+#define CMD_GET_STATUS		3
+
+#define CMD_I2C_IO		4
+#define CMD_I2C_IO_BEGIN	BIT(0)
+#define CMD_I2C_IO_END		BIT(1)
+
+/* Status reported by CMD_GET_STATUS */
+#define STATUS_IDLE		0
+#define STATUS_ADDRESS_ACK	1
+#define STATUS_ADDRESS_NAK	2
+
+/* Linux I2C message flags used in wValue of CMD_I2C_IO commands */
+#define TINY_USB_M_RD		BIT(0)
+
+/* Linux I2C adapter functionality reported by CMD_GET_FUNC */
+#define TINY_USB_FUNC_I2C	0x00000001UL
+#define TINY_USB_FUNC_SMBUS_EMUL 0x0eff0008UL
+
+/*
+ * An I2C transaction may consist of multiple messages, each transferred in a
+ * separate vendor request. Messages are collected here and the transaction is
+ * executed as a whole, preserving repeated start conditions, when either the
+ * last message is announced or a message requires read data.
+ */
+#define MAX_MSGS		8U
+#define MAX_DATA		256U
+
+struct i2c_tiny_usb_data {
+	const struct device *i2c_dev;
+	struct i2c_msg msgs[MAX_MSGS];
+	uint8_t data[MAX_DATA];
+	uint16_t used;
+	uint8_t num_msgs;
+	uint16_t addr;
+	uint8_t status;
+};
+
+static struct i2c_tiny_usb_data bridge = {
+	.i2c_dev = DEVICE_DT_GET(DT_NODELABEL(zephyr_i2c)),
+	.status = STATUS_IDLE,
+};
+
+static void transaction_reset(struct i2c_tiny_usb_data *const ctx)
+{
+	ctx->num_msgs = 0;
+	ctx->used = 0;
+}
+
+static struct i2c_msg *msg_append(struct i2c_tiny_usb_data *const ctx,
+				  const struct usb_setup_packet *const setup)
+{
+	struct i2c_msg *msg;
+
+	if (setup->bRequest & CMD_I2C_IO_BEGIN) {
+		transaction_reset(ctx);
+	}
+
+	if (ctx->num_msgs >= MAX_MSGS ||
+	    setup->wLength > sizeof(ctx->data) - ctx->used) {
+		LOG_ERR("Transaction exceeds message or data limits");
+		transaction_reset(ctx);
+		ctx->status = STATUS_ADDRESS_NAK;
+		return NULL;
+	}
+
+	if (ctx->num_msgs == 0U) {
+		ctx->addr = setup->wIndex;
+	} else if (ctx->addr != setup->wIndex) {
+		LOG_ERR("Multiple target addresses in a transaction are not supported");
+		transaction_reset(ctx);
+		ctx->status = STATUS_ADDRESS_NAK;
+		return NULL;
+	}
+
+	msg = &ctx->msgs[ctx->num_msgs];
+	msg->buf = &ctx->data[ctx->used];
+	msg->len = setup->wLength;
+	msg->flags = (setup->wValue & TINY_USB_M_RD) ? I2C_MSG_READ : I2C_MSG_WRITE;
+
+	if (ctx->num_msgs != 0U) {
+		msg->flags |= I2C_MSG_RESTART;
+	}
+
+	if (setup->bRequest & CMD_I2C_IO_END) {
+		msg->flags |= I2C_MSG_STOP;
+	}
+
+	ctx->num_msgs++;
+	ctx->used += setup->wLength;
+
+	return msg;
+}
+
+static void transaction_run(struct i2c_tiny_usb_data *const ctx)
+{
+	int err;
+
+	err = i2c_transfer(ctx->i2c_dev, ctx->msgs, ctx->num_msgs, ctx->addr);
+	if (err) {
+		LOG_WRN("Transfer to address 0x%02x failed (%d)", ctx->addr, err);
+		ctx->status = STATUS_ADDRESS_NAK;
+	} else {
+		ctx->status = STATUS_ADDRESS_ACK;
+	}
+
+	transaction_reset(ctx);
+}
+
+static int set_delay(struct i2c_tiny_usb_data *const ctx, const uint16_t delay_us)
+{
+	uint32_t freq_hz;
+	uint8_t speed;
+	int err;
+
+	/*
+	 * The delay is the clock half-period in microseconds used by the
+	 * original bit-banging firmware. Map it to the closest supported
+	 * bus speed, ignore errors as not all controllers support runtime
+	 * configuration.
+	 */
+	freq_hz = USEC_PER_SEC / (2U * max(delay_us, 1U));
+	if (freq_hz >= MHZ(1)) {
+		speed = I2C_SPEED_FAST_PLUS;
+	} else if (freq_hz >= KHZ(400)) {
+		speed = I2C_SPEED_FAST;
+	} else {
+		speed = I2C_SPEED_STANDARD;
+	}
+
+	err = i2c_configure(ctx->i2c_dev, I2C_MODE_CONTROLLER | I2C_SPEED_SET(speed));
+	if (err) {
+		LOG_WRN("Failed to configure bus speed (%d), continue anyway", err);
+	}
+
+	return 0;
+}
+
+static int cmd_to_dev(const struct usb_setup_packet *const setup,
+		      const struct net_buf *const buf)
+{
+	struct i2c_tiny_usb_data *ctx = &bridge;
+	struct i2c_msg *msg;
+
+	if (setup->RequestType.type != USB_REQTYPE_TYPE_VENDOR) {
+		return -ENOTSUP;
+	}
+
+	if (setup->wLength != 0U && buf == NULL) {
+		/* Allow the data OUT stage to be received */
+		return 0;
+	}
+
+	if ((setup->bRequest & ~(CMD_I2C_IO_BEGIN | CMD_I2C_IO_END)) == CMD_I2C_IO) {
+		msg = msg_append(ctx, setup);
+		if (msg == NULL) {
+			/* The failure is reported through CMD_GET_STATUS */
+			return 0;
+		}
+
+		if (buf != NULL) {
+			msg->len = min(msg->len, buf->len);
+			memcpy(msg->buf, buf->data, msg->len);
+		}
+
+		if (setup->bRequest & CMD_I2C_IO_END) {
+			transaction_run(ctx);
+		} else {
+			/*
+			 * Execution is deferred until the last message of the
+			 * transaction, a failure would be reported with the
+			 * status of the whole transaction.
+			 */
+			ctx->status = STATUS_ADDRESS_ACK;
+		}
+
+		return 0;
+	}
+
+	if (setup->bRequest == CMD_SET_DELAY) {
+		return set_delay(ctx, setup->wValue);
+	}
+
+	LOG_ERR("Vendor request 0x%02x to device not supported", setup->bRequest);
+
+	return -ENOTSUP;
+}
+
+static struct net_buf *cmd_to_host(const struct usbd_context *const uds_ctx,
+				   const struct usb_setup_packet *const setup)
+{
+	struct i2c_tiny_usb_data *ctx = &bridge;
+	struct net_buf *buf;
+
+	if (setup->RequestType.type != USB_REQTYPE_TYPE_VENDOR) {
+		return NULL;
+	}
+
+	buf = usbd_ep_ctrl_data_in_alloc(uds_ctx, setup->wLength);
+	if (buf == NULL) {
+		return NULL;
+	}
+
+	if ((setup->bRequest & ~(CMD_I2C_IO_BEGIN | CMD_I2C_IO_END)) == CMD_I2C_IO) {
+		struct i2c_msg *msg = msg_append(ctx, setup);
+
+		if (msg != NULL) {
+			transaction_run(ctx);
+		}
+
+		if (msg != NULL && ctx->status == STATUS_ADDRESS_ACK) {
+			net_buf_add_mem(buf, msg->buf, msg->len);
+		} else {
+			/*
+			 * Always return the requested length, the host driver
+			 * treats a short transfer as a fatal error and would
+			 * not query the status anymore.
+			 */
+			memset(net_buf_add(buf, setup->wLength), 0, setup->wLength);
+		}
+
+		return buf;
+	}
+
+	switch (setup->bRequest) {
+	case CMD_ECHO: {
+		uint16_t echo = sys_cpu_to_le16(setup->wValue);
+
+		net_buf_add_mem(buf, &echo, min(setup->wLength, sizeof(echo)));
+		return buf;
+	}
+	case CMD_GET_FUNC: {
+		uint32_t func = sys_cpu_to_le32(TINY_USB_FUNC_I2C | TINY_USB_FUNC_SMBUS_EMUL);
+
+		net_buf_add_mem(buf, &func, min(setup->wLength, sizeof(func)));
+		return buf;
+	}
+	case CMD_GET_STATUS:
+		net_buf_add_u8(buf, ctx->status);
+		return buf;
+	default:
+		break;
+	}
+
+	LOG_ERR("Vendor request 0x%02x to host not supported", setup->bRequest);
+	net_buf_unref(buf);
+
+	return NULL;
+}
+
+/*
+ * Vendor requests with wIndex equal to the interface number are routed to the
+ * class instance. This covers CMD_ECHO, CMD_GET_FUNC, CMD_SET_DELAY, and
+ * CMD_GET_STATUS, which are always sent with wIndex set to zero.
+ */
+static int class_control_to_dev(struct usbd_class_data *const c_data,
+				const struct usb_setup_packet *const setup,
+				const struct net_buf *const buf)
+{
+	return cmd_to_dev(setup, buf);
+}
+
+static struct net_buf *class_control_to_host(struct usbd_class_data *const c_data,
+					     const struct usb_setup_packet *const setup)
+{
+	return cmd_to_host(usbd_class_get_ctx(c_data), setup);
+}
+
+/*
+ * CMD_I2C_IO requests carry the target address in wIndex, so they do not
+ * match any interface and are handled by device vendor request nodes
+ * registered for all four possible command codes.
+ */
+static int vreq_to_dev(const struct usbd_context *const uds_ctx,
+		       const struct usb_setup_packet *const setup,
+		       const struct net_buf *const buf)
+{
+	return cmd_to_dev(setup, buf);
+}
+
+static struct net_buf *vreq_to_host(const struct usbd_context *const uds_ctx,
+				    const struct usb_setup_packet *const setup)
+{
+	return cmd_to_host(uds_ctx, setup);
+}
+
+USBD_VREQUEST_DEFINE(i2c_io_vreq, CMD_I2C_IO,
+		     vreq_to_host, vreq_to_dev);
+USBD_VREQUEST_DEFINE(i2c_io_begin_vreq, CMD_I2C_IO | CMD_I2C_IO_BEGIN,
+		     vreq_to_host, vreq_to_dev);
+USBD_VREQUEST_DEFINE(i2c_io_end_vreq, CMD_I2C_IO | CMD_I2C_IO_END,
+		     vreq_to_host, vreq_to_dev);
+USBD_VREQUEST_DEFINE(i2c_io_begin_end_vreq,
+		     CMD_I2C_IO | CMD_I2C_IO_BEGIN | CMD_I2C_IO_END,
+		     vreq_to_host, vreq_to_dev);
+
+int i2c_tiny_usb_register_vreqs(struct usbd_context *const uds_ctx)
+{
+	struct usbd_vreq_node *const nodes[] = {
+		&i2c_io_vreq, &i2c_io_begin_vreq,
+		&i2c_io_end_vreq, &i2c_io_begin_end_vreq,
+	};
+	int err;
+
+	if (!device_is_ready(bridge.i2c_dev)) {
+		LOG_ERR("I2C device is not ready");
+		return -ENODEV;
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(nodes); i++) {
+		err = usbd_device_register_vreq(uds_ctx, nodes[i]);
+		if (err) {
+			LOG_ERR("Failed to register vendor request 0x%02x (%d)",
+				nodes[i]->code, err);
+			return err;
+		}
+	}
+
+	return 0;
+}
+
+struct i2c_tiny_usb_desc {
+	struct usb_if_descriptor if0;
+	struct usb_desc_header nil_desc;
+};
+
+static struct i2c_tiny_usb_desc bridge_desc = {
+	/* Vendor specific interface without endpoints */
+	.if0 = {
+		.bLength = sizeof(struct usb_if_descriptor),
+		.bDescriptorType = USB_DESC_INTERFACE,
+		.bInterfaceNumber = 0,
+		.bAlternateSetting = 0,
+		.bNumEndpoints = 0,
+		.bInterfaceClass = USB_BCC_VENDOR,
+		.bInterfaceSubClass = 0,
+		.bInterfaceProtocol = 0,
+		.iInterface = 0,
+	},
+
+	/* Termination descriptor */
+	.nil_desc = {
+		.bLength = 0,
+		.bDescriptorType = 0,
+	},
+};
+
+const static struct usb_desc_header *bridge_fs_desc[] = {
+	(struct usb_desc_header *)&bridge_desc.if0,
+	(struct usb_desc_header *)&bridge_desc.nil_desc,
+};
+
+const static struct usb_desc_header *bridge_hs_desc[] = {
+	(struct usb_desc_header *)&bridge_desc.if0,
+	(struct usb_desc_header *)&bridge_desc.nil_desc,
+};
+
+static void *bridge_get_desc(struct usbd_class_data *const c_data,
+			     const enum usbd_speed speed)
+{
+	if (USBD_SUPPORTS_HIGH_SPEED && speed == USBD_SPEED_HS) {
+		return bridge_hs_desc;
+	}
+
+	return bridge_fs_desc;
+}
+
+static int bridge_init(struct usbd_class_data *const c_data)
+{
+	LOG_DBG("Init class instance %p", (void *)c_data);
+
+	return 0;
+}
+
+static struct usbd_class_api bridge_api = {
+	.control_to_dev = class_control_to_dev,
+	.control_to_host = class_control_to_host,
+	.get_desc = bridge_get_desc,
+	.init = bridge_init,
+};
+
+USBD_DEFINE_CLASS(i2c_tiny_usb, &bridge_api, &bridge, NULL);

--- a/samples/subsys/usb/i2c_tiny_usb/src/i2c_tiny_usb.h
+++ b/samples/subsys/usb/i2c_tiny_usb/src/i2c_tiny_usb.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef I2C_TINY_USB_H
+#define I2C_TINY_USB_H
+
+#include <zephyr/usb/usbd.h>
+
+/*
+ * Register the vendor request handlers used by the i2c-tiny-usb function.
+ * Must be called after the device context is set up but before usbd_init().
+ */
+int i2c_tiny_usb_register_vreqs(struct usbd_context *const uds_ctx);
+
+#endif /* I2C_TINY_USB_H */

--- a/samples/subsys/usb/i2c_tiny_usb/src/main.c
+++ b/samples/subsys/usb/i2c_tiny_usb/src/main.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 The Zephyr Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <sample_usbd.h>
+
+#include <zephyr/usb/usbd.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);
+
+#include "i2c_tiny_usb.h"
+
+static void msg_cb(struct usbd_context *const usbd_ctx,
+		   const struct usbd_msg *const msg)
+{
+	LOG_INF("USBD message: %s", usbd_msg_type_string(msg->type));
+
+	if (usbd_can_detect_vbus(usbd_ctx)) {
+		if (msg->type == USBD_MSG_VBUS_READY) {
+			if (usbd_enable(usbd_ctx)) {
+				LOG_ERR("Failed to enable device support");
+			}
+		}
+
+		if (msg->type == USBD_MSG_VBUS_REMOVED) {
+			if (usbd_disable(usbd_ctx)) {
+				LOG_ERR("Failed to disable device support");
+			}
+		}
+	}
+}
+
+int main(void)
+{
+	struct usbd_context *sample_usbd;
+	int ret;
+
+	sample_usbd = sample_usbd_setup_device(msg_cb);
+	if (sample_usbd == NULL) {
+		LOG_ERR("Failed to setup USB device");
+		return -ENODEV;
+	}
+
+	ret = i2c_tiny_usb_register_vreqs(sample_usbd);
+	if (ret) {
+		LOG_ERR("Failed to register vendor requests");
+		return ret;
+	}
+
+	ret = usbd_init(sample_usbd);
+	if (ret) {
+		LOG_ERR("Failed to initialize device support");
+		return ret;
+	}
+
+	if (!usbd_can_detect_vbus(sample_usbd)) {
+		ret = usbd_enable(sample_usbd);
+		if (ret) {
+			LOG_ERR("Failed to enable device support");
+			return ret;
+		}
+	}
+
+	LOG_INF("USB to I2C bridge sample is initialized");
+
+	return 0;
+}


### PR DESCRIPTION
Add a sample implementing the vendor request protocol of the
I2C-Tiny-USB project on top of the new USB device stack and the I2C
driver API. It makes a Zephyr board enumerate as a USB to I2C adapter
that works out of the box with the Linux i2c-tiny-usb bus driver, so
the I2C bus of the board can be accessed from the host with the
i2c-dev interface and the usual i2c-tools.

Commands addressed to the interface are handled by a minimal USB
function with a vendor specific interface without endpoints, while the
I2C transfer commands, which carry the target address in wIndex, are
handled with device vendor request nodes. Messages belonging to the
same I2C transaction are collected and executed in a single I2C
transfer to preserve repeated start conditions.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WV7zhWSefLKqrwknqpWor5
Signed-off-by: Benjamin Cabé <kartben@gmail.com>