### PR TITLE
scripts: dts: dtdoctor: detect more classes of devicetree errors

### DIFF
--- a/.github/workflows/scripts_tests.yml
+++ b/.github/workflows/scripts_tests.yml
@@ -10,6 +10,7 @@ on:
       - v*-branch
     paths:
       - 'scripts/build/**'
+      - 'scripts/dts/dtdoctor*'
       - '.github/workflows/scripts_tests.yml'
   pull_request:
     branches:
@@ -17,6 +18,7 @@ on:
       - v*-branch
     paths:
       - 'scripts/build/**'
+      - 'scripts/dts/dtdoctor*'
       - '.github/workflows/scripts_tests.yml'
 
 permissions:
@@ -73,4 +75,4 @@ jobs:
           ZEPHYR_BASE: ./
         run: |
           echo "Run script tests"
-          pytest ./scripts/build
+          pytest ./scripts/build ./scripts/dts/dtdoctor_test.py

--- a/doc/develop/sca/dtdoctor.rst
+++ b/doc/develop/sca/dtdoctor.rst
@@ -6,8 +6,42 @@ Devicetree diagnostics (``dtdoctor``)
 ``dtdoctor`` is a static analysis tool that helps diagnose Devicetree-related build errors.
 
 It intercepts error messages from the compiler and linker and, when they refer to unresolved
-Devicetree device symbols (e.g. ``__device_dts_ord_*``), provides detailed information about what
-might be causing the error and how to fix it.
+Devicetree symbols, provides detailed information about what might be causing the error and how to
+fix it.
+
+Detected error classes
+**********************
+
+``dtdoctor`` currently recognizes the following classes of errors:
+
+Unresolved device symbols (``__device_dts_ord_*``)
+   Typically caused by :c:macro:`DEVICE_DT_GET` on a node that is disabled, or enabled but with no
+   driver compiled in. ``dtdoctor`` reports where the node is disabled (and what refers to it), or
+   suggests Kconfig options that may be gating the device driver.
+
+Nonexistent node labels and aliases
+   E.g. :c:macro:`DT_NODELABEL` or :c:macro:`DT_ALIAS` on a name that does not exist in the final
+   devicetree. ``dtdoctor`` suggests close matches among existing labels/aliases and shows how to
+   define a missing alias in an overlay.
+
+Missing ``/chosen`` properties
+   E.g. :c:macro:`DT_CHOSEN` on a property that is not set. ``dtdoctor`` suggests close matches
+   among existing chosen properties and shows how to define one in an overlay.
+
+Nonexistent node paths
+   E.g. :c:macro:`DT_PATH` with a path that does not exist. ``dtdoctor`` reports the closest
+   existing ancestor node, its children, and similar existing paths.
+
+Missing or mistyped properties
+   E.g. :c:macro:`DT_PROP` for a property that is not set on the node. If the property is declared
+   in the node's binding, ``dtdoctor`` shows its type and description and how to set it in an
+   overlay; otherwise it suggests close matches among the node's properties. Out-of-range array
+   indexes (e.g. :c:macro:`DT_PROP_BY_IDX` past the end of an array) are also detected.
+
+Invalid instance numbers
+   E.g. :c:macro:`DT_INST` with an instance number that is out of range, or a compatible that no
+   node matches. ``dtdoctor`` reports the valid instance numbers, and points out nodes that have
+   the right compatible but are not enabled.
 
 Using dtdoctor
 **************
@@ -19,3 +53,15 @@ For example:
 .. code-block:: shell
 
    west build -b reel_board samples/basic/blinky -- -DZEPHYR_SCA_VARIANT=dtdoctor
+
+Standalone usage
+****************
+
+The underlying analyzer can also be run directly against the ``edt.pickle`` file of an existing
+build, passing a symbol that appeared in a build error message:
+
+.. code-block:: shell
+
+   ./scripts/dts/dtdoctor_analyzer.py \
+       --edt-pickle ./build/zephyr/edt.pickle \
+       --symbol __device_dts_ord_123

--- a/scripts/dts/dtdoctor_analyzer.py
+++ b/scripts/dts/dtdoctor_analyzer.py
@@ -8,7 +8,16 @@ A script to help diagnose build errors related to Devicetree.
 
 To use this script as a standalone tool, provide the path to an edt.pickle file
 (e.g ./build/zephyr/edt.pickle) and a symbol that appeared in the build error
-message (e.g. __device_dts_ord_123).
+message.
+
+Supported symbol forms include:
+
+- __device_dts_ord_<N>            device symbol for a devicetree node
+- DT_N_ALIAS_<name>...            nonexistent devicetree alias
+- DT_N_NODELABEL_<name>...        nonexistent node label
+- DT_N_INST_<n>_<compat>...       nonexistent instance of a compatible
+- DT_N_S_<path>...                nonexistent node path or missing property
+- DT_CHOSEN_<name>...             missing /chosen property
 
 Example usage:
 
@@ -19,6 +28,7 @@ Example usage:
 """
 
 import argparse
+import difflib
 import os
 import pickle
 import re
@@ -60,8 +70,82 @@ def setup_kconfig() -> kconfiglib.Kconfig:
     return kconf
 
 
+def str2ident(s: str) -> str:
+    """
+    Convert 's' to the form gen_defines.py uses in devicetree C identifiers.
+    """
+    return re.sub("[-,.@/+]", "_", s.lower())
+
+
+def node_path_ident(node: edtlib.Node) -> str:
+    """
+    Return the 'DT_N...' identifier corresponding to the node's path, mirroring
+    node_z_path_id() in gen_defines.py.
+    """
+    components = ["DT_N"]
+    if node.parent is not None:
+        components.extend(f"S_{str2ident(component)}" for component in node.path.split("/")[1:])
+    return "_".join(components)
+
+
 def format_node(node: edtlib.Node) -> str:
     return f"{node.labels[0]}: {node.path}" if node.labels else node.path
+
+
+def strip_macro_suffix(ident: str) -> str:
+    """
+    Strip trailing devicetree macro machinery (e.g. '_P_gpios_IDX_0_PH_ORD') from a
+    mangled devicetree name. Mangled names are always lowercase (see str2ident) while
+    macro suffixes are uppercase, so cut at the first '_' followed by an uppercase
+    letter.
+    """
+    m = re.search(r"_[A-Z]", ident)
+    return ident[: m.start()] if m else ident
+
+
+def longest_ident_match(tail: str, idents) -> str | None:
+    """
+    Return the longest identifier from 'idents' that 'tail' is, or starts with
+    (followed by '_'), or None.
+    """
+    matches = [ident for ident in idents if tail == ident or tail.startswith(ident + "_")]
+    return max(matches, key=len) if matches else None
+
+
+def suggest(name: str, candidates: dict[str, str], intro: str) -> list[str]:
+    """
+    Return "did you mean" lines for 'name' against 'candidates', a dict mapping
+    identifier forms to display strings.
+    """
+    close = difflib.get_close_matches(name, candidates.keys(), n=3, cutoff=0.6)
+    if not close:
+        return []
+    return [intro] + [f" - {candidates[c]}" for c in close]
+
+
+def overlay_ref(node: edtlib.Node) -> str:
+    """
+    Return an overlay reference for the node: '&label' if it has a label, else
+    a path-based reference.
+    """
+    return f"&{node.labels[0]}" if node.labels else f"&{{{node.path}}}"
+
+
+def prop_placeholder(spec: edtlib.PropertySpec) -> str:
+    """
+    Return an example overlay assignment for a property of the given spec.
+    """
+    placeholders = {
+        "boolean": f"{spec.name};",
+        "string": f'{spec.name} = "...";',
+        "string-array": f'{spec.name} = "...", "...";',
+        "uint8-array": f"{spec.name} = [de ad be ef];",
+        "phandle": f"{spec.name} = <&some_node>;",
+        "phandles": f"{spec.name} = <&some_node &other_node>;",
+        "phandle-array": f"{spec.name} = <&some_node 1 2>;",
+        "path": f"{spec.name} = &some_node;",
+    }
+    return placeholders.get(spec.type, f"{spec.name} = <...>;")
 
 
 def find_kconfig_deps(kconf: kconfiglib.Kconfig, dt_has_symbol: str) -> set[str]:
@@ -199,6 +283,219 @@ def diagnose_ordinal(edt: edtlib.EDT, ordinal: int, kconf_factory) -> list[str]:
     return handle_disabled_node(node)
 
 
+def diagnose_missing_alias(edt: edtlib.EDT, rest: str) -> list[str]:
+    name = strip_macro_suffix(rest)
+    aliases = _alias2node(edt)
+    candidates = {
+        str2ident(alias): f"{alias} ({format_node(node)})" for alias, node in aliases.items()
+    }
+
+    lines = [
+        f"Devicetree alias '{name}' does not exist.\n",
+        "Note: in this identifier, characters like '-' in the actual alias name",
+        "appear as '_'.\n",
+    ]
+    lines.extend(suggest(name, candidates, "Did you mean one of these existing aliases?"))
+    lines.extend(
+        [
+            "\nTo define the alias, add something like this to your devicetree overlay:\n",
+            "    / {",
+            "            aliases {",
+            f"                    {name.replace('_', '-')} = &some_node_label;",
+            "            };",
+            "    };",
+        ]
+    )
+    return lines
+
+
+def diagnose_missing_nodelabel(edt: edtlib.EDT, rest: str) -> list[str]:
+    name = strip_macro_suffix(rest)
+    candidates = {
+        str2ident(label): f"{label} ({node.path})" for label, node in edt.label2node.items()
+    }
+
+    lines = [
+        f"No devicetree node has the node label '{name}'.\n",
+        "Note: DT_NODELABEL() expects the lowercase-and-underscores form of the label.\n",
+    ]
+    lines.extend(suggest(name, candidates, "Did you mean one of these existing node labels?"))
+    if not candidates:
+        lines.append("The final devicetree does not contain any labeled nodes.")
+    return lines
+
+
+def diagnose_missing_chosen(edt: edtlib.EDT, rest: str) -> list[str]:
+    name = strip_macro_suffix(rest)
+    chosen = getattr(edt, "chosen_nodes", {}) or {}
+    candidates = {
+        str2ident(cname): f"{cname} ({format_node(node)})" for cname, node in chosen.items()
+    }
+
+    lines = [
+        f"The devicetree has no chosen property named '{name}'.\n",
+        "Note: in this identifier, characters like ',' or '-' in the actual chosen",
+        "property name appear as '_'.\n",
+    ]
+    lines.extend(suggest(name, candidates, "Did you mean one of these existing chosen properties?"))
+    lines.extend(
+        [
+            "\nTo define it, add something like this to your devicetree overlay:\n",
+            "    / {",
+            "            chosen {",
+            "                    some,property = &some_node_label;",
+            "            };",
+            "    };",
+        ]
+    )
+    return lines
+
+
+def diagnose_instance(edt: edtlib.EDT, rest: str) -> list[str]:
+    m = re.match(r"(\d+)_(.*)", rest)
+    if not m:
+        return [f"Could not parse instance identifier 'DT_N_INST_{rest}'."]
+
+    inst = int(m.group(1))
+    tail = m.group(2)
+
+    compat_idents = {str2ident(compat): compat for compat in edt.compat2nodes}
+    match = longest_ident_match(tail, compat_idents)
+
+    if match is None:
+        name = strip_macro_suffix(tail)
+        lines = [f"No devicetree node has a compatible matching '{name}'.\n"]
+        lines.extend(suggest(name, compat_idents, "Did you mean one of these compatibles?"))
+        return lines
+
+    compat = compat_idents[match]
+    okay = edt.compat2okay.get(compat, [])
+    lines = [f"There is no instance {inst} of compatible '{compat}'.\n"]
+    if okay:
+        lines.append(
+            f"There are {len(okay)} enabled node(s) with this compatible "
+            f"(valid instance numbers: 0 to {len(okay) - 1}):"
+        )
+        lines.extend(f" - {format_node(n)}" for n in okay)
+    else:
+        lines.append(f"No node with compatible '{compat}' is enabled.")
+
+    disabled = [n for n in edt.compat2nodes.get(compat, []) if n.status != "okay"]
+    if disabled:
+        lines.append("\nThese nodes have the right compatible but are not enabled:")
+        lines.extend(f" - {format_node(n)} (status: {n.status})" for n in disabled)
+        lines.append("\nTry setting their 'status' property to 'okay'.")
+
+    return lines
+
+
+def diagnose_missing_property(edt: edtlib.EDT, node: edtlib.Node, rest: str) -> list[str]:
+    binding_specs = node.binding.prop2specs if node.binding else {}
+    candidates = {str2ident(name): name for name in {*binding_specs, *node.props}}
+    match = longest_ident_match(rest, candidates)
+
+    if match is None:
+        name = strip_macro_suffix(rest)
+        lines = [f"Node '{format_node(node)}' has no property '{name}'.\n"]
+        lines.extend(suggest(name, candidates, "Did you mean one of these properties of the node?"))
+        lines.append(
+            "\nNote: devicetree macros are only generated for properties that are"
+            "\ndeclared in the node's binding."
+        )
+        if node.binding_path:
+            lines.append(f"Binding: {node.binding_path}")
+        elif node.compats:
+            lines.append(f"No binding was found for compatible(s): {', '.join(node.compats)}")
+        else:
+            lines.append("The node has no 'compatible' property, so it has no binding.")
+        return lines
+
+    name = candidates[match]
+    suffix = rest[len(match) :]
+
+    if name in node.props:
+        prop = node.props[name]
+        m = re.match(r"_IDX_(\d+)", suffix)
+        if m and isinstance(prop.val, list):
+            idx = int(m.group(1))
+            if idx >= len(prop.val):
+                return [
+                    f"Index {idx} of property '{name}' on node '{format_node(node)}' "
+                    "is out of range.\n",
+                    f"The property only has {len(prop.val)} element(s) "
+                    f"(valid indexes: 0 to {len(prop.val) - 1}).",
+                ]
+        return [
+            f"Property '{name}' on node '{format_node(node)}' is set, but the",
+            "accessed macro does not exist.\n",
+            f"Check that the devicetree API used matches the property's type "
+            f"('{prop.spec.type if prop.spec else 'unknown'}').",
+        ]
+
+    # Property is declared in the binding but not set on the node
+    spec = binding_specs[name]
+    lines = [f"Node '{format_node(node)}' does not set the '{name}' property.\n"]
+    if spec.description:
+        lines.append(f"Description: {spec.description.strip().splitlines()[0]}")
+    lines.append(f"Type: {spec.type}")
+    lines.append(f"Binding: {node.binding_path}\n")
+    lines.extend(
+        [
+            "To set it, add something like this to your devicetree overlay:\n",
+            f"    {overlay_ref(node)} {{",
+            f"            {prop_placeholder(spec)}",
+            "    };",
+        ]
+    )
+    return lines
+
+
+def diagnose_path(edt: edtlib.EDT, sym: str) -> list[str]:
+    id2node = {node_path_ident(node): node for node in edt.nodes}
+
+    ancestor_ident = longest_ident_match(sym, id2node) or "DT_N"
+    ancestor = id2node.get(ancestor_ident)
+    rest = sym[len(ancestor_ident) :]
+
+    if ancestor is not None and not rest:
+        # The node exists; a bare node identifier ending up in an error message is unusual.
+        return [
+            f"Node '{format_node(ancestor)}' exists, but the symbol '{sym}' was not resolved.\n",
+            "Check that the node identifier is passed to a devicetree API macro.",
+        ]
+
+    if ancestor is not None and rest.startswith("_P_"):
+        return diagnose_missing_property(edt, ancestor, rest[len("_P_") :])
+
+    # Nonexistent node path. Reconstruct the attempted path, cutting off any
+    # macro suffix (uppercase markers other than the '_S_' path separators).
+    m = re.search(r"_(?!S_)[A-Z]", rest)
+    tail = rest[: m.start()] if m else rest
+    base = "" if ancestor is None or ancestor.path == "/" else ancestor.path
+    attempted = base + "/" + "/".join(seg for seg in tail.split("_S_") if seg)
+    attempted_ident = sym[: len(ancestor_ident)] + tail
+
+    lines = [
+        f"No node with path '{attempted}' exists in the final devicetree.\n",
+        "Note: in this path, characters like '@', '-' or ',' appear as '_'.\n",
+    ]
+
+    if ancestor is not None:
+        where = "the root node" if ancestor.path == "/" else f"'{format_node(ancestor)}'"
+        lines.append(f"The closest existing ancestor is {where}, whose children are:")
+        lines.extend(f" - {name}" for name in ancestor.children)
+        lines.append("")
+
+    lines.extend(
+        suggest(
+            attempted_ident,
+            {ident: node.path for ident, node in id2node.items()},
+            "Did you mean one of these existing nodes?",
+        )
+    )
+    return lines
+
+
 def diagnose(edt: edtlib.EDT, symbol: str, kconf_factory=setup_kconfig) -> list[str] | None:
     """
     Diagnose the given symbol against the given EDT. Returns a list of lines with
@@ -209,6 +506,25 @@ def diagnose(edt: edtlib.EDT, symbol: str, kconf_factory=setup_kconfig) -> list[
     m = re.fullmatch(r"__device_dts_ord_(\d+)", sym)
     if m:
         return diagnose_ordinal(edt, int(m.group(1)), kconf_factory)
+
+    # DEVICE_DT_GET() on an unresolved node identifier, e.g.
+    # __device_dts_ord_DT_N_NODELABEL_foo_ORD: diagnose the inner identifier.
+    m = re.fullmatch(r"__device_dts_ord_(DT_\w+?)(_ORD)?", sym)
+    if m:
+        return diagnose(edt, m.group(1), kconf_factory)
+
+    prefix_handlers = {
+        "DT_N_ALIAS_": diagnose_missing_alias,
+        "DT_N_NODELABEL_": diagnose_missing_nodelabel,
+        "DT_N_INST_": diagnose_instance,
+        "DT_CHOSEN_": diagnose_missing_chosen,
+    }
+    for prefix, handler in prefix_handlers.items():
+        if sym.startswith(prefix):
+            return handler(edt, sym[len(prefix) :])
+
+    if sym.startswith("DT_N_S_"):
+        return diagnose_path(edt, sym)
 
     return None
 

--- a/scripts/dts/dtdoctor_analyzer.py
+++ b/scripts/dts/dtdoctor_analyzer.py
@@ -147,7 +147,7 @@ def handle_disabled_node(node: edtlib.Node) -> list[str]:
         for name, n in (getattr(edt, "chosen_nodes", {}) or getattr(edt, "chosen", {})).items()
         if n is node
     ]
-    alias_refs = [name for name, n in getattr(edt, "aliases", {}).items() if n is node]
+    alias_refs = [name for name, n in _alias2node(edt).items() if n is node]
 
     if chosen_refs or alias_refs:
         lines.append("")
@@ -166,6 +166,10 @@ def handle_disabled_node(node: edtlib.Node) -> list[str]:
     lines.append("\nTry enabling the node by setting its 'status' property to 'okay'.")
 
     return lines
+
+
+def _alias2node(edt: edtlib.EDT) -> dict[str, edtlib.Node]:
+    return {alias: node for node in edt.nodes for alias in node.aliases}
 
 
 def main() -> int:

--- a/scripts/dts/dtdoctor_analyzer.py
+++ b/scripts/dts/dtdoctor_analyzer.py
@@ -103,7 +103,7 @@ def find_kconfig_deps(kconf: kconfiglib.Kconfig, dt_has_symbol: str) -> set[str]
     return deps
 
 
-def handle_enabled_node(node: edtlib.Node) -> list[str]:
+def handle_enabled_node(node: edtlib.Node, kconf_factory=setup_kconfig) -> list[str]:
     """
     Handle diagnosis for an enabled DT node (linker error, one or more Kconfigs might be gating
     the device driver).
@@ -111,18 +111,32 @@ def handle_enabled_node(node: edtlib.Node) -> list[str]:
     lines = [f"'{format_node(node)}' is enabled but no driver appears to be available for it.\n"]
 
     compats = list(getattr(node, "compats", []))
-    if compats:
-        kconf = setup_kconfig()
-        deps = set()
+    if not compats:
+        lines.append("Could not determine compatible; check driver Kconfig manually.")
+        return lines
+
+    kconf = None
+    if kconf_factory is not None:
+        try:
+            kconf = kconf_factory()
+        except Exception:
+            kconf = None
+
+    deps = set()
+    if kconf is not None:
         for compat in compats:
             dt_has = f"DT_HAS_{edtlib.str_as_token(compat.upper())}_ENABLED"
             deps.update(find_kconfig_deps(kconf, dt_has))
 
-        if deps:
-            lines.append("Try enabling these Kconfig options:\n")
-            lines.extend(f" - {dep}=y" for dep in sorted(deps))
+    if deps:
+        lines.append("Try enabling these Kconfig options:\n")
+        lines.extend(f" - {dep}=y" for dep in sorted(deps))
     else:
-        lines.append("Could not determine compatible; check driver Kconfig manually.")
+        compat_list = ", ".join(f"'{c}'" for c in compats)
+        lines.append(
+            f"Check that a driver for compatible {compat_list} exists and that\n"
+            "the Kconfig options gating it are enabled."
+        )
 
     return lines
 
@@ -172,24 +186,41 @@ def _alias2node(edt: edtlib.EDT) -> dict[str, edtlib.Node]:
     return {alias: node for node in edt.nodes for alias in node.aliases}
 
 
+def diagnose_ordinal(edt: edtlib.EDT, ordinal: int, kconf_factory) -> list[str]:
+    node = next((n for n in edt.nodes if n.dep_ordinal == ordinal), None)
+    if not node:
+        return [
+            f"No devicetree node with dependency ordinal {ordinal} was found.\n",
+            "The build directory may be out of date; try a pristine build.",
+        ]
+
+    if node.status == "okay":
+        return handle_enabled_node(node, kconf_factory)
+    return handle_disabled_node(node)
+
+
+def diagnose(edt: edtlib.EDT, symbol: str, kconf_factory=setup_kconfig) -> list[str] | None:
+    """
+    Diagnose the given symbol against the given EDT. Returns a list of lines with
+    troubleshooting information, or None if the symbol is not recognized.
+    """
+    sym = symbol.strip()
+
+    m = re.fullmatch(r"__device_dts_ord_(\d+)", sym)
+    if m:
+        return diagnose_ordinal(edt, int(m.group(1)), kconf_factory)
+
+    return None
+
+
 def main() -> int:
     args = parse_args()
 
-    m = re.search(r"__device_dts_ord_(\d+)", args.symbol)
-    if not m:
-        return 1
-
-    # Find node by ordinal amongst all nodes
     edt = load_edt(args.edt_pickle)
-    node = next((n for n in edt.nodes if n.dep_ordinal == int(m.group(1))), None)
-    if not node:
-        print(f"Ordinal {m.group(1)} not found in edt.pickle", file=sys.stderr)
+    lines = diagnose(edt, args.symbol)
+    if lines is None:
+        print(f"Symbol '{args.symbol}' does not look like a devicetree symbol", file=sys.stderr)
         return 1
-
-    if node.status == "okay":
-        lines = handle_enabled_node(node)
-    else:
-        lines = handle_disabled_node(node)
 
     print(tabulate([["\n".join(lines)]], headers=["DT Doctor"], tablefmt="grid"))
     return 0

--- a/scripts/dts/dtdoctor_sca_wrapper.py
+++ b/scripts/dts/dtdoctor_sca_wrapper.py
@@ -22,18 +22,34 @@ import re
 import subprocess
 import sys
 
+# Devicetree-related symbols that may show up in compiler/linker error messages:
+# - __device_dts_ord_<N>: device symbol for a devicetree node (also matches the unresolved
+#   __device_dts_ord_DT_..._ORD form produced by DEVICE_DT_GET() on a nonexistent node)
+# - DT_N_*: unresolved node identifiers (nonexistent alias, node label, instance, path, or
+#   property macros)
+# - DT_CHOSEN_*: missing /chosen property
+_DT_SYM = r"(?:__device_dts_ord_\w+|DT_N_\w+|DT_CHOSEN_\w+)"
+
 _ERROR_PATTERNS = [
-    r"(__device_dts_ord_\d+).*undeclared here",  # gcc
-    r"use of undeclared identifier '(__device_dts_ord_\d+)'",  # LLVM/clang (ATfE)
-    r"undefined reference to.*(__device_dts_ord_\d+)",  # GNU ld
-    r"undefined symbol: (__device_dts_ord_\d+)",  # LLVM/lld (ATfE)
+    rf"'({_DT_SYM})' undeclared",  # gcc
+    rf"use of undeclared identifier '({_DT_SYM})'",  # LLVM/clang (ATfE)
+    rf"undefined reference to `?'?({_DT_SYM})",  # GNU ld
+    rf"undefined symbol: ({_DT_SYM})",  # LLVM/lld (ATfE)
 ]
+
+# Zephyr builds compile with -fdiagnostics-color=always, so the captured error output
+# contains ANSI SGR/erase-line escape sequences, including inside the quoted
+# identifiers the patterns above match on.
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 
 
 def extract_symbols(text: str) -> set[str]:
     """
     Extract devicetree-related symbols from compiler/linker error output.
     """
+    text = _ANSI_ESCAPE_RE.sub("", text)
+    # gcc quotes identifiers with Unicode quotation marks in UTF-8 locales
+    text = text.replace("‘", "'").replace("’", "'")
     return {m for p in _ERROR_PATTERNS for m in re.findall(p, text)}
 
 

--- a/scripts/dts/dtdoctor_sca_wrapper.py
+++ b/scripts/dts/dtdoctor_sca_wrapper.py
@@ -53,6 +53,26 @@ def extract_symbols(text: str) -> set[str]:
     return {m for p in _ERROR_PATTERNS for m in re.findall(p, text)}
 
 
+def run_diagnostics(symbols, edt_pickle: str) -> list[str]:
+    """
+    Run the analyzer for each symbol and return the unique diagnosis outputs, in symbol
+    order. A single faulty source line often produces several symbols that reduce to
+    the same root cause (e.g. every macro expanded from one nonexistent alias), so
+    identical diagnoses are only reported once.
+    """
+    diag_script = os.path.join(os.path.dirname(__file__), "dtdoctor_analyzer.py")
+    outputs = []
+    for symbol in sorted(symbols):
+        proc = subprocess.run(
+            [sys.executable, diag_script, "--edt-pickle", edt_pickle, "--symbol", symbol],
+            capture_output=True,
+            text=True,
+        )
+        if proc.stdout and proc.stdout not in outputs:
+            outputs.append(proc.stdout)
+    return outputs
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -76,18 +96,8 @@ def main() -> int:
 
     # Extract devicetree symbols from errors and run diagnostics
     if proc.returncode != 0 and args.edt_pickle:
-        diag_script = os.path.join(os.path.dirname(__file__), "dtdoctor_analyzer.py")
-        for symbol in sorted(extract_symbols(proc.stderr)):
-            subprocess.run(
-                [
-                    sys.executable,
-                    diag_script,
-                    "--edt-pickle",
-                    args.edt_pickle,
-                    "--symbol",
-                    symbol,
-                ]
-            )
+        for diagnosis in run_diagnostics(extract_symbols(proc.stderr), args.edt_pickle):
+            sys.stdout.write(diagnosis)
 
     return proc.returncode
 

--- a/scripts/dts/dtdoctor_sca_wrapper.py
+++ b/scripts/dts/dtdoctor_sca_wrapper.py
@@ -5,7 +5,7 @@
 
 """
 Compiler launcher wrapper that captures what appears to be Devicetree-related build errors, and
-diagnoses them using diagnose_build_error.py.
+diagnoses them using dtdoctor_analyzer.py.
 
 The tool is meant to be configured as a CMAKE_<LANG>_COMPILER_LAUNCHER or as a
 CMAKE_<LANG>_LINKER_LAUNCHER.
@@ -21,6 +21,20 @@ import os
 import re
 import subprocess
 import sys
+
+_ERROR_PATTERNS = [
+    r"(__device_dts_ord_\d+).*undeclared here",  # gcc
+    r"use of undeclared identifier '(__device_dts_ord_\d+)'",  # LLVM/clang (ATfE)
+    r"undefined reference to.*(__device_dts_ord_\d+)",  # GNU ld
+    r"undefined symbol: (__device_dts_ord_\d+)",  # LLVM/lld (ATfE)
+]
+
+
+def extract_symbols(text: str) -> set[str]:
+    """
+    Extract devicetree-related symbols from compiler/linker error output.
+    """
+    return {m for p in _ERROR_PATTERNS for m in re.findall(p, text)}
 
 
 def main() -> int:
@@ -44,18 +58,10 @@ def main() -> int:
     sys.stdout.write(proc.stdout)
     sys.stderr.write(proc.stderr)
 
-    # Extract __device_dts_ord_xxx symbols from errors and run diagnostics
+    # Extract devicetree symbols from errors and run diagnostics
     if proc.returncode != 0 and args.edt_pickle:
-        patterns = [
-            r"(__device_dts_ord_\d+).*undeclared here",  # gcc
-            r"undefined reference to.*(__device_dts_ord_\d+)",  # ld
-            r"use of undeclared identifier '(__device_dts_ord_\d+)'",  # LLVM/clang (ATfE)
-            r"undefined symbol: (__device_dts_ord_\d+)",  # LLVM/lld (ATfE)
-        ]
-        symbols = {m for p in patterns for m in re.findall(p, proc.stderr)}
-
         diag_script = os.path.join(os.path.dirname(__file__), "dtdoctor_analyzer.py")
-        for symbol in sorted(symbols):
+        for symbol in sorted(extract_symbols(proc.stderr)):
             subprocess.run(
                 [
                     sys.executable,

--- a/scripts/dts/dtdoctor_sca_wrapper.py
+++ b/scripts/dts/dtdoctor_sca_wrapper.py
@@ -50,7 +50,7 @@ def main() -> int:
             r"(__device_dts_ord_\d+).*undeclared here",  # gcc
             r"undefined reference to.*(__device_dts_ord_\d+)",  # ld
             r"use of undeclared identifier '(__device_dts_ord_\d+)'",  # LLVM/clang (ATfE)
-            r"undefined symbol: \(__device_dts_ord_(\d+)",  # LLVM/lld (ATfE)
+            r"undefined symbol: (__device_dts_ord_\d+)",  # LLVM/lld (ATfE)
         ]
         symbols = {m for p in patterns for m in re.findall(p, proc.stderr)}
 

--- a/scripts/dts/dtdoctor_test.py
+++ b/scripts/dts/dtdoctor_test.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
+
+"""
+Tests for dtdoctor_analyzer.py and dtdoctor_sca_wrapper.py.
+
+The diagnosis tests compare the full analyzer output against the expected text,
+with the temporary fixture directory normalized to '<test-data>'.
+
+Run with:
+
+    pytest ./scripts/dts/dtdoctor_test.py
+"""
+
+import sys
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import dtdoctor_analyzer as dtdoc
+import dtdoctor_sca_wrapper as wrapper
+import kconfiglib
+from devicetree import edtlib
+
+TEST_DTS = """
+/dts-v1/;
+
+/ {
+    #address-cells = <1>;
+    #size-cells = <1>;
+
+    aliases {
+        my-uart = &uart0;
+        backup-uart = &uart1;
+    };
+
+    chosen {
+        zephyr,console = &uart0;
+        zephyr,shell-uart = &uart1;
+    };
+
+    soc {
+        #address-cells = <1>;
+        #size-cells = <1>;
+
+        uart0: uart@1000 {
+            compatible = "vnd,serial";
+            reg = <0x1000 0x100>;
+            status = "okay";
+            current-speed = <115200>;
+            calibration = <1 2 3>;
+        };
+
+        uart1: uart@2000 {
+            compatible = "vnd,serial";
+            reg = <0x2000 0x100>;
+            status = "disabled";
+        };
+
+        i2c0: i2c@3000 {
+            compatible = "vnd,i2c";
+            reg = <0x3000 0x100>;
+            status = "okay";
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            sensor0: sensor@10 {
+                compatible = "vnd,sensor";
+                reg = <0x10>;
+                status = "okay";
+            };
+        };
+    };
+};
+"""
+
+SERIAL_BINDING = """
+description: Test UART
+
+compatible: "vnd,serial"
+
+properties:
+  reg:
+    type: array
+    required: true
+  current-speed:
+    type: int
+  fifo-depth:
+    type: int
+    description: Depth of the hardware FIFO
+  calibration:
+    type: array
+"""
+
+I2C_BINDING = """
+description: Test I2C controller
+
+compatible: "vnd,i2c"
+
+properties:
+  reg:
+    type: array
+    required: true
+"""
+
+SENSOR_BINDING = """
+description: Test sensor
+
+compatible: "vnd,sensor"
+
+properties:
+  reg:
+    type: array
+    required: true
+"""
+
+TEST_KCONFIG = """
+config DT_HAS_VND_SERIAL_ENABLED
+	bool
+	default y
+
+config SERIAL
+	bool "serial driver support"
+
+config UART_VND
+	bool "vnd uart driver"
+	default y
+	depends on SERIAL && DT_HAS_VND_SERIAL_ENABLED
+"""
+
+
+@pytest.fixture(scope="module")
+def env(tmp_path_factory) -> SimpleNamespace:
+    tmp_path = tmp_path_factory.mktemp("dtdoctor")
+
+    dts = tmp_path / "test.dts"
+    dts.write_text(TEST_DTS)
+
+    bindings = tmp_path / "bindings"
+    bindings.mkdir()
+    (bindings / "vnd,serial.yaml").write_text(SERIAL_BINDING)
+    (bindings / "vnd,i2c.yaml").write_text(I2C_BINDING)
+    (bindings / "vnd,sensor.yaml").write_text(SENSOR_BINDING)
+
+    kconfig = tmp_path / "Kconfig"
+    kconfig.write_text(TEST_KCONFIG)
+
+    return SimpleNamespace(
+        edt=edtlib.EDT(str(dts), [str(bindings)]),
+        kconf=kconfiglib.Kconfig(str(kconfig), warn=False),
+        path=tmp_path,
+    )
+
+
+@pytest.fixture
+def check(env):
+    def _check(symbol: str, expected: str, kconf_factory=None):
+        lines = dtdoc.diagnose(env.edt, symbol, kconf_factory=kconf_factory)
+        assert lines is not None, f"symbol '{symbol}' was not recognized"
+
+        out = "\n".join(lines)
+        out = out.replace(str(env.path), "<test-data>")
+        assert out == textwrap.dedent(expected).strip("\n")
+
+    return _check
+
+
+def test_disabled_node(env, check):
+    ordinal = env.edt.label2node["uart1"].dep_ordinal
+    # The diagnosis points at the line disabling the node in the fixture DTS
+    lineno = next(i for i, line in enumerate(TEST_DTS.splitlines(), 1) if "disabled" in line)
+    check(
+        f"__device_dts_ord_{ordinal}",
+        f"""
+        'uart1: /soc/uart@2000' is disabled in <test-data>/test.dts:{lineno}
+
+        It is referenced as a "chosen" in 'zephyr,shell-uart'
+        It is referenced by the following aliases: 'backup-uart'
+
+        Try enabling the node by setting its 'status' property to 'okay'.
+        """,
+    )
+
+
+def test_enabled_node_no_driver(env, check):
+    # Without a Kconfig tree, only generic guidance mentioning the compatible is given
+    ordinal = env.edt.label2node["uart0"].dep_ordinal
+    check(
+        f"__device_dts_ord_{ordinal}",
+        """
+        'uart0: /soc/uart@1000' is enabled but no driver appears to be available for it.
+
+        Check that a driver for compatible 'vnd,serial' exists and that
+        the Kconfig options gating it are enabled.
+        """,
+    )
+
+
+def test_enabled_node_kconfig_suggestions(env, check):
+    ordinal = env.edt.label2node["uart0"].dep_ordinal
+    check(
+        f"__device_dts_ord_{ordinal}",
+        """
+        'uart0: /soc/uart@1000' is enabled but no driver appears to be available for it.
+
+        Try enabling these Kconfig options:
+
+         - CONFIG_SERIAL=y
+        """,
+        kconf_factory=lambda: env.kconf,
+    )
+
+
+def test_find_kconfig_deps(env):
+    deps = dtdoc.find_kconfig_deps(env.kconf, "DT_HAS_VND_SERIAL_ENABLED")
+    assert deps == {"CONFIG_SERIAL"}
+
+
+def test_stale_ordinal(check):
+    check(
+        "__device_dts_ord_9999",
+        """
+        No devicetree node with dependency ordinal 9999 was found.
+
+        The build directory may be out of date; try a pristine build.
+        """,
+    )
+
+
+@pytest.mark.parametrize("symbol", ["some_random_symbol", "DT_FOO", "z_impl_k_sleep"])
+def test_unrecognized_symbol(env, symbol):
+    assert dtdoc.diagnose(env.edt, symbol) is None
+
+
+def test_wrapper_extract_symbols_gcc():
+    stderr = (
+        "main.c:10:5: error: '__device_dts_ord_123' undeclared here (not in a function); "
+        "did you mean '__device_dts_ord_16'?\n"
+    )
+    assert wrapper.extract_symbols(stderr) == {"__device_dts_ord_123"}
+
+
+def test_wrapper_extract_symbols_clang():
+    stderr = "main.c:10:5: error: use of undeclared identifier '__device_dts_ord_42'\n"
+    assert wrapper.extract_symbols(stderr) == {"__device_dts_ord_42"}
+
+
+def test_wrapper_extract_symbols_ld():
+    stderr = "main.c:(.text+0x4): undefined reference to `__device_dts_ord_7'\n"
+    assert wrapper.extract_symbols(stderr) == {"__device_dts_ord_7"}
+
+
+def test_wrapper_extract_symbols_lld():
+    stderr = "ld.lld: error: undefined symbol: __device_dts_ord_11\n"
+    assert wrapper.extract_symbols(stderr) == {"__device_dts_ord_11"}
+
+
+def test_wrapper_extract_symbols_no_match():
+    stderr = "main.c:10:5: error: 'foo' undeclared (first use in this function)\n"
+    assert wrapper.extract_symbols(stderr) == set()

--- a/scripts/dts/dtdoctor_test.py
+++ b/scripts/dts/dtdoctor_test.py
@@ -14,6 +14,7 @@ Run with:
     pytest ./scripts/dts/dtdoctor_test.py
 """
 
+import pickle
 import sys
 import textwrap
 from pathlib import Path
@@ -500,3 +501,21 @@ def test_wrapper_extract_symbols_unicode_quotes():
     # gcc quotes identifiers with Unicode quotation marks in UTF-8 locales
     stderr = "main.c:10:5: error: ‘DT_N_NODELABEL_foo_ORD’ undeclared\n"
     assert wrapper.extract_symbols(stderr) == {"DT_N_NODELABEL_foo_ORD"}
+
+
+def test_wrapper_dedupes_diagnoses(env, tmp_path):
+    # A single faulty source line typically produces several distinct symbols that
+    # reduce to the same root cause: only one diagnosis should be reported
+    edt_pickle = tmp_path / "edt.pickle"
+    edt_pickle.write_bytes(pickle.dumps(env.edt))
+
+    outputs = wrapper.run_diagnostics(
+        {
+            "__device_dts_ord_DT_N_ALIAS_my_usrt_P_gpios_IDX_0_PH_ORD",
+            "DT_N_ALIAS_my_usrt_P_gpios_IDX_0_VAL_pin",
+        },
+        str(edt_pickle),
+    )
+
+    assert len(outputs) == 1
+    assert "alias 'my_usrt' does not exist" in outputs[0]

--- a/scripts/dts/dtdoctor_test.py
+++ b/scripts/dts/dtdoctor_test.py
@@ -233,6 +233,213 @@ def test_stale_ordinal(check):
     )
 
 
+def test_missing_alias(check):
+    check(
+        "DT_N_ALIAS_my_usrt_P_gpios_IDX_0_PH_ORD",
+        """
+        Devicetree alias 'my_usrt' does not exist.
+
+        Note: in this identifier, characters like '-' in the actual alias name
+        appear as '_'.
+
+        Did you mean one of these existing aliases?
+         - my-uart (uart0: /soc/uart@1000)
+
+        To define the alias, add something like this to your devicetree overlay:
+
+            / {
+                    aliases {
+                            my-usrt = &some_node_label;
+                    };
+            };
+        """,
+    )
+
+
+def test_missing_nodelabel(check):
+    check(
+        "DT_N_NODELABEL_usrt0_ORD",
+        """
+        No devicetree node has the node label 'usrt0'.
+
+        Note: DT_NODELABEL() expects the lowercase-and-underscores form of the label.
+
+        Did you mean one of these existing node labels?
+         - uart0 (/soc/uart@1000)
+         - uart1 (/soc/uart@2000)
+        """,
+    )
+
+
+def test_missing_chosen(check):
+    check(
+        "DT_CHOSEN_zephyr_consol",
+        """
+        The devicetree has no chosen property named 'zephyr_consol'.
+
+        Note: in this identifier, characters like ',' or '-' in the actual chosen
+        property name appear as '_'.
+
+        Did you mean one of these existing chosen properties?
+         - zephyr,console (uart0: /soc/uart@1000)
+         - zephyr,shell-uart (uart1: /soc/uart@2000)
+
+        To define it, add something like this to your devicetree overlay:
+
+            / {
+                    chosen {
+                            some,property = &some_node_label;
+                    };
+            };
+        """,
+    )
+
+
+def test_missing_node_path(check):
+    check(
+        "DT_N_S_soc_S_spi_4000_P_reg",
+        """
+        No node with path '/soc/spi_4000' exists in the final devicetree.
+
+        Note: in this path, characters like '@', '-' or ',' appear as '_'.
+
+        The closest existing ancestor is '/soc', whose children are:
+         - uart@1000
+         - uart@2000
+         - i2c@3000
+
+        Did you mean one of these existing nodes?
+         - /soc/i2c@3000
+         - /soc/uart@2000
+         - /soc/uart@1000
+        """,
+    )
+
+
+def test_missing_child_node_path(check):
+    check(
+        "DT_N_S_soc_S_i2c_3000_S_sensor_20_P_reg",
+        """
+        No node with path '/soc/i2c@3000/sensor_20' exists in the final devicetree.
+
+        Note: in this path, characters like '@', '-' or ',' appear as '_'.
+
+        The closest existing ancestor is 'i2c0: /soc/i2c@3000', whose children are:
+         - sensor@10
+
+        Did you mean one of these existing nodes?
+         - /soc/i2c@3000/sensor@10
+         - /soc/i2c@3000
+         - /soc/uart@2000
+        """,
+    )
+
+
+def test_missing_property_declared_in_binding(check):
+    check(
+        "DT_N_S_soc_S_uart_1000_P_fifo_depth",
+        """
+        Node 'uart0: /soc/uart@1000' does not set the 'fifo-depth' property.
+
+        Description: Depth of the hardware FIFO
+        Type: int
+        Binding: <test-data>/bindings/vnd,serial.yaml
+
+        To set it, add something like this to your devicetree overlay:
+
+            &uart0 {
+                    fifo-depth = <...>;
+            };
+        """,
+    )
+
+
+def test_property_typo(check):
+    check(
+        "DT_N_S_soc_S_uart_1000_P_curent_speed",
+        """
+        Node 'uart0: /soc/uart@1000' has no property 'curent_speed'.
+
+        Did you mean one of these properties of the node?
+         - current-speed
+
+        Note: devicetree macros are only generated for properties that are
+        declared in the node's binding.
+        Binding: <test-data>/bindings/vnd,serial.yaml
+        """,
+    )
+
+
+def test_property_index_out_of_range(check):
+    check(
+        "DT_N_S_soc_S_uart_1000_P_calibration_IDX_5",
+        """
+        Index 5 of property 'calibration' on node 'uart0: /soc/uart@1000' is out of range.
+
+        The property only has 3 element(s) (valid indexes: 0 to 2).
+        """,
+    )
+
+
+def test_property_set_but_wrong_accessor(check):
+    check(
+        "DT_N_S_soc_S_uart_1000_P_current_speed_STRING_TOKEN",
+        """
+        Property 'current-speed' on node 'uart0: /soc/uart@1000' is set, but the
+        accessed macro does not exist.
+
+        Check that the devicetree API used matches the property's type ('int').
+        """,
+    )
+
+
+def test_instance_out_of_range(check):
+    check(
+        "DT_N_INST_3_vnd_serial_P_current_speed",
+        """
+        There is no instance 3 of compatible 'vnd,serial'.
+
+        There are 1 enabled node(s) with this compatible (valid instance numbers: 0 to 0):
+         - uart0: /soc/uart@1000
+
+        These nodes have the right compatible but are not enabled:
+         - uart1: /soc/uart@2000 (status: disabled)
+
+        Try setting their 'status' property to 'okay'.
+        """,
+    )
+
+
+def test_instance_unknown_compat(check):
+    check(
+        "DT_N_INST_0_vnd_serail_P_current_speed",
+        """
+        No devicetree node has a compatible matching 'vnd_serail'.
+
+        Did you mean one of these compatibles?
+         - vnd,serial
+         - vnd,sensor
+        """,
+    )
+
+
+def test_device_get_on_missing_nodelabel(check):
+    # DEVICE_DT_GET(DT_NODELABEL(usrt0)) leaves an unresolved __device_dts_ord_DT_..._ORD
+    # symbol; the inner node identifier is diagnosed
+    check(
+        "__device_dts_ord_DT_N_NODELABEL_usrt0_ORD",
+        """
+        No devicetree node has the node label 'usrt0'.
+
+        Note: DT_NODELABEL() expects the lowercase-and-underscores form of the label.
+
+        Did you mean one of these existing node labels?
+         - uart0 (/soc/uart@1000)
+         - uart1 (/soc/uart@2000)
+        """,
+    )
+
+
 @pytest.mark.parametrize("symbol", ["some_random_symbol", "DT_FOO", "z_impl_k_sleep"])
 def test_unrecognized_symbol(env, symbol):
     assert dtdoc.diagnose(env.edt, symbol) is None
@@ -242,13 +449,25 @@ def test_wrapper_extract_symbols_gcc():
     stderr = (
         "main.c:10:5: error: '__device_dts_ord_123' undeclared here (not in a function); "
         "did you mean '__device_dts_ord_16'?\n"
+        "main.c:12:5: error: 'DT_N_NODELABEL_foo_ORD' undeclared (first use in this function)\n"
     )
-    assert wrapper.extract_symbols(stderr) == {"__device_dts_ord_123"}
+    assert wrapper.extract_symbols(stderr) == {
+        "__device_dts_ord_123",
+        "DT_N_NODELABEL_foo_ORD",
+    }
 
 
 def test_wrapper_extract_symbols_clang():
-    stderr = "main.c:10:5: error: use of undeclared identifier '__device_dts_ord_42'\n"
-    assert wrapper.extract_symbols(stderr) == {"__device_dts_ord_42"}
+    stderr = (
+        "main.c:10:5: error: use of undeclared identifier '__device_dts_ord_42'\n"
+        "main.c:12:5: error: use of undeclared identifier 'DT_N_ALIAS_led0_P_gpios_IDX_0_PH_ORD'\n"
+        "main.c:14:5: error: use of undeclared identifier 'DT_CHOSEN_zephyr_display'\n"
+    )
+    assert wrapper.extract_symbols(stderr) == {
+        "__device_dts_ord_42",
+        "DT_N_ALIAS_led0_P_gpios_IDX_0_PH_ORD",
+        "DT_CHOSEN_zephyr_display",
+    }
 
 
 def test_wrapper_extract_symbols_ld():
@@ -264,3 +483,20 @@ def test_wrapper_extract_symbols_lld():
 def test_wrapper_extract_symbols_no_match():
     stderr = "main.c:10:5: error: 'foo' undeclared (first use in this function)\n"
     assert wrapper.extract_symbols(stderr) == set()
+
+
+def test_wrapper_extract_symbols_colored():
+    # Zephyr builds pass -fdiagnostics-color=always, so the captured stderr contains
+    # ANSI escape sequences, including inside the quoted identifiers
+    stderr = (
+        "main.c:23:15: \x1b[01;31m\x1b[Kerror: \x1b[m\x1b[K"
+        "'\x1b[01m\x1b[K__device_dts_ord_DT_CHOSEN_zephyr_display_ORD\x1b[m\x1b[K'"
+        " undeclared (first use in this function)\n"
+    )
+    assert wrapper.extract_symbols(stderr) == {"__device_dts_ord_DT_CHOSEN_zephyr_display_ORD"}
+
+
+def test_wrapper_extract_symbols_unicode_quotes():
+    # gcc quotes identifiers with Unicode quotation marks in UTF-8 locales
+    stderr = "main.c:10:5: error: ‘DT_N_NODELABEL_foo_ORD’ undeclared\n"
+    assert wrapper.extract_symbols(stderr) == {"DT_N_NODELABEL_foo_ORD"}


### PR DESCRIPTION
Extend the DT Doctor analyzer beyond unresolved __device_dts_ord_N
device symbols so it can diagnose, and propose fixes for, additional
classes of devicetree build errors:

- nonexistent node labels and aliases, with "did you mean" suggestions
  and an overlay snippet showing how to define a missing alias
- missing /chosen properties, with suggestions and an overlay snippet
- nonexistent node paths, reporting the closest existing ancestor node,
  its children, and similar existing paths
- properties that are not set but declared in the node's binding,
  showing their type, description, and how to set them in an overlay
- mistyped property names, with suggestions based on the node's binding
- out-of-range array property indexes
- DT_INST() with an out-of-range instance number or unknown compatible,
  listing valid instance numbers and disabled candidate nodes
- DEVICE_DT_GET() on an unresolved node identifier
  (__device_dts_ord_DT_..._ORD symbols)

The SCA wrapper now recognizes these identifiers in gcc, clang, GNU ld
and LLVM lld error messages. This also fixes the lld pattern, which
previously only captured the ordinal digits, producing a symbol the
analyzer could not parse.

The analyzer is refactored around a diagnose() entry point that takes an
EDT and a symbol, making it testable without a full build; the Kconfig
tree used for driver suggestions is now injectable and failures to load
it no longer prevent diagnosis. Alias references to disabled nodes are
now correctly reported (the previous code looked up a nonexistent
edt.aliases attribute).

Add a pytest suite covering all diagnosis classes and the wrapper's
error-message parsing, wired into the scripts tests CI workflow, and
document the detected error classes and standalone usage.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QXZR3L7KApt3EzBKEVUfs7