### PR TITLE
drivers: ethernet: sam_gmac: clean only transmitted length on TX

### DIFF
--- a/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
+++ b/drivers/ethernet/dwc_xgmac/eth_dwc_xgmac.c
@@ -1360,7 +1360,7 @@ static int eth_dwc_xgmac_send(const struct device *dev, struct net_pkt *pkt)
 	struct eth_dwc_xgmac_dev_data *dev_data = (struct eth_dwc_xgmac_dev_data *)dev->data;
 	struct xgmac_dma_chnl_config *dma_ch_cfg =
 		(struct xgmac_dma_chnl_config *)&dev_conf->dma_chnl_cfg;
-	uint32_t tdes2_flgs, tdes3_flgs, tdes3_fd_flg;
+	uint32_t tdes2_flgs, tdes3_flgs, tdes3_fd_flg, pkt_len;
 
 	if (!pkt || !pkt->frags) {
 		LOG_ERR("%s: cannot TX, invalid argument", dev->name);
@@ -1382,6 +1382,7 @@ static int eth_dwc_xgmac_send(const struct device *dev, struct net_pkt *pkt)
 		return -EIO;
 	}
 
+	pkt_len = net_pkt_get_len(pkt);
 	context.q_id = net_tx_priority2tc(net_pkt_priority(pkt));
 	context.descmeta = (struct xgmac_dma_tx_desc_meta *)&dev_data->tx_desc_meta[context.q_id];
 	context.pkt_desc_id = context.descmeta->next_to_use;
@@ -1400,7 +1401,7 @@ static int eth_dwc_xgmac_send(const struct device *dev, struct net_pkt *pkt)
 							       (context.q_id * dma_ch_cfg->tdrl) +
 							       context.pkt_desc_id);
 		arch_dcache_invd_range(context.tx_desc, sizeof(context.tx_desc));
-		arch_dcache_flush_range(frag->data, CONFIG_NET_BUF_DATA_SIZE);
+		arch_dcache_flush_range(frag->data, frag->len);
 		context.tx_desc->tdes0 = (uint32_t)POINTER_TO_UINT(frag->data);
 		context.tx_desc->tdes1 = (uint32_t)(POINTER_TO_UINT(frag->data) >> 32u);
 		tdes2_flgs = frag->len;
@@ -1408,7 +1409,7 @@ static int eth_dwc_xgmac_send(const struct device *dev, struct net_pkt *pkt)
 #ifdef CONFIG_ETH_DWC_XGMAC_TX_CS_OFFLOAD
 			     XGMAC_TDES3_CS_EN_MSK |
 #endif
-			     net_pkt_get_len(pkt);
+			     pkt_len;
 		tdes3_fd_flg = 0;
 
 		if (!frag->frags) { /* check last fragment of the packet */
@@ -1447,7 +1448,7 @@ static int eth_dwc_xgmac_send(const struct device *dev, struct net_pkt *pkt)
 	/* unlock the TX desc ring */
 	(void)k_mutex_unlock(&(context.descmeta->ring_lock));
 
-	UPDATE_ETH_STATS_TX_BYTE_CNT(dev_data, net_pkt_get_len(pkt));
+	UPDATE_ETH_STATS_TX_BYTE_CNT(dev_data, pkt_len);
 	UPDATE_ETH_STATS_TX_PKT_CNT(dev_data, 1u);
 
 	return 0;

--- a/drivers/ethernet/eth_adin2111.c
+++ b/drivers/ethernet/eth_adin2111.c
@@ -266,12 +266,11 @@ int eth_adin2111_oa_data_read(const struct device *dev, const uint16_t port_idx)
 	rca &= ADIN2111_BUFSTS_RCA_MASK;
 
 	/* Preare all tx headers */
+	hdr = ADIN2111_OA_DATA_HDR_DNC;
+	hdr |= eth_adin2111_oa_get_parity(hdr);
+	hdr = sys_cpu_to_be32(hdr);
 	for (i = 0, len = 0; i < rca; ++i) {
-		hdr = ADIN2111_OA_DATA_HDR_DNC;
-		hdr |= eth_adin2111_oa_get_parity(hdr);
-
-		*(uint32_t *)&ctx->oa_tx_buf[len] = sys_cpu_to_be32(hdr);
-
+		*(uint32_t *)&ctx->oa_tx_buf[len] = hdr;
 		len += sizeof(uint32_t) + ctx->oa_cps;
 	}
 
@@ -890,8 +889,15 @@ static int adin2111_port_send(const struct device *dev, struct net_pkt *pkt)
 		goto end_unlock;
 	}
 
-	/* prepare tx buffer */
-	memset(ctx->buf, 0, burst_size + ADIN2111_WRITE_HEADER_SIZE);
+	/* Only the trailing pad needs zeroing; header and payload are written below */
+	{
+		size_t data_end = ADIN2111_WRITE_HEADER_SIZE + ADIN2111_FRAME_HEADER_SIZE + pkt_len;
+		size_t total = ADIN2111_WRITE_HEADER_SIZE + burst_size;
+
+		if (total > data_end) {
+			memset(ctx->buf + data_end, 0, total - data_end);
+		}
+	}
 
 	/* spi header */
 	*(uint16_t *)ctx->buf = net_htons(ADIN2111_TXN_CTRL_TX_REG);

--- a/drivers/ethernet/eth_cyclonev.c
+++ b/drivers/ethernet/eth_cyclonev.c
@@ -439,7 +439,8 @@ static int eth_cyclonev_send(const struct device *dev, struct net_pkt *pkt)
 
 		/* Copy data to local buffer   */
 
-		memcpy(&p->tx_buf[p->tx_current_desc_number * ETH_BUFFER_SIZE], frag->data, len);
+		/* DMA sends only frag->len bytes from this slice */
+		memcpy(&p->tx_buf[p->tx_current_desc_number * ETH_BUFFER_SIZE], frag->data, frag->len);
 
 		/* Set the buffer size.  */
 		tx_desc->control_buffer_size = (frag->len & ETH_DMATXDESC_TBS1);

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -554,7 +554,7 @@ static void enc28j60_read_packet(const struct device *dev, uint16_t frm_len)
 	struct net_buf *pkt_buf;
 	struct net_pkt *pkt;
 	uint16_t lengthfr;
-	uint8_t dummy[4];
+	uint8_t dummy[5];
 
 	/* Get the frame from the buffer */
 	pkt = net_pkt_rx_alloc_with_buffer(get_iface(context), frm_len, NET_AF_UNSPEC, 0,
@@ -593,15 +593,8 @@ static void enc28j60_read_packet(const struct device *dev, uint16_t frm_len)
 		pkt_buf = pkt_buf->frags;
 	} while (frm_len > 0);
 
-	/* Let's pop the useless CRC */
-	eth_enc28j60_read_mem(dev, dummy, 4);
-
-	/* Pops one padding byte from spi circular buffer
-	 * introduced by the device when the frame length is odd
-	 */
-	if (lengthfr & 0x01) {
-		eth_enc28j60_read_mem(dev, dummy, 1);
-	}
+	/* Pop the CRC, plus the device's pad byte on odd lengths, in one read */
+	eth_enc28j60_read_mem(dev, dummy, (lengthfr & 0x01) ? 5 : 4);
 
 	/* Feed buffer frame to IP stack */
 	LOG_DBG("%s: Received packet of length %u", dev->name, lengthfr);
@@ -629,7 +622,7 @@ static int eth_enc28j60_rx(const struct device *dev)
 
 	do {
 		uint16_t frm_len = 0U;
-		uint8_t info[RSV_SIZE];
+		uint8_t info[2 + RSV_SIZE];
 		uint16_t next_packet;
 		uint8_t rdptl = 0U;
 		uint8_t rdpth = 0U;
@@ -641,8 +634,8 @@ static int eth_enc28j60_rx(const struct device *dev)
 		eth_enc28j60_write_reg(dev, ENC28J60_REG_ERDPTL, rdptl);
 		eth_enc28j60_write_reg(dev, ENC28J60_REG_ERDPTH, rdpth);
 
-		/* Read address for next packet */
-		eth_enc28j60_read_mem(dev, info, 2);
+		/* Read next-packet pointer and status vector in one read (ERDPT auto-increments) */
+		eth_enc28j60_read_mem(dev, info, 2 + RSV_SIZE);
 		next_packet = info[0] | (uint16_t)info[1] << 8;
 
 		/* Errata 14. Even values in ERXRDPT
@@ -654,17 +647,14 @@ static int eth_enc28j60_rx(const struct device *dev)
 			next_packet--;
 		}*/
 
-		/* Read reception status vector */
-		eth_enc28j60_read_mem(dev, info, 4);
-
 		/* Get the frame length from the rx status vector,
 		 * minus CRC size at the end which is always present
 		 */
-		if (sys_get_le16(info) <= 4U) {
-			LOG_ERR("Invalid enc28j60 frame length %u", sys_get_le16(info));
+		if (sys_get_le16(&info[2]) <= 4U) {
+			LOG_ERR("Invalid enc28j60 frame length %u", sys_get_le16(&info[2]));
 			break;
 		}
-		frm_len = sys_get_le16(info) - 4;
+		frm_len = sys_get_le16(&info[2]) - 4;
 
 		enc28j60_read_packet(dev, frm_len);
 

--- a/drivers/ethernet/eth_lan9250.c
+++ b/drivers/ethernet/eth_lan9250.c
@@ -742,13 +742,9 @@ static void lan9250_thread(void *p1, void *p2, void *p3)
 	struct lan9250_runtime *context = dev->data;
 	uint32_t int_sts;
 	uint16_t tmp = 0;
-	uint32_t ier;
 
 	while (true) {
 		k_sem_take(&context->int_sem, K_FOREVER);
-
-		/* Save interrupt enable register value */
-		lan9250_read_sys_reg(dev, LAN9250_INT_EN, &ier);
 
 		/* Disable interrupts to release the interrupt line */
 		lan9250_write_sys_reg(dev, LAN9250_INT_EN, 0);
@@ -773,7 +769,8 @@ static void lan9250_thread(void *p1, void *p2, void *p3)
 		}
 
 		/* Re-enable interrupts */
-		lan9250_write_sys_reg(dev, LAN9250_INT_EN, ier);
+		lan9250_write_sys_reg(dev, LAN9250_INT_EN,
+				      LAN9250_INT_EN_PHY_INT_EN | LAN9250_INT_EN_RSFL_EN);
 	}
 }
 

--- a/drivers/ethernet/eth_mchp_gmac_g1.c
+++ b/drivers/ethernet/eth_mchp_gmac_g1.c
@@ -589,9 +589,8 @@ static struct net_pkt *gmac_extract_and_replace_buffers(struct gmac_queue *queue
 		frag = new_frag;
 		rx_frag_list[tail] = frag;
 		rx_desc->status = 0U;
-		rx_desc->addr &= (~GMAC_RXW0_ADDR);
-		rx_desc->addr |= ((uint32_t)frag->data & GMAC_RXW0_ADDR);
-		rx_desc->addr &= (~GMAC_RXW0_OWNERSHIP);
+		rx_desc->addr = ((uint32_t)frag->data & GMAC_RXW0_ADDR) |
+				(rx_desc->addr & GMAC_RXW0_WRAP);
 
 		MODULO_INC(tail, rx_desc_list->len);
 		rx_desc = &rx_desc_list->buf_desc[tail];

--- a/drivers/ethernet/eth_numaker.c
+++ b/drivers/ethernet/eth_numaker.c
@@ -459,9 +459,10 @@ static void m_numaker_gmacdev_trigger_tx(synopGMACdevice *gmacdev, uint16_t leng
 	__DSB();
 	txdesc->status |= DescOwnByDma;
 
-	gmacdev->TxNext = synopGMAC_is_last_tx_desc(gmacdev, txdesc) ? 0 : txnext + 1;
-	gmacdev->TxNextDesc =
-		synopGMAC_is_last_tx_desc(gmacdev, txdesc) ? gmacdev->TxDesc : (txdesc + 1);
+	bool is_last = synopGMAC_is_last_tx_desc(gmacdev, txdesc);
+
+	gmacdev->TxNext = is_last ? 0 : txnext + 1;
+	gmacdev->TxNextDesc = is_last ? gmacdev->TxDesc : (txdesc + 1);
 
 	/* Enable the interrupt */
 	synopGMAC_enable_interrupt(gmacdev, DmaIntEnable);

--- a/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
+++ b/drivers/ethernet/eth_nxp_enet_qos/eth_nxp_enet_qos_mac.c
@@ -157,7 +157,8 @@ static int eth_nxp_enet_qos_tx(const struct device *dev, struct net_pkt *pkt)
 	LOG_DBG("Setting up TX descriptors for packet %p", pkt);
 
 	/* Reset the descriptors */
-	memset((void *)data->tx.descriptors, 0, sizeof(union nxp_enet_qos_tx_desc) * frags_count);
+	memset((void *)data->tx.descriptors, 0,
+	       sizeof(union nxp_enet_qos_tx_desc) * ((frags_count + 1) / 2));
 
 	/* Setting up the descriptors  */
 	fragment = pkt->frags;

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1380,7 +1380,7 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 		frag_len = frag->len;
 
 		/* Assure cache coherency before DMA read operation */
-		dcache_clean((uint32_t)frag_data, frag->size);
+		dcache_clean((uint32_t)frag_data, frag_len);
 
 #if GMAC_MULTIPLE_TX_PACKETS == 1
 		k_sem_take(&queue->tx_desc_sem, K_FOREVER);

--- a/drivers/ethernet/eth_sensry_sy1xx_mac.c
+++ b/drivers/ethernet/eth_sensry_sy1xx_mac.c
@@ -387,9 +387,7 @@ static int sy1xx_mac_low_level_send(const struct device *dev, uint8_t *tx, uint1
 	}
 
 	/* copy data to dma buffer */
-	for (uint32_t i = 0; i < len; i++) {
-		data->dma_buffers->tx[i] = tx[i];
-	}
+	memcpy(data->dma_buffers->tx, tx, len);
 
 	/* start dma transfer */
 	SY1XX_UDMA_START_TX(cfg->base_addr, (uint32_t)data->dma_buffers->tx, len, 0);
@@ -442,14 +440,12 @@ static int sy1xx_mac_send(const struct device *dev, struct net_pkt *pkt)
 	data->temp.tx_len = 0;
 	do {
 		/* copy fragment to buffer */
-		for (uint32_t i = 0; i < frag->len; i++) {
-			if (data->temp.tx_len < MAX_MAC_PACKET_LEN) {
-				data->temp.tx[data->temp.tx_len++] = frag->data[i];
-			} else {
-				LOG_ERR("tx buffer overflow");
-				return -ENOMEM;
-			}
+		if (data->temp.tx_len + frag->len > MAX_MAC_PACKET_LEN) {
+			LOG_ERR("tx buffer overflow");
+			return -ENOMEM;
 		}
+		memcpy(&data->temp.tx[data->temp.tx_len], frag->data, frag->len);
+		data->temp.tx_len += frag->len;
 
 		frag = frag->frags;
 	} while (frag);

--- a/drivers/ethernet/eth_smsc91x.c
+++ b/drivers/ethernet/eth_smsc91x.c
@@ -422,12 +422,9 @@ static void smsc_recv_pkt(struct eth_context *data)
 			}
 
 			/*
-			 * Pull the packet out of the device.
-			 */
-			smsc_select_bank(sc, 2);
-			smsc_write_1(sc, PNR, packet);
-
-			/*
+			 * Pull the packet out of the device; bank 2 and PNR are
+			 * still set from the header read above.
+			 *
 			 * Pointer start from 4 because we have already read status and len from
 			 * RX_FIFO
 			 */

--- a/drivers/ethernet/eth_w6100.c
+++ b/drivers/ethernet/eth_w6100.c
@@ -329,7 +329,10 @@ static void w6100_thread(void *p1, void *p2, void *p3)
 			/* Read interrupt */
 			w6100_spi_read(dev, W6100_S0_IR, &ir, 1);
 			w6100_spi_read(dev, W6100_SLIR, &slir, 1);
-			w6100_spi_write(dev, W6100_SLIRCLR, &slir, 1);
+			/* SLIRCLR is write-1-to-clear; nothing to do when slir == 0 */
+			if (slir != 0U) {
+				w6100_spi_write(dev, W6100_SLIRCLR, &slir, 1);
+			}
 
 
 			if (ir) {

--- a/drivers/ethernet/eth_wch.c
+++ b/drivers/ethernet/eth_wch.c
@@ -283,17 +283,19 @@ static struct net_pkt *eth_rx(const struct device *dev)
 	ETH_TypeDef *eth = config->regs;
 	struct net_pkt *pkt = NULL;
 
-	if ((dma_rx_desc_current->Status & ETH_DMARxDesc_OWN) != 0U) {
+	uint32_t desc_status = dma_rx_desc_current->Status;
+
+	if ((desc_status & ETH_DMARxDesc_OWN) != 0U) {
 		return NULL; /* Not error, simply packet has not arrived yet */
 	}
 
-	if (((dma_rx_desc_current->Status & ETH_DMARxDesc_ES) != 0U) ||
-	    ((dma_rx_desc_current->Status & (ETH_DMARxDesc_FS | ETH_DMARxDesc_LS)) !=
+	if (((desc_status & ETH_DMARxDesc_ES) != 0U) ||
+	    ((desc_status & (ETH_DMARxDesc_FS | ETH_DMARxDesc_LS)) !=
 	     (ETH_DMARxDesc_FS | ETH_DMARxDesc_LS))) {
 		goto release_desc; /* Drop descriptor if it is corrupt, or not a full frame */
 	}
 
-	size_t total_len = ((dma_rx_desc_current->Status & ETH_DMARxDesc_FL) >>
+	size_t total_len = ((desc_status & ETH_DMARxDesc_FL) >>
 			    ETH_DMARXDESC_FRAME_LENGTHSHIFT) -
 			   sizeof(uint32_t); /* This discards CRC (checked by hardware) */
 

--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -250,9 +250,10 @@ static void eth_xlnx_gem_isr(const struct device *dev)
 	const struct eth_xlnx_gem_dev_cfg *dev_conf = DEV_CFG(dev);
 	struct eth_xlnx_gem_dev_data *dev_data = DEV_DATA(dev);
 	uint32_t reg_val;
+	mm_reg_t mac_base = DEVICE_MMIO_NAMED_GET(dev, mac);
 
 	/* Read the interrupt status register */
-	reg_val = sys_read32(DEVICE_MMIO_NAMED_GET(dev, mac) + ETH_XLNX_GEM_ISR_OFFSET);
+	reg_val = sys_read32(mac_base + ETH_XLNX_GEM_ISR_OFFSET);
 
 	/*
 	 * TODO: handling if one or more error flag(s) are set in the
@@ -274,9 +275,9 @@ static void eth_xlnx_gem_isr(const struct device *dev)
 	 */
 	if ((reg_val & ETH_XLNX_GEM_IXR_TX_COMPLETE_BIT) != 0) {
 		sys_write32(ETH_XLNX_GEM_IXR_TX_COMPLETE_BIT,
-			    DEVICE_MMIO_NAMED_GET(dev, mac) + ETH_XLNX_GEM_IDR_OFFSET);
+			    mac_base + ETH_XLNX_GEM_IDR_OFFSET);
 		sys_write32(ETH_XLNX_GEM_IXR_TX_COMPLETE_BIT,
-			    DEVICE_MMIO_NAMED_GET(dev, mac) + ETH_XLNX_GEM_ISR_OFFSET);
+			    mac_base + ETH_XLNX_GEM_ISR_OFFSET);
 		if (dev_conf->defer_txd_to_queue) {
 			k_work_submit(&dev_data->tx_done_work);
 		} else {
@@ -285,9 +286,9 @@ static void eth_xlnx_gem_isr(const struct device *dev)
 	}
 	if ((reg_val & ETH_XLNX_GEM_IXR_FRAME_RX_BIT) != 0) {
 		sys_write32(ETH_XLNX_GEM_IXR_FRAME_RX_BIT,
-			    DEVICE_MMIO_NAMED_GET(dev, mac) + ETH_XLNX_GEM_IDR_OFFSET);
+			    mac_base + ETH_XLNX_GEM_IDR_OFFSET);
 		sys_write32(ETH_XLNX_GEM_IXR_FRAME_RX_BIT,
-			    DEVICE_MMIO_NAMED_GET(dev, mac) + ETH_XLNX_GEM_ISR_OFFSET);
+			    mac_base + ETH_XLNX_GEM_ISR_OFFSET);
 		if (dev_conf->defer_rxp_to_queue) {
 			k_work_submit(&dev_data->rx_pend_work);
 		} else {
@@ -306,7 +307,7 @@ static void eth_xlnx_gem_isr(const struct device *dev)
 	 */
 	sys_write32((0xFFFFFFFF & ~(ETH_XLNX_GEM_IXR_FRAME_RX_BIT |
 		    ETH_XLNX_GEM_IXR_TX_COMPLETE_BIT)),
-		    DEVICE_MMIO_NAMED_GET(dev, mac) + ETH_XLNX_GEM_ISR_OFFSET);
+		    mac_base + ETH_XLNX_GEM_ISR_OFFSET);
 }
 
 /**
@@ -1399,21 +1400,20 @@ static void eth_xlnx_gem_handle_rx_pending(const struct device *dev)
 		 * by the controller.
 		 */
 		do {
+			uint32_t this_len = (rx_data_remaining < dev_conf->rx_buffer_size) ?
+					    rx_data_remaining : dev_conf->rx_buffer_size;
+
 			if (pkt != NULL) {
+				const void *rx_buffer = (const void *)
+					(dev_data->rx_bd_ring.first_bd[curr_bd_idx].addr &
+					 ETH_XLNX_GEM_RX_BD_BUFFER_ADDR_MASK);
 #ifdef CONFIG_DCACHE
-				sys_cache_data_invd_range(
-					(void *)(dev_data->rx_bd_ring.first_bd[curr_bd_idx].addr &
-					ETH_XLNX_GEM_RX_BD_BUFFER_ADDR_MASK),
-					dev_conf->rx_buffer_size);
+				sys_cache_data_invd_range((void *)rx_buffer,
+							  dev_conf->rx_buffer_size);
 #endif
-				net_pkt_write(pkt, (const void *)
-					      (dev_data->rx_bd_ring.first_bd[curr_bd_idx].addr &
-					      ETH_XLNX_GEM_RX_BD_BUFFER_ADDR_MASK),
-					      (rx_data_remaining < dev_conf->rx_buffer_size) ?
-					      rx_data_remaining : dev_conf->rx_buffer_size);
+				net_pkt_write(pkt, rx_buffer, this_len);
 			}
-			rx_data_remaining -= (rx_data_remaining < dev_conf->rx_buffer_size) ?
-					     rx_data_remaining : dev_conf->rx_buffer_size;
+			rx_data_remaining -= this_len;
 
 			/*
 			 * The entire packet data of the current BD has been

--- a/drivers/ethernet/eth_xmc4xxx.c
+++ b/drivers/ethernet/eth_xmc4xxx.c
@@ -670,12 +670,15 @@ static struct net_pkt *eth_xmc4xxx_rx_pkt(const struct device *dev)
 			}
 		}
 
-prepare_dma_descriptor:
+prepare_dma_descriptor: {
+		struct net_buf *rx_buf = dev_data->rx_frag_list[tail];
+
 		/* Prepare the current DMA descriptor for the next reception. */
-		dma_desc->buffer1 = (uint32_t)dev_data->rx_frag_list[tail]->data;
-		dma_desc->length = dev_data->rx_frag_list[tail]->size |
+		dma_desc->buffer1 = (uint32_t)rx_buf->data;
+		dma_desc->length = rx_buf->size |
 				   ETH_RX_DMA_DESC_SECOND_ADDR_CHAINED_MASK;
 		dma_desc->status = ETH_MAC_DMA_RDES0_OWN;
+	}
 
 		if (tail == frame_end_index) {
 			/* Time to leave the loop. */

--- a/drivers/ethernet/intel/eth_intel_igc.c
+++ b/drivers/ethernet/intel/eth_intel_igc.c
@@ -571,11 +571,10 @@ static void eth_intel_igc_tx_clean(struct eth_intel_igc_mac_data *data, uint8_t 
  * sets up the descriptor with the fragment data, and updates the write pointer.
  */
 static int eth_intel_igc_tx_frag(const struct device *dev, struct net_pkt *pkt,
-				 struct net_buf *frag, uint8_t queue)
+				 struct net_buf *frag, uint8_t queue, uint16_t total_len)
 {
 	const struct eth_intel_igc_mac_cfg *cfg = dev->config;
 	struct eth_intel_igc_mac_data *data = dev->data;
-	uint16_t total_len = net_pkt_get_len(pkt);
 	union dma_tx_desc *desc;
 	uint32_t idx = 0;
 
@@ -634,13 +633,15 @@ static int eth_intel_igc_tx_data(const struct device *dev, struct net_pkt *pkt)
 		queue = cfg->num_queues - 1;
 	}
 
+	uint16_t total_len = net_pkt_get_len(pkt);
+
 	NET_PKT_FRAG_FOR_EACH(pkt, frag) {
 		/* Hold the Header fragment until transmit clean done */
 		if (frag == pkt->frags) {
 			net_pkt_frag_ref(frag);
 		}
 
-		ret = eth_intel_igc_tx_frag(dev, pkt, frag, queue);
+		ret = eth_intel_igc_tx_frag(dev, pkt, frag, queue, total_len);
 		if (ret < 0) {
 			LOG_ERR("Failed to transmit in queue number: %d", queue);
 		}
@@ -724,8 +725,10 @@ static void eth_intel_igc_rx_data(struct eth_intel_igc_mac_data *data, uint8_t q
 			continue;
 		}
 
-		if (!net_if_is_up(data->iface) || !desc->writeback.pkt_len) {
-			LOG_ERR("RX interface is down or pkt_len is %d", desc->writeback.pkt_len);
+		uint16_t pkt_len = desc->writeback.pkt_len;
+
+		if (!net_if_is_up(data->iface) || !pkt_len) {
+			LOG_ERR("RX interface is down or pkt_len is %d", pkt_len);
 			eth_intel_igc_rx_data_hdl_err(data, queue, idx, desc, NULL);
 			continue;
 		}
@@ -734,7 +737,7 @@ static void eth_intel_igc_rx_data(struct eth_intel_igc_mac_data *data, uint8_t q
 		rx_buf = data->rx.buf + ((queue * cfg->num_rx_desc + idx) * ETH_MAX_FRAME_SZ);
 
 		/* Allocate packet buffer as per address family */
-		pkt = net_pkt_rx_alloc_with_buffer(data->iface, desc->writeback.pkt_len,
+		pkt = net_pkt_rx_alloc_with_buffer(data->iface, pkt_len,
 						   eth_intel_igc_get_sa_family(rx_buf), 0,
 						   K_MSEC(200));
 		if (pkt == NULL) {
@@ -744,7 +747,7 @@ static void eth_intel_igc_rx_data(struct eth_intel_igc_mac_data *data, uint8_t q
 		}
 
 		/* Write DMA buffer to packet */
-		ret = net_pkt_write(pkt, (void *)rx_buf, desc->writeback.pkt_len);
+		ret = net_pkt_write(pkt, (void *)rx_buf, pkt_len);
 		if (ret < 0) {
 			LOG_ERR("Failed to write Receive buffer to packet");
 			eth_intel_igc_rx_data_hdl_err(data, queue, idx, desc, pkt);

--- a/drivers/ethernet/oa_tc6.c
+++ b/drivers/ethernet/oa_tc6.c
@@ -410,6 +410,9 @@ int oa_tc6_read_chunks(struct oa_tc6 *tc6, struct net_pkt *pkt)
 		tc6->concat_buf = NULL;
 	}
 
+	hdr = FIELD_PREP(OA_DATA_HDR_DNC, 1);
+	hdr |= FIELD_PREP(OA_DATA_HDR_P, oa_tc6_get_parity(hdr));
+
 	do {
 		if (!buf_rx) {
 			buf_rx = net_pkt_get_frag(pkt, buf_rx_size, OA_TC6_BUF_ALLOC_TIMEOUT);
@@ -418,9 +421,6 @@ int oa_tc6_read_chunks(struct oa_tc6 *tc6, struct net_pkt *pkt)
 				return -ENOMEM;
 			}
 		}
-
-		hdr = FIELD_PREP(OA_DATA_HDR_DNC, 1);
-		hdr |= FIELD_PREP(OA_DATA_HDR_P, oa_tc6_get_parity(hdr));
 
 		ret = oa_tc6_chunk_spi_transfer(tc6, buf_rx->data + buf_rx_used, NULL, hdr, &ftr);
 		if (ret < 0) {


### PR DESCRIPTION
The per-fragment TX cache clean used frag->size (full net_buf
capacity) instead of frag_len (the number of bytes the GMAC DMA
actually reads, as programmed into GMAC_TXW1_LEN). Cleaning only the
transmitted length is sufficient and avoids writing back unused trailing
bytes on every transmitted fragment. This is a write-back-only clean, so
reducing the range has no functional effect.

Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>
Assisted-by: Claude:opus-4.8