### PR TITLE
drivers: input: analog_axis: hoist num_axes out of log loop

### DIFF
--- a/drivers/input/input_analog_axis_settings.c
+++ b/drivers/input/input_analog_axis_settings.c
@@ -21,9 +21,10 @@ LOG_MODULE_REGISTER(analog_axis_settings, CONFIG_INPUT_LOG_LEVEL);
 static void analog_axis_calibration_log(const struct device *dev)
 {
 	struct analog_axis_calibration cal;
+	int axes = analog_axis_num_axes(dev);
 	int i;
 
-	for (i = 0; i < analog_axis_num_axes(dev); i++) {
+	for (i = 0; i < axes; i++) {
 		analog_axis_calibration_get(dev, i, &cal);
 
 		LOG_INF("%s: ch: %d min: %d max: %d deadzone: %d",

--- a/drivers/input/input_bee_keyscan.c
+++ b/drivers/input/input_bee_keyscan.c
@@ -160,6 +160,8 @@ static void bee_keyscan_process_matrix(const struct device *dev, uint8_t new_pre
 	const struct bee_keyscan_config *config = dev->config;
 	const struct input_kbd_matrix_common_config *cfg_common = &config->common;
 	kbd_row_t *matrix_new_state = cfg_common->matrix_new_state;
+	const uint8_t row_size = cfg_common->row_size;
+	const uint8_t col_size = cfg_common->col_size;
 	__maybe_unused struct bee_keyscan_data *data = dev->data;
 	__maybe_unused KEYSCAN_TypeDef *keyscan = config->reg;
 
@@ -167,7 +169,7 @@ static void bee_keyscan_process_matrix(const struct device *dev, uint8_t new_pre
 	KeyScan_Cmd(keyscan, DISABLE);
 #endif
 
-	for (int c = 0; c < cfg_common->col_size; c++) {
+	for (int c = 0; c < col_size; c++) {
 		matrix_new_state[c] = 0;
 	}
 
@@ -175,7 +177,7 @@ static void bee_keyscan_process_matrix(const struct device *dev, uint8_t new_pre
 		uint8_t r = new_keys[i].row;
 		uint8_t c = new_keys[i].column;
 
-		if (r >= cfg_common->row_size || c >= cfg_common->col_size) {
+		if (r >= row_size || c >= col_size) {
 			continue;
 		}
 

--- a/drivers/input/input_gpio_kbd_matrix.c
+++ b/drivers/input/input_gpio_kbd_matrix.c
@@ -70,10 +70,12 @@ static void gpio_kbd_matrix_drive_column(const struct device *dev, int col)
 		return;
 	}
 
+	uint32_t changed = data->last_col_state ^ state;
+
 	for (int i = 0; i < common->col_size; i++) {
 		const struct gpio_dt_spec *gpio = &cfg->col_gpio[i];
 
-		if ((data->last_col_state ^ state) & BIT(i)) {
+		if (changed & BIT(i)) {
 			if (cfg->col_drive_inactive) {
 				gpio_pin_set_dt(gpio, state & BIT(i));
 			} else if (state & BIT(i)) {

--- a/drivers/input/input_gpio_qdec.c
+++ b/drivers/input/input_gpio_qdec.c
@@ -129,9 +129,10 @@ static void gpio_qdec_idle_mode(const struct device *dev)
 static uint8_t gpio_qdec_get_step(const struct device *dev)
 {
 	const struct gpio_qdec_config *cfg = dev->config;
+	bool idle_polling = gpio_qdec_idle_polling_mode(dev);
 	uint8_t step = 0x00;
 
-	if (gpio_qdec_idle_polling_mode(dev)) {
+	if (idle_polling) {
 		for (int i = 0; i < cfg->led_gpio_count; i++) {
 			gpio_pin_set_dt(&cfg->led_gpio[i], 1);
 		}
@@ -146,7 +147,7 @@ static uint8_t gpio_qdec_get_step(const struct device *dev)
 		step |= 0x02;
 	}
 
-	if (gpio_qdec_idle_polling_mode(dev)) {
+	if (idle_polling) {
 		for (int i = 0; i < cfg->led_gpio_count; i++) {
 			gpio_pin_set_dt(&cfg->led_gpio[i], 0);
 		}

--- a/drivers/input/input_pat912x.c
+++ b/drivers/input/input_pat912x.c
@@ -125,7 +125,7 @@ static void pat912x_motion_work_handler(struct k_work *work)
 	if (cfg->axis_x >= 0) {
 		bool sync = cfg->axis_y < 0;
 
-		input_report_rel(data->dev, cfg->axis_x, x, sync, K_FOREVER);
+		input_report_rel(dev, cfg->axis_x, x, sync, K_FOREVER);
 	}
 
 	if (cfg->axis_y >= 0) {

--- a/drivers/input/input_pat912x.c
+++ b/drivers/input/input_pat912x.c
@@ -129,7 +129,7 @@ static void pat912x_motion_work_handler(struct k_work *work)
 	}
 
 	if (cfg->axis_y >= 0) {
-		input_report_rel(data->dev, cfg->axis_y, y, true, K_FOREVER);
+		input_report_rel(dev, cfg->axis_y, y, true, K_FOREVER);
 	}
 
 	/* Trigger one more scan in case more data is available. */

--- a/drivers/input/input_paw32xx.c
+++ b/drivers/input/input_paw32xx.c
@@ -218,8 +218,8 @@ static void paw32xx_motion_work_handler(struct k_work *work)
 
 	LOG_DBG("x=%4d y=%4d", x, y);
 
-	input_report_rel(data->dev, cfg->axis_x, x, false, K_FOREVER);
-	input_report_rel(data->dev, cfg->axis_y, y, true, K_FOREVER);
+	input_report_rel(dev, cfg->axis_x, x, false, K_FOREVER);
+	input_report_rel(dev, cfg->axis_y, y, true, K_FOREVER);
 
 	/* Trigger one more scan if more data is available. */
 	if (gpio_pin_get_dt(&cfg->motion_gpio)) {

--- a/drivers/input/input_pmw3610.c
+++ b/drivers/input/input_pmw3610.c
@@ -218,8 +218,8 @@ static void pmw3610_motion_work_handler(struct k_work *work)
 	x = sign_extend(x, PMW3610_DATA_SIZE_BITS - 1);
 	y = sign_extend(y, PMW3610_DATA_SIZE_BITS - 1);
 
-	input_report_rel(data->dev, cfg->axis_x, x, false, K_FOREVER);
-	input_report_rel(data->dev, cfg->axis_y, y, true, K_FOREVER);
+	input_report_rel(dev, cfg->axis_x, x, false, K_FOREVER);
+	input_report_rel(dev, cfg->axis_y, y, true, K_FOREVER);
 
 	if (cfg->smart_mode) {
 		uint16_t shutter_val = sys_get_be16(&burst_data[BURST_SHUTTER_HI]);

--- a/drivers/input/input_renesas_rx_ctsu.c
+++ b/drivers/input/input_renesas_rx_ctsu.c
@@ -194,7 +194,9 @@ static void process_data(struct k_work *work)
 	}
 
 	/** Wheels */
-	for (int i = 0; i < data->touch_instance.p_cfg->num_wheels; i++) {
+	const int num_wheels = data->touch_instance.p_cfg->num_wheels;
+
+	for (int i = 0; i < num_wheels; i++) {
 		if (data->curr_wheels_position[i] != data->prev_wheels_position[i]) {
 			input_report_abs(dev, config->wheels[i].event,
 					 data->curr_wheels_position[i], true, K_FOREVER);

--- a/drivers/input/input_renesas_rx_ctsu.c
+++ b/drivers/input/input_renesas_rx_ctsu.c
@@ -183,7 +183,9 @@ static void process_data(struct k_work *work)
 	data->prev_buttons_data = data->curr_buttons_data;
 
 	/** Sliders */
-	for (int i = 0; i < data->touch_instance.p_cfg->num_sliders; i++) {
+	const int num_sliders = data->touch_instance.p_cfg->num_sliders;
+
+	for (int i = 0; i < num_sliders; i++) {
 		if (data->curr_sliders_position[i] != data->prev_sliders_position[i]) {
 			input_report_abs(dev, config->sliders[i].event,
 					 data->curr_sliders_position[i], true, K_FOREVER);


### PR DESCRIPTION
The loop condition in analog_axis_calibration_log re-calls the cross-TU
function analog_axis_num_axes() on every iteration. Cache it once in a
local, matching how the save/load functions in the same file already do.

Assisted-by: Claude:opus-4.8
Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>