### PR TITLE
drivers: input: optimize for size with static const constant data

### DIFF
--- a/drivers/input/input_ch9350l.c
+++ b/drivers/input/input_ch9350l.c
@@ -397,10 +397,10 @@ static int ch9350l_init(struct device const *dev)
 	static struct ch9350l_config const ch9350l_config_##inst = {				\
 		.uart = DEVICE_DT_GET(DT_INST_BUS(inst)),					\
 		.kb_codemap = COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(inst), kb_codemap),	\
-					  ((int []) DT_INST_PROP(inst, kb_codemap)), NULL),	\
+					  ((const int []) DT_INST_PROP(inst, kb_codemap)), NULL),	\
 		.kb_codemap_len = DT_INST_PROP_LEN_OR(inst, kb_codemap, 0),			\
 		.mouse_codemap = COND_CODE_1(DT_NODE_HAS_PROP(DT_DRV_INST(inst), mouse_codemap),\
-				((int []) DT_INST_PROP(inst, mouse_codemap)), NULL),		\
+				((const int []) DT_INST_PROP(inst, mouse_codemap)), NULL),		\
 		.mouse_codemap_len = DT_INST_PROP_LEN_OR(inst, mouse_codemap, 0),		\
 	};											\
 												\

--- a/drivers/input/input_chsc5x.c
+++ b/drivers/input/input_chsc5x.c
@@ -68,7 +68,7 @@ static void chsc5x_work_handler(struct k_work *work)
 	uint16_t row, col;
 	bool is_pressed;
 	int ret;
-	const uint8_t write_buffer[] = {
+	static const uint8_t write_buffer[] = {
 		CHSC5X_BASE_ADDR1,
 		CHSC5X_BASE_ADDR2,
 		CHSC5X_BASE_ADDR3,
@@ -112,7 +112,7 @@ static int chsc5x_verify_ic(const struct device *dev)
 {
 	const struct chsc5x_config *cfg = dev->config;
 	int ret;
-	const uint8_t write_buffer[] = {
+	static const uint8_t write_buffer[] = {
 		CHSC5X_BASE_ADDR1,
 		CHSC5X_BASE_ADDR2,
 		CHSC5X_BASE_ADDR3,
@@ -198,7 +198,7 @@ static int chsc5x_pm_action(const struct device *dev, enum pm_device_action acti
 		break;
 
 	case PM_DEVICE_ACTION_SUSPEND: {
-		const uint8_t write_buffer[] = {
+		static const uint8_t write_buffer[] = {
 			CHSC5X_BASE_ADDR1,
 			CHSC5X_BASE_ADDR2,
 			CHSC5X_BASE_ADDR3,

--- a/drivers/input/input_gt911.c
+++ b/drivers/input/input_gt911.c
@@ -148,7 +148,8 @@ static int gt911_process(const struct device *dev)
 	points = status & GT911_TOUCH_POINTS_MSK;
 
 	/* need to clear the status */
-	uint8_t clear_buffer[3] = {(uint8_t)GT911_REG_STATUS, (uint8_t)(GT911_REG_STATUS >> 8), 0};
+	static const uint8_t clear_buffer[3] = {(uint8_t)GT911_REG_STATUS,
+						(uint8_t)(GT911_REG_STATUS >> 8), 0};
 
 	r = gt911_i2c_write(dev, clear_buffer, sizeof(clear_buffer));
 	if (r < 0) {

--- a/drivers/input/input_nunchuk.c
+++ b/drivers/input/input_nunchuk.c
@@ -144,8 +144,8 @@ static int nunchuk_init(const struct device *dev)
 	struct nunchuk_data *data = dev->data;
 	int ret;
 
-	uint8_t init_seq_1[2] = {0xf0, 0x55};
-	uint8_t init_seq_2[2] = {0xfb, 0x00};
+	static const uint8_t init_seq_1[2] = {0xf0, 0x55};
+	static const uint8_t init_seq_2[2] = {0xfb, 0x00};
 	uint8_t buffer[NUNCHUK_READ_SIZE];
 
 	data->dev = dev;

--- a/drivers/input/input_renesas_rx_ctsu.c
+++ b/drivers/input/input_renesas_rx_ctsu.c
@@ -79,9 +79,9 @@ struct renesas_rx_ctsu_config {
 	uint8_t *channels_index_map;
 	uint8_t *button_position_index;
 	/** Touch components */
-	touch_button_context_t *buttons;
-	touch_slider_context_t *sliders;
-	touch_wheel_context_t *wheels;
+	const touch_button_context_t *buttons;
+	const touch_slider_context_t *sliders;
+	const touch_wheel_context_t *wheels;
 };
 
 struct renesas_rx_ctsu_data {
@@ -530,11 +530,11 @@ static int renesas_rx_ctsu_init(const struct device *dev)
 		}                                                                                  \
 	}                                                                                          \
                                                                                                    \
-	static touch_button_context_t buttons_##idx[] = {                                          \
+	static const touch_button_context_t buttons_##idx[] = {                                    \
 		DT_INST_FOREACH_CHILD_STATUS_OKAY(idx, BUTTON_GET_CONTEXT)};                       \
-	static touch_slider_context_t sliders_##idx[] = {                                          \
+	static const touch_slider_context_t sliders_##idx[] = {                                    \
 		DT_INST_FOREACH_CHILD_STATUS_OKAY(idx, SLIDER_GET_CONTEXT)};                       \
-	static touch_wheel_context_t wheels_##idx[] = {                                            \
+	static const touch_wheel_context_t wheels_##idx[] = {                                      \
 		DT_INST_FOREACH_CHILD_STATUS_OKAY(idx, WHEEL_GET_CONTEXT)};                        \
                                                                                                    \
 	static touch_button_cfg_t                                                                  \

--- a/drivers/input/input_sbus.c
+++ b/drivers/input/input_sbus.c
@@ -25,7 +25,7 @@ struct sbus_input_channel {
 	uint32_t zephyr_code;
 };
 
-const struct uart_config uart_cfg_sbus = {
+static const struct uart_config uart_cfg_sbus = {
 	.baudrate = 100000,
 	.parity = UART_CFG_PARITY_EVEN,
 	.stop_bits = UART_CFG_STOP_BITS_2,

--- a/drivers/input/input_xec_kbd.c
+++ b/drivers/input/input_xec_kbd.c
@@ -195,7 +195,7 @@ static const struct input_kbd_matrix_api xec_kbd_api = {
 /* To enable wakeup, set the "wakeup-source" on the keyboard scanning device
  * node.
  */
-static struct xec_kbd_config xec_kbd_cfg_0 = {
+static const struct xec_kbd_config xec_kbd_cfg_0 = {
 	.common = INPUT_KBD_MATRIX_DT_INST_COMMON_CONFIG_INIT(0, &xec_kbd_api),
 	.base = DT_INST_REG_ADDR(0),
 	.girq = DEV_CFG_GIRQ(0),


### PR DESCRIPTION
Move compile-time-constant, read-only data out of RAM/stack into .rodata
(flash) across several input drivers, and mark file-scope constant tables
with internal linkage. These are qualifier-only changes with no functional
impact.

- ch9350l: make the kb/mouse codemap compound literals const, matching the
  already-const kb_codemap/mouse_codemap config fields.
- chsc5x: mark the fixed I2C command write_buffers static (they were
  already const) in the work handler, IC verify and PM suspend paths.
- gt911: make the status-clear command buffer static const.
- nunchuk: make the fixed init sequences static const.
- renesas_rx_ctsu: make the devicetree-derived button/slider/wheel context
  tables const, and const-qualify the matching config pointer fields; the
  mutable runtime state lives in separate arrays.
- sbus: give the file-local uart_config internal linkage (static).
- xec_kbd: mark the device config struct const, matching every other
  kbd-matrix driver (npcx, it8xxx2, rts5912).

Assisted-by: Claude:opus-4.8
Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>