### PR TITLE
drivers: auxdisplay: add shell module for testing

### DIFF
--- a/doc/hardware/peripherals/auxdisplay.rst
+++ b/doc/hardware/peripherals/auxdisplay.rst
@@ -23,6 +23,7 @@ Related configuration options:
 
 * :kconfig:option:`CONFIG_AUXDISPLAY`
 * :kconfig:option:`CONFIG_AUXDISPLAY_INIT_PRIORITY`
+* :kconfig:option:`CONFIG_AUXDISPLAY_SHELL`
 
 API Reference
 *************

--- a/drivers/auxdisplay/CMakeLists.txt
+++ b/drivers/auxdisplay/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_syscall_header(${ZEPHYR_BASE}/include/zephyr/drivers/auxdisplay.h)
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE auxdisplay_handlers.c)
+zephyr_library_sources_ifdef(CONFIG_AUXDISPLAY_SHELL auxdisplay_shell.c)
 
 # zephyr-keep-sorted-start
 zephyr_library_sources_ifdef(CONFIG_AUXDISPLAY_GPIO_7SEG auxdisplay_gpio_7seg.c)

--- a/drivers/auxdisplay/Kconfig
+++ b/drivers/auxdisplay/Kconfig
@@ -10,6 +10,12 @@ menuconfig AUXDISPLAY
 
 if AUXDISPLAY
 
+config AUXDISPLAY_SHELL
+	bool "Auxiliary display shell"
+	depends on SHELL
+	help
+	  Enable the auxiliary display shell with related commands.
+
 config AUXDISPLAY_INIT_PRIORITY
 	int "Auxiliary display devices init priority"
 	default 85

--- a/drivers/auxdisplay/auxdisplay_shell.c
+++ b/drivers/auxdisplay/auxdisplay_shell.c
@@ -10,6 +10,7 @@
 
 #define AUXD_ARGV_DEVICE  1
 #define AUXD_ARGV_ARG0    2
+#define AUXD_ARGV_ARG1    3
 #define AUXD_ARGV_PATTERN 2
 #define AUXD_ARGV_X       3
 #define AUXD_ARGV_Y       4
@@ -367,28 +368,6 @@ static int cmd_backlight(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
-static int cmd_busy(const struct shell *sh, size_t argc, char **argv)
-{
-	const struct device *dev;
-	int err;
-
-	ARG_UNUSED(argc);
-
-	err = get_auxdisplay_device(sh, argv[AUXD_ARGV_DEVICE], &dev);
-	if (err < 0) {
-		return err;
-	}
-
-	err = auxdisplay_is_busy(dev);
-	if (err < 0) {
-		return report_error(sh, "busy", err);
-	}
-
-	shell_print(sh, "busy: %s", err ? "yes" : "no");
-
-	return 0;
-}
-
 static int cmd_cursor_pos(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
@@ -412,7 +391,7 @@ static int cmd_cursor_pos(const struct shell *sh, size_t argc, char **argv)
 			return err;
 		}
 
-		err = parse_i16(sh, argv[3], "Y", &y);
+		err = parse_i16(sh, argv[AUXD_ARGV_ARG1], "Y", &y);
 		if (err < 0) {
 			return err;
 		}

--- a/drivers/auxdisplay/auxdisplay_shell.c
+++ b/drivers/auxdisplay/auxdisplay_shell.c
@@ -8,12 +8,12 @@
 #include <zephyr/drivers/auxdisplay.h>
 #include <zephyr/shell/shell.h>
 
-#define AUXD_ARGV_DEVICE  1
-#define AUXD_ARGV_ARG0    2
-#define AUXD_ARGV_ARG1    3
-#define AUXD_ARGV_PATTERN 2
-#define AUXD_ARGV_X       3
-#define AUXD_ARGV_Y       4
+#define AUXD_ARGV_DEVICE 1
+#define AUXD_ARGV_ARG0   2
+#define AUXD_ARGV_ARG1   3
+#define AUXD_ARGV_TEXT   2
+#define AUXD_ARGV_X      3
+#define AUXD_ARGV_Y      4
 
 static int get_auxdisplay_device(const struct shell *sh, const char *name,
 				 const struct device **dev)
@@ -478,9 +478,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(brightness, &dsub_device_name,
 		      SHELL_HELP("Get or set brightness level", "<device> [level]"),
 		      cmd_brightness, 2, 1),
-	SHELL_CMD_ARG(busy, &dsub_device_name,
-		      SHELL_HELP("Check if the display is busy", "<device>"),
-		      cmd_busy, 2, 0),
 	SHELL_CMD_ARG(clear, &dsub_device_name,
 		      SHELL_HELP("Clear the auxiliary display", "<device>"),
 		      cmd_clear, 2, 0),

--- a/drivers/auxdisplay/auxdisplay_shell.c
+++ b/drivers/auxdisplay/auxdisplay_shell.c
@@ -9,6 +9,7 @@
 #include <zephyr/shell/shell.h>
 
 #define AUXD_ARGV_DEVICE  1
+#define AUXD_ARGV_ARG0    2
 #define AUXD_ARGV_PATTERN 2
 #define AUXD_ARGV_X       3
 #define AUXD_ARGV_Y       4
@@ -26,6 +27,76 @@ static int get_auxdisplay_device(const struct shell *sh, const char *name,
 	return 0;
 }
 
+static int report_error(const struct shell *sh, const char *feature, int err)
+{
+	if (err == -ENOSYS || err == -ENOTSUP) {
+		shell_error(sh, "Device does not support %s", feature);
+	} else {
+		shell_error(sh, "Failed to %s (err %d)", feature, err);
+	}
+
+	return err;
+}
+
+static int parse_on_off(const struct shell *sh, const char *arg, bool *enabled)
+{
+	int err = 0;
+
+	*enabled = shell_strtobool(arg, 0, &err);
+	if (err < 0) {
+		shell_error(sh, "Invalid value '%s', use on/off", arg);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int parse_u8(const struct shell *sh, const char *arg, uint8_t *value)
+{
+	unsigned long val;
+	int err = 0;
+
+	val = shell_strtoul(arg, 0, &err);
+	if (err < 0 || val > UINT8_MAX) {
+		shell_error(sh, "Invalid level '%s'", arg);
+		return -EINVAL;
+	}
+
+	*value = (uint8_t)val;
+	return 0;
+}
+
+static int parse_i16(const struct shell *sh, const char *arg, const char *name, int16_t *value)
+{
+	long val;
+	int err = 0;
+
+	val = shell_strtol(arg, 0, &err);
+	if (err < 0 || val < INT16_MIN || val > INT16_MAX) {
+		shell_error(sh, "Error parsing %s position", name);
+		return -EINVAL;
+	}
+
+	*value = (int16_t)val;
+	return 0;
+}
+
+static bool light_is_supported(const struct auxdisplay_light *light)
+{
+	return !(light->minimum == AUXDISPLAY_LIGHT_NOT_SUPPORTED &&
+		 light->maximum == AUXDISPLAY_LIGHT_NOT_SUPPORTED);
+}
+
+static void print_light_caps(const struct shell *sh, const char *name,
+			     const struct auxdisplay_light *light)
+{
+	if (light_is_supported(light)) {
+		shell_print(sh, "%s: %u .. %u", name, light->minimum, light->maximum);
+	} else {
+		shell_print(sh, "%s: unsupported", name);
+	}
+}
+
 static int cmd_clear(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *dev;
@@ -40,8 +111,7 @@ static int cmd_clear(const struct shell *sh, size_t argc, char **argv)
 
 	err = auxdisplay_clear(dev);
 	if (err < 0) {
-		shell_error(sh, "Failed to clear display (err %d)", err);
-		return err;
+		return report_error(sh, "clear", err);
 	}
 
 	return 0;
@@ -62,11 +132,15 @@ static int cmd_size(const struct shell *sh, size_t argc, char **argv)
 
 	err = auxdisplay_capabilities_get(dev, &capabilities);
 	if (err < 0) {
-		shell_error(sh, "Failed to get display capabilities (err %d)", err);
-		return err;
+		return report_error(sh, "capabilities", err);
 	}
 
-	shell_print(sh, "%zu rows, %zu columns", capabilities.rows, capabilities.columns);
+	shell_print(sh, "%u rows, %u columns", capabilities.rows, capabilities.columns);
+	shell_print(sh, "mode: 0x%x", capabilities.mode);
+	print_light_caps(sh, "brightness", &capabilities.brightness);
+	print_light_caps(sh, "backlight", &capabilities.backlight);
+	shell_print(sh, "custom characters: %u (%ux%u)", capabilities.custom_characters,
+		    capabilities.custom_character_width, capabilities.custom_character_height);
 
 	return 0;
 }
@@ -77,7 +151,6 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 	int16_t x = 0;
 	int16_t y = 0;
 	size_t len;
-	long val;
 	int err;
 
 	err = get_auxdisplay_device(sh, argv[AUXD_ARGV_DEVICE], &dev);
@@ -86,29 +159,22 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 	}
 
 	if (argc > AUXD_ARGV_X) {
-		err = 0;
-		val = shell_strtol(argv[AUXD_ARGV_X], 0, &err);
-		if (err < 0 || val < INT16_MIN || val > INT16_MAX) {
-			shell_error(sh, "Error parsing X position");
-			return -EINVAL;
+		err = parse_i16(sh, argv[AUXD_ARGV_X], "X", &x);
+		if (err < 0) {
+			return err;
 		}
-		x = (int16_t)val;
-	}
 
-	if (argc > AUXD_ARGV_Y) {
-		err = 0;
-		val = shell_strtol(argv[AUXD_ARGV_Y], 0, &err);
-		if (err < 0 || val < INT16_MIN || val > INT16_MAX) {
-			shell_error(sh, "Error parsing Y position");
-			return -EINVAL;
+		if (argc > AUXD_ARGV_Y) {
+			err = parse_i16(sh, argv[AUXD_ARGV_Y], "Y", &y);
+			if (err < 0) {
+				return err;
+			}
 		}
-		y = (int16_t)val;
-	}
 
-	err = auxdisplay_cursor_position_set(dev, AUXDISPLAY_POSITION_ABSOLUTE, x, y);
-	if (err < 0) {
-		shell_error(sh, "Failed to set cursor position (err %d)", err);
-		return err;
+		err = auxdisplay_cursor_position_set(dev, AUXDISPLAY_POSITION_ABSOLUTE, x, y);
+		if (err < 0) {
+			return report_error(sh, "cursor position", err);
+		}
 	}
 
 	len = strlen(argv[AUXD_ARGV_PATTERN]);
@@ -119,9 +185,252 @@ static int cmd_write(const struct shell *sh, size_t argc, char **argv)
 
 	err = auxdisplay_write(dev, (const uint8_t *)argv[AUXD_ARGV_PATTERN], (uint16_t)len);
 	if (err < 0) {
-		shell_error(sh, "Failed to write to display (err %d)", err);
+		return report_error(sh, "write", err);
+	}
+
+	return 0;
+}
+
+static int cmd_on(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	int err;
+
+	ARG_UNUSED(argc);
+
+	err = get_auxdisplay_device(sh, argv[AUXD_ARGV_DEVICE], &dev);
+	if (err < 0) {
 		return err;
 	}
+
+	err = auxdisplay_display_on(dev);
+	if (err < 0) {
+		return report_error(sh, "display on", err);
+	}
+
+	return 0;
+}
+
+static int cmd_off(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	int err;
+
+	ARG_UNUSED(argc);
+
+	err = get_auxdisplay_device(sh, argv[AUXD_ARGV_DEVICE], &dev);
+	if (err < 0) {
+		return err;
+	}
+
+	err = auxdisplay_display_off(dev);
+	if (err < 0) {
+		return report_error(sh, "display off", err);
+	}
+
+	return 0;
+}
+
+static int cmd_cursor(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	bool enabled;
+	int err;
+
+	ARG_UNUSED(argc);
+
+	err = get_auxdisplay_device(sh, argv[AUXD_ARGV_DEVICE], &dev);
+	if (err < 0) {
+		return err;
+	}
+
+	err = parse_on_off(sh, argv[AUXD_ARGV_ARG0], &enabled);
+	if (err < 0) {
+		return err;
+	}
+
+	err = auxdisplay_cursor_set_enabled(dev, enabled);
+	if (err < 0) {
+		return report_error(sh, "cursor", err);
+	}
+
+	return 0;
+}
+
+static int cmd_blink(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	bool enabled;
+	int err;
+
+	ARG_UNUSED(argc);
+
+	err = get_auxdisplay_device(sh, argv[AUXD_ARGV_DEVICE], &dev);
+	if (err < 0) {
+		return err;
+	}
+
+	err = parse_on_off(sh, argv[AUXD_ARGV_ARG0], &enabled);
+	if (err < 0) {
+		return err;
+	}
+
+	err = auxdisplay_position_blinking_set_enabled(dev, enabled);
+	if (err < 0) {
+		return report_error(sh, "blink", err);
+	}
+
+	return 0;
+}
+
+static int cmd_brightness(const struct shell *sh, size_t argc, char **argv)
+{
+	struct auxdisplay_capabilities capabilities;
+	const struct device *dev;
+	uint8_t brightness;
+	int err;
+
+	err = get_auxdisplay_device(sh, argv[AUXD_ARGV_DEVICE], &dev);
+	if (err < 0) {
+		return err;
+	}
+
+	if (argc > AUXD_ARGV_ARG0) {
+		err = parse_u8(sh, argv[AUXD_ARGV_ARG0], &brightness);
+		if (err < 0) {
+			return err;
+		}
+
+		err = auxdisplay_brightness_set(dev, brightness);
+		if (err < 0) {
+			return report_error(sh, "brightness", err);
+		}
+
+		return 0;
+	}
+
+	err = auxdisplay_brightness_get(dev, &brightness);
+	if (err < 0) {
+		return report_error(sh, "brightness", err);
+	}
+
+	shell_print(sh, "brightness: %u", brightness);
+
+	err = auxdisplay_capabilities_get(dev, &capabilities);
+	if (err == 0 && light_is_supported(&capabilities.brightness)) {
+		shell_print(sh, "range: %u .. %u", capabilities.brightness.minimum,
+			    capabilities.brightness.maximum);
+	}
+
+	return 0;
+}
+
+static int cmd_backlight(const struct shell *sh, size_t argc, char **argv)
+{
+	struct auxdisplay_capabilities capabilities;
+	const struct device *dev;
+	uint8_t backlight;
+	int err;
+
+	err = get_auxdisplay_device(sh, argv[AUXD_ARGV_DEVICE], &dev);
+	if (err < 0) {
+		return err;
+	}
+
+	if (argc > AUXD_ARGV_ARG0) {
+		err = parse_u8(sh, argv[AUXD_ARGV_ARG0], &backlight);
+		if (err < 0) {
+			return err;
+		}
+
+		err = auxdisplay_backlight_set(dev, backlight);
+		if (err < 0) {
+			return report_error(sh, "backlight", err);
+		}
+
+		return 0;
+	}
+
+	err = auxdisplay_backlight_get(dev, &backlight);
+	if (err < 0) {
+		return report_error(sh, "backlight", err);
+	}
+
+	shell_print(sh, "backlight: %u", backlight);
+
+	err = auxdisplay_capabilities_get(dev, &capabilities);
+	if (err == 0 && light_is_supported(&capabilities.backlight)) {
+		shell_print(sh, "range: %u .. %u", capabilities.backlight.minimum,
+			    capabilities.backlight.maximum);
+	}
+
+	return 0;
+}
+
+static int cmd_busy(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	int err;
+
+	ARG_UNUSED(argc);
+
+	err = get_auxdisplay_device(sh, argv[AUXD_ARGV_DEVICE], &dev);
+	if (err < 0) {
+		return err;
+	}
+
+	err = auxdisplay_is_busy(dev);
+	if (err < 0) {
+		return report_error(sh, "busy", err);
+	}
+
+	shell_print(sh, "busy: %s", err ? "yes" : "no");
+
+	return 0;
+}
+
+static int cmd_cursor_pos(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	int16_t x;
+	int16_t y;
+	int err;
+
+	err = get_auxdisplay_device(sh, argv[AUXD_ARGV_DEVICE], &dev);
+	if (err < 0) {
+		return err;
+	}
+
+	if (argc > AUXD_ARGV_ARG0) {
+		if (argc < 4) {
+			shell_error(sh, "Both X and Y positions are required");
+			return -EINVAL;
+		}
+
+		err = parse_i16(sh, argv[AUXD_ARGV_ARG0], "X", &x);
+		if (err < 0) {
+			return err;
+		}
+
+		err = parse_i16(sh, argv[3], "Y", &y);
+		if (err < 0) {
+			return err;
+		}
+
+		err = auxdisplay_cursor_position_set(dev, AUXDISPLAY_POSITION_ABSOLUTE, x, y);
+		if (err < 0) {
+			return report_error(sh, "cursor position", err);
+		}
+
+		return 0;
+	}
+
+	err = auxdisplay_cursor_position_get(dev, &x, &y);
+	if (err < 0) {
+		return report_error(sh, "cursor position", err);
+	}
+
+	shell_print(sh, "cursor: x=%d y=%d", x, y);
 
 	return 0;
 }
@@ -130,6 +439,27 @@ static bool device_is_auxdisplay(const struct device *dev)
 {
 	return DEVICE_API_IS(auxdisplay, dev);
 }
+
+static void on_off_get(size_t idx, struct shell_static_entry *entry)
+{
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+
+	switch (idx) {
+	case 0:
+		entry->syntax = "on";
+		break;
+	case 1:
+		entry->syntax = "off";
+		break;
+	default:
+		entry->syntax = NULL;
+		break;
+	}
+}
+
+SHELL_DYNAMIC_CMD_CREATE(dsub_on_off, on_off_get);
 
 /* Device name autocompletion support */
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
@@ -144,14 +474,52 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 
 SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
+static void device_name_get_on_off(size_t idx, struct shell_static_entry *entry)
+{
+	const struct device *dev = shell_device_filter(idx, device_is_auxdisplay);
+
+	entry->syntax = (dev != NULL) ? dev->name : NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = &dsub_on_off;
+}
+
+SHELL_DYNAMIC_CMD_CREATE(dsub_device_name_on_off, device_name_get_on_off);
+
 /* clang-format off */
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	auxdisplay_cmds,
+	SHELL_CMD_ARG(backlight, &dsub_device_name,
+		      SHELL_HELP("Get or set backlight level", "<device> [level]"),
+		      cmd_backlight, 2, 1),
+	SHELL_CMD_ARG(blink, &dsub_device_name_on_off,
+		      SHELL_HELP("Enable or disable cursor position blink",
+				 "<device> <on|off>"),
+		      cmd_blink, 3, 0),
+	SHELL_CMD_ARG(brightness, &dsub_device_name,
+		      SHELL_HELP("Get or set brightness level", "<device> [level]"),
+		      cmd_brightness, 2, 1),
+	SHELL_CMD_ARG(busy, &dsub_device_name,
+		      SHELL_HELP("Check if the display is busy", "<device>"),
+		      cmd_busy, 2, 0),
 	SHELL_CMD_ARG(clear, &dsub_device_name,
 		      SHELL_HELP("Clear the auxiliary display", "<device>"),
 		      cmd_clear, 2, 0),
+	SHELL_CMD_ARG(cursor, &dsub_device_name_on_off,
+		      SHELL_HELP("Enable or disable the cursor", "<device> <on|off>"),
+		      cmd_cursor, 3, 0),
+	SHELL_CMD_ARG(cursor_pos, &dsub_device_name,
+		      SHELL_HELP("Get or set absolute cursor position",
+				 "<device> [<x> <y>]"),
+		      cmd_cursor_pos, 2, 2),
+	SHELL_CMD_ARG(off, &dsub_device_name,
+		      SHELL_HELP("Turn the display off", "<device>"),
+		      cmd_off, 2, 0),
+	SHELL_CMD_ARG(on, &dsub_device_name,
+		      SHELL_HELP("Turn the display on", "<device>"),
+		      cmd_on, 2, 0),
 	SHELL_CMD_ARG(size, &dsub_device_name,
-		      SHELL_HELP("Show auxiliary display size", "<device>"),
+		      SHELL_HELP("Show auxiliary display capabilities", "<device>"),
 		      cmd_size, 2, 0),
 	SHELL_CMD_ARG(write, &dsub_device_name,
 		      SHELL_HELP("Write text to the auxiliary display",

--- a/drivers/auxdisplay/auxdisplay_shell.c
+++ b/drivers/auxdisplay/auxdisplay_shell.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026 Benjamin Cabé <benjamin@zephyrproject.org>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <string.h>
+#include <zephyr/drivers/auxdisplay.h>
+#include <zephyr/shell/shell.h>
+
+#define AUXD_ARGV_DEVICE  1
+#define AUXD_ARGV_PATTERN 2
+#define AUXD_ARGV_X       3
+#define AUXD_ARGV_Y       4
+
+static int get_auxdisplay_device(const struct shell *sh, const char *name,
+				 const struct device **dev)
+{
+	*dev = shell_device_get_binding(name);
+	if (!device_is_ready(*dev)) {
+		shell_error(sh, "Auxiliary display device not %s",
+			    *dev == NULL ? "found" : "ready");
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static int cmd_clear(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	int err;
+
+	ARG_UNUSED(argc);
+
+	err = get_auxdisplay_device(sh, argv[AUXD_ARGV_DEVICE], &dev);
+	if (err < 0) {
+		return err;
+	}
+
+	err = auxdisplay_clear(dev);
+	if (err < 0) {
+		shell_error(sh, "Failed to clear display (err %d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static int cmd_size(const struct shell *sh, size_t argc, char **argv)
+{
+	struct auxdisplay_capabilities capabilities;
+	const struct device *dev;
+	int err;
+
+	ARG_UNUSED(argc);
+
+	err = get_auxdisplay_device(sh, argv[AUXD_ARGV_DEVICE], &dev);
+	if (err < 0) {
+		return err;
+	}
+
+	err = auxdisplay_capabilities_get(dev, &capabilities);
+	if (err < 0) {
+		shell_error(sh, "Failed to get display capabilities (err %d)", err);
+		return err;
+	}
+
+	shell_print(sh, "%zu rows, %zu columns", capabilities.rows, capabilities.columns);
+
+	return 0;
+}
+
+static int cmd_write(const struct shell *sh, size_t argc, char **argv)
+{
+	const struct device *dev;
+	int16_t x = 0;
+	int16_t y = 0;
+	size_t len;
+	long val;
+	int err;
+
+	err = get_auxdisplay_device(sh, argv[AUXD_ARGV_DEVICE], &dev);
+	if (err < 0) {
+		return err;
+	}
+
+	if (argc > AUXD_ARGV_X) {
+		err = 0;
+		val = shell_strtol(argv[AUXD_ARGV_X], 0, &err);
+		if (err < 0 || val < INT16_MIN || val > INT16_MAX) {
+			shell_error(sh, "Error parsing X position");
+			return -EINVAL;
+		}
+		x = (int16_t)val;
+	}
+
+	if (argc > AUXD_ARGV_Y) {
+		err = 0;
+		val = shell_strtol(argv[AUXD_ARGV_Y], 0, &err);
+		if (err < 0 || val < INT16_MIN || val > INT16_MAX) {
+			shell_error(sh, "Error parsing Y position");
+			return -EINVAL;
+		}
+		y = (int16_t)val;
+	}
+
+	err = auxdisplay_cursor_position_set(dev, AUXDISPLAY_POSITION_ABSOLUTE, x, y);
+	if (err < 0) {
+		shell_error(sh, "Failed to set cursor position (err %d)", err);
+		return err;
+	}
+
+	len = strlen(argv[AUXD_ARGV_PATTERN]);
+	if (len > UINT16_MAX) {
+		shell_error(sh, "Pattern too long");
+		return -EINVAL;
+	}
+
+	err = auxdisplay_write(dev, (const uint8_t *)argv[AUXD_ARGV_PATTERN], (uint16_t)len);
+	if (err < 0) {
+		shell_error(sh, "Failed to write to display (err %d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static bool device_is_auxdisplay(const struct device *dev)
+{
+	return DEVICE_API_IS(auxdisplay, dev);
+}
+
+/* Device name autocompletion support */
+static void device_name_get(size_t idx, struct shell_static_entry *entry)
+{
+	const struct device *dev = shell_device_filter(idx, device_is_auxdisplay);
+
+	entry->syntax = (dev != NULL) ? dev->name : NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+}
+
+SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
+
+/* clang-format off */
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	auxdisplay_cmds,
+	SHELL_CMD_ARG(clear, &dsub_device_name,
+		      SHELL_HELP("Clear the auxiliary display", "<device>"),
+		      cmd_clear, 2, 0),
+	SHELL_CMD_ARG(size, &dsub_device_name,
+		      SHELL_HELP("Show auxiliary display size", "<device>"),
+		      cmd_size, 2, 0),
+	SHELL_CMD_ARG(write, &dsub_device_name,
+		      SHELL_HELP("Write text to the auxiliary display",
+				 "<device> <pattern> [x] [y]"),
+		      cmd_write, 3, 2),
+	SHELL_SUBCMD_SET_END
+);
+/* clang-format on */
+
+SHELL_CMD_REGISTER(auxdisplay, &auxdisplay_cmds, "Auxiliary display shell commands", NULL);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add an auxiliary display shell module to help with interactive testing of column/segment connections and optional display features.

Commands (enabled with `CONFIG_AUXDISPLAY_SHELL`):
- `auxdisplay backlight <device> [level]`
- `auxdisplay blink <device> <on|off>`
- `auxdisplay brightness <device> [level]`
- `auxdisplay clear <device>`
- `auxdisplay cursor <device> <on|off>`
- `auxdisplay cursor_pos <device> [<x> <y>]`
- `auxdisplay on|off <device>`
- `auxdisplay size <device>`
- `auxdisplay write <device> <text> [x] [y]`

Unsupported optional APIs return a clear `Device does not support <feature>` message (`-ENOSYS`/`-ENOTSUP`). Uses `SHELL_HELP` for structured help, device-name autocompletion, and standard shell coding style (`clang-format`, checkpatch, compliance).

Also documents `CONFIG_AUXDISPLAY_SHELL` in the auxdisplay peripheral docs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-362fe391-24c8-4d9a-adae-7a12661b0d7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-362fe391-24c8-4d9a-adae-7a12661b0d7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

