### PR TITLE
tracing: ctf: add queue, FIFO, LIFO and stack events

### DIFF
--- a/subsys/tracing/ctf/ctf_top.c
+++ b/subsys/tracing/ctf/ctf_top.c
@@ -1647,3 +1647,352 @@ void sys_trace_k_event_wait_exit(struct k_event *event, uint32_t events, int ret
 {
 	ctf_top_event_wait_exit((uint32_t)(uintptr_t)event, events, (int32_t)ret);
 }
+
+/* Queue */
+void sys_trace_k_queue_init(struct k_queue *queue)
+{
+	ctf_top_queue_init((uint32_t)(uintptr_t)queue);
+}
+
+void sys_trace_k_queue_cancel_wait(struct k_queue *queue)
+{
+	ctf_top_queue_cancel_wait((uint32_t)(uintptr_t)queue);
+}
+
+void sys_trace_k_queue_queue_insert_enter(struct k_queue *queue, bool alloc)
+{
+	ctf_top_queue_queue_insert_enter((uint32_t)(uintptr_t)queue, (uint8_t)alloc);
+}
+
+void sys_trace_k_queue_queue_insert_blocking(struct k_queue *queue, bool alloc, k_timeout_t timeout)
+{
+	ctf_top_queue_queue_insert_blocking((uint32_t)(uintptr_t)queue, (uint8_t)alloc,
+					 k_ticks_to_us_floor32((uint32_t)timeout.ticks));
+}
+
+void sys_trace_k_queue_queue_insert_exit(struct k_queue *queue, bool alloc, int ret)
+{
+	ctf_top_queue_queue_insert_exit((uint32_t)(uintptr_t)queue, (uint8_t)alloc, (int32_t)ret);
+}
+
+void sys_trace_k_queue_append_enter(struct k_queue *queue)
+{
+	ctf_top_queue_append_enter((uint32_t)(uintptr_t)queue);
+}
+
+void sys_trace_k_queue_append_exit(struct k_queue *queue)
+{
+	ctf_top_queue_append_exit((uint32_t)(uintptr_t)queue);
+}
+
+void sys_trace_k_queue_prepend_enter(struct k_queue *queue)
+{
+	ctf_top_queue_prepend_enter((uint32_t)(uintptr_t)queue);
+}
+
+void sys_trace_k_queue_prepend_exit(struct k_queue *queue)
+{
+	ctf_top_queue_prepend_exit((uint32_t)(uintptr_t)queue);
+}
+
+void sys_trace_k_queue_alloc_append_enter(struct k_queue *queue)
+{
+	ctf_top_queue_alloc_append_enter((uint32_t)(uintptr_t)queue);
+}
+
+void sys_trace_k_queue_alloc_append_exit(struct k_queue *queue, int ret)
+{
+	ctf_top_queue_alloc_append_exit((uint32_t)(uintptr_t)queue, (int32_t)ret);
+}
+
+void sys_trace_k_queue_alloc_prepend_enter(struct k_queue *queue)
+{
+	ctf_top_queue_alloc_prepend_enter((uint32_t)(uintptr_t)queue);
+}
+
+void sys_trace_k_queue_alloc_prepend_exit(struct k_queue *queue, int ret)
+{
+	ctf_top_queue_alloc_prepend_exit((uint32_t)(uintptr_t)queue, (int32_t)ret);
+}
+
+void sys_trace_k_queue_insert_enter(struct k_queue *queue)
+{
+	ctf_top_queue_insert_enter((uint32_t)(uintptr_t)queue);
+}
+
+void sys_trace_k_queue_insert_blocking(struct k_queue *queue, k_timeout_t timeout)
+{
+	ctf_top_queue_insert_blocking((uint32_t)(uintptr_t)queue,
+				  k_ticks_to_us_floor32((uint32_t)timeout.ticks));
+}
+
+void sys_trace_k_queue_insert_exit(struct k_queue *queue)
+{
+	ctf_top_queue_insert_exit((uint32_t)(uintptr_t)queue);
+}
+
+void sys_trace_k_queue_append_list_enter(struct k_queue *queue)
+{
+	ctf_top_queue_append_list_enter((uint32_t)(uintptr_t)queue);
+}
+
+void sys_trace_k_queue_append_list_exit(struct k_queue *queue, int ret)
+{
+	ctf_top_queue_append_list_exit((uint32_t)(uintptr_t)queue, (int32_t)ret);
+}
+
+void sys_trace_k_queue_merge_slist_enter(struct k_queue *queue)
+{
+	ctf_top_queue_merge_slist_enter((uint32_t)(uintptr_t)queue);
+}
+
+void sys_trace_k_queue_merge_slist_exit(struct k_queue *queue, int ret)
+{
+	ctf_top_queue_merge_slist_exit((uint32_t)(uintptr_t)queue, (int32_t)ret);
+}
+
+void sys_trace_k_queue_get_enter(struct k_queue *queue, k_timeout_t timeout)
+{
+	ctf_top_queue_get_enter((uint32_t)(uintptr_t)queue,
+			     k_ticks_to_us_floor32((uint32_t)timeout.ticks));
+}
+
+void sys_trace_k_queue_get_blocking(struct k_queue *queue, k_timeout_t timeout)
+{
+	ctf_top_queue_get_blocking((uint32_t)(uintptr_t)queue,
+				k_ticks_to_us_floor32((uint32_t)timeout.ticks));
+}
+
+void sys_trace_k_queue_get_exit(struct k_queue *queue, k_timeout_t timeout, void *ret)
+{
+	ctf_top_queue_get_exit((uint32_t)(uintptr_t)queue,
+			    k_ticks_to_us_floor32((uint32_t)timeout.ticks),
+			    (uint32_t)(uintptr_t)ret);
+}
+
+void sys_trace_k_queue_remove_enter(struct k_queue *queue)
+{
+	ctf_top_queue_remove_enter((uint32_t)(uintptr_t)queue);
+}
+
+void sys_trace_k_queue_remove_exit(struct k_queue *queue, bool ret)
+{
+	ctf_top_queue_remove_exit((uint32_t)(uintptr_t)queue, (uint8_t)ret);
+}
+
+void sys_trace_k_queue_unique_append_enter(struct k_queue *queue)
+{
+	ctf_top_queue_unique_append_enter((uint32_t)(uintptr_t)queue);
+}
+
+void sys_trace_k_queue_unique_append_exit(struct k_queue *queue, bool ret)
+{
+	ctf_top_queue_unique_append_exit((uint32_t)(uintptr_t)queue, (uint8_t)ret);
+}
+
+void sys_trace_k_queue_peek_head(struct k_queue *queue, void *ret)
+{
+	ctf_top_queue_peek_head((uint32_t)(uintptr_t)queue, (uint32_t)(uintptr_t)ret);
+}
+
+void sys_trace_k_queue_peek_tail(struct k_queue *queue, void *ret)
+{
+	ctf_top_queue_peek_tail((uint32_t)(uintptr_t)queue, (uint32_t)(uintptr_t)ret);
+}
+
+/* FIFO */
+void sys_trace_k_fifo_init_enter(struct k_fifo *fifo)
+{
+	ctf_top_fifo_init_enter((uint32_t)(uintptr_t)fifo);
+}
+
+void sys_trace_k_fifo_cancel_wait_enter(struct k_fifo *fifo)
+{
+	ctf_top_fifo_cancel_wait_enter((uint32_t)(uintptr_t)fifo);
+}
+
+void sys_trace_k_fifo_init_exit(struct k_fifo *fifo)
+{
+	ctf_top_fifo_init_exit((uint32_t)(uintptr_t)fifo);
+}
+
+void sys_trace_k_fifo_cancel_wait_exit(struct k_fifo *fifo)
+{
+	ctf_top_fifo_cancel_wait_exit((uint32_t)(uintptr_t)fifo);
+}
+
+void sys_trace_k_fifo_put_enter(struct k_fifo *fifo, void *data)
+{
+	ctf_top_fifo_put_enter((uint32_t)(uintptr_t)fifo, (uint32_t)(uintptr_t)data);
+}
+
+void sys_trace_k_fifo_put_exit(struct k_fifo *fifo, void *data)
+{
+	ctf_top_fifo_put_exit((uint32_t)(uintptr_t)fifo, (uint32_t)(uintptr_t)data);
+}
+
+void sys_trace_k_fifo_alloc_put_enter(struct k_fifo *fifo, void *data)
+{
+	ctf_top_fifo_alloc_put_enter((uint32_t)(uintptr_t)fifo, (uint32_t)(uintptr_t)data);
+}
+
+void sys_trace_k_fifo_alloc_put_exit(struct k_fifo *fifo, void *data, int ret)
+{
+	ctf_top_fifo_alloc_put_exit((uint32_t)(uintptr_t)fifo, (uint32_t)(uintptr_t)data,
+				 (int32_t)ret);
+}
+
+void sys_trace_k_fifo_put_list_enter(struct k_fifo *fifo, void *head, void *tail)
+{
+	ctf_top_fifo_put_list_enter((uint32_t)(uintptr_t)fifo, (uint32_t)(uintptr_t)head,
+				  (uint32_t)(uintptr_t)tail);
+}
+
+void sys_trace_k_fifo_put_list_exit(struct k_fifo *fifo, void *head, void *tail)
+{
+	ctf_top_fifo_put_list_exit((uint32_t)(uintptr_t)fifo, (uint32_t)(uintptr_t)head,
+				 (uint32_t)(uintptr_t)tail);
+}
+
+void sys_trace_k_fifo_put_slist_enter(struct k_fifo *fifo, sys_slist_t *list)
+{
+	ctf_top_fifo_put_slist_enter((uint32_t)(uintptr_t)fifo, (uint32_t)(uintptr_t)list);
+}
+
+void sys_trace_k_fifo_put_slist_exit(struct k_fifo *fifo, sys_slist_t *list)
+{
+	ctf_top_fifo_put_slist_exit((uint32_t)(uintptr_t)fifo, (uint32_t)(uintptr_t)list);
+}
+
+void sys_trace_k_fifo_get_enter(struct k_fifo *fifo, k_timeout_t timeout)
+{
+	ctf_top_fifo_get_enter((uint32_t)(uintptr_t)fifo,
+			    k_ticks_to_us_floor32((uint32_t)timeout.ticks));
+}
+
+void sys_trace_k_fifo_get_exit(struct k_fifo *fifo, k_timeout_t timeout, void *ret)
+{
+	ctf_top_fifo_get_exit((uint32_t)(uintptr_t)fifo,
+			   k_ticks_to_us_floor32((uint32_t)timeout.ticks),
+			   (uint32_t)(uintptr_t)ret);
+}
+
+void sys_trace_k_fifo_peek_head_enter(struct k_fifo *fifo)
+{
+	ctf_top_fifo_peek_head_enter((uint32_t)(uintptr_t)fifo);
+}
+
+void sys_trace_k_fifo_peek_head_exit(struct k_fifo *fifo, void *ret)
+{
+	ctf_top_fifo_peek_head_exit((uint32_t)(uintptr_t)fifo, (uint32_t)(uintptr_t)ret);
+}
+
+void sys_trace_k_fifo_peek_tail_enter(struct k_fifo *fifo)
+{
+	ctf_top_fifo_peek_tail_enter((uint32_t)(uintptr_t)fifo);
+}
+
+void sys_trace_k_fifo_peek_tail_exit(struct k_fifo *fifo, void *ret)
+{
+	ctf_top_fifo_peek_tail_exit((uint32_t)(uintptr_t)fifo, (uint32_t)(uintptr_t)ret);
+}
+
+/* LIFO */
+void sys_trace_k_lifo_init_enter(struct k_lifo *lifo)
+{
+	ctf_top_lifo_init_enter((uint32_t)(uintptr_t)lifo);
+}
+
+void sys_trace_k_lifo_init_exit(struct k_lifo *lifo)
+{
+	ctf_top_lifo_init_exit((uint32_t)(uintptr_t)lifo);
+}
+
+void sys_trace_k_lifo_put_enter(struct k_lifo *lifo, void *data)
+{
+	ctf_top_lifo_put_enter((uint32_t)(uintptr_t)lifo, (uint32_t)(uintptr_t)data);
+}
+
+void sys_trace_k_lifo_put_exit(struct k_lifo *lifo, void *data)
+{
+	ctf_top_lifo_put_exit((uint32_t)(uintptr_t)lifo, (uint32_t)(uintptr_t)data);
+}
+
+void sys_trace_k_lifo_alloc_put_enter(struct k_lifo *lifo, void *data)
+{
+	ctf_top_lifo_alloc_put_enter((uint32_t)(uintptr_t)lifo, (uint32_t)(uintptr_t)data);
+}
+
+void sys_trace_k_lifo_alloc_put_exit(struct k_lifo *lifo, void *data, int ret)
+{
+	ctf_top_lifo_alloc_put_exit((uint32_t)(uintptr_t)lifo, (uint32_t)(uintptr_t)data,
+				 (int32_t)ret);
+}
+
+void sys_trace_k_lifo_get_enter(struct k_lifo *lifo, k_timeout_t timeout)
+{
+	ctf_top_lifo_get_enter((uint32_t)(uintptr_t)lifo,
+			    k_ticks_to_us_floor32((uint32_t)timeout.ticks));
+}
+
+void sys_trace_k_lifo_get_exit(struct k_lifo *lifo, k_timeout_t timeout, void *ret)
+{
+	ctf_top_lifo_get_exit((uint32_t)(uintptr_t)lifo,
+			   k_ticks_to_us_floor32((uint32_t)timeout.ticks),
+			   (uint32_t)(uintptr_t)ret);
+}
+
+/* Stack */
+void sys_trace_k_stack_init(struct k_stack *stack)
+{
+	ctf_top_stack_init((uint32_t)(uintptr_t)stack);
+}
+
+void sys_trace_k_stack_alloc_init_enter(struct k_stack *stack)
+{
+	ctf_top_stack_alloc_init_enter((uint32_t)(uintptr_t)stack);
+}
+
+void sys_trace_k_stack_alloc_init_exit(struct k_stack *stack, int ret)
+{
+	ctf_top_stack_alloc_init_exit((uint32_t)(uintptr_t)stack, (int32_t)ret);
+}
+
+void sys_trace_k_stack_cleanup_enter(struct k_stack *stack)
+{
+	ctf_top_stack_cleanup_enter((uint32_t)(uintptr_t)stack);
+}
+
+void sys_trace_k_stack_cleanup_exit(struct k_stack *stack, int ret)
+{
+	ctf_top_stack_cleanup_exit((uint32_t)(uintptr_t)stack, (int32_t)ret);
+}
+
+void sys_trace_k_stack_push_enter(struct k_stack *stack)
+{
+	ctf_top_stack_push_enter((uint32_t)(uintptr_t)stack);
+}
+
+void sys_trace_k_stack_push_exit(struct k_stack *stack, int ret)
+{
+	ctf_top_stack_push_exit((uint32_t)(uintptr_t)stack, (int32_t)ret);
+}
+
+void sys_trace_k_stack_pop_enter(struct k_stack *stack, k_timeout_t timeout)
+{
+	ctf_top_stack_pop_enter((uint32_t)(uintptr_t)stack,
+			     k_ticks_to_us_floor32((uint32_t)timeout.ticks));
+}
+
+void sys_trace_k_stack_pop_blocking(struct k_stack *stack, k_timeout_t timeout)
+{
+	ctf_top_stack_pop_blocking((uint32_t)(uintptr_t)stack,
+				k_ticks_to_us_floor32((uint32_t)timeout.ticks));
+}
+
+void sys_trace_k_stack_pop_exit(struct k_stack *stack, k_timeout_t timeout, int ret)
+{
+	ctf_top_stack_pop_exit((uint32_t)(uintptr_t)stack,
+			    k_ticks_to_us_floor32((uint32_t)timeout.ticks), (int32_t)ret);
+}
+

--- a/subsys/tracing/ctf/ctf_top.h
+++ b/subsys/tracing/ctf/ctf_top.h
@@ -354,6 +354,76 @@ typedef enum {
 	CTF_EVENT_SYS_INIT_ENTER = 0x104,
 	CTF_EVENT_SYS_INIT_EXIT = 0x105,
 
+	/* Queue */
+	CTF_EVENT_QUEUE_INIT = 0x106,
+	CTF_EVENT_QUEUE_CANCEL_WAIT = 0x107,
+	CTF_EVENT_QUEUE_QUEUE_INSERT_ENTER = 0x108,
+	CTF_EVENT_QUEUE_QUEUE_INSERT_BLOCKING = 0x109,
+	CTF_EVENT_QUEUE_QUEUE_INSERT_EXIT = 0x10A,
+	CTF_EVENT_QUEUE_APPEND_ENTER = 0x10B,
+	CTF_EVENT_QUEUE_APPEND_EXIT = 0x10C,
+	CTF_EVENT_QUEUE_ALLOC_APPEND_ENTER = 0x10D,
+	CTF_EVENT_QUEUE_ALLOC_APPEND_EXIT = 0x10E,
+	CTF_EVENT_QUEUE_PREPEND_ENTER = 0x10F,
+	CTF_EVENT_QUEUE_PREPEND_EXIT = 0x110,
+	CTF_EVENT_QUEUE_ALLOC_PREPEND_ENTER = 0x111,
+	CTF_EVENT_QUEUE_ALLOC_PREPEND_EXIT = 0x112,
+	CTF_EVENT_QUEUE_INSERT_ENTER = 0x113,
+	CTF_EVENT_QUEUE_INSERT_BLOCKING = 0x114,
+	CTF_EVENT_QUEUE_INSERT_EXIT = 0x115,
+	CTF_EVENT_QUEUE_APPEND_LIST_ENTER = 0x116,
+	CTF_EVENT_QUEUE_APPEND_LIST_EXIT = 0x117,
+	CTF_EVENT_QUEUE_MERGE_SLIST_ENTER = 0x118,
+	CTF_EVENT_QUEUE_MERGE_SLIST_EXIT = 0x119,
+	CTF_EVENT_QUEUE_GET_ENTER = 0x11A,
+	CTF_EVENT_QUEUE_GET_BLOCKING = 0x11B,
+	CTF_EVENT_QUEUE_GET_EXIT = 0x11C,
+	CTF_EVENT_QUEUE_REMOVE_ENTER = 0x11D,
+	CTF_EVENT_QUEUE_REMOVE_EXIT = 0x11E,
+	CTF_EVENT_QUEUE_UNIQUE_APPEND_ENTER = 0x11F,
+	CTF_EVENT_QUEUE_UNIQUE_APPEND_EXIT = 0x120,
+	CTF_EVENT_QUEUE_PEEK_HEAD = 0x121,
+	CTF_EVENT_QUEUE_PEEK_TAIL = 0x122,
+	/* FIFO */
+	CTF_EVENT_FIFO_INIT_ENTER = 0x123,
+	CTF_EVENT_FIFO_INIT_EXIT = 0x124,
+	CTF_EVENT_FIFO_CANCEL_WAIT_ENTER = 0x125,
+	CTF_EVENT_FIFO_CANCEL_WAIT_EXIT = 0x126,
+	CTF_EVENT_FIFO_PUT_ENTER = 0x127,
+	CTF_EVENT_FIFO_PUT_EXIT = 0x128,
+	CTF_EVENT_FIFO_ALLOC_PUT_ENTER = 0x129,
+	CTF_EVENT_FIFO_ALLOC_PUT_EXIT = 0x12A,
+	CTF_EVENT_FIFO_PUT_LIST_ENTER = 0x12B,
+	CTF_EVENT_FIFO_PUT_LIST_EXIT = 0x12C,
+	CTF_EVENT_FIFO_PUT_SLIST_ENTER = 0x12D,
+	CTF_EVENT_FIFO_PUT_SLIST_EXIT = 0x12E,
+	CTF_EVENT_FIFO_GET_ENTER = 0x12F,
+	CTF_EVENT_FIFO_GET_EXIT = 0x130,
+	CTF_EVENT_FIFO_PEEK_HEAD_ENTER = 0x131,
+	CTF_EVENT_FIFO_PEEK_HEAD_EXIT = 0x132,
+	CTF_EVENT_FIFO_PEEK_TAIL_ENTER = 0x133,
+	CTF_EVENT_FIFO_PEEK_TAIL_EXIT = 0x134,
+	/* LIFO */
+	CTF_EVENT_LIFO_INIT_ENTER = 0x135,
+	CTF_EVENT_LIFO_INIT_EXIT = 0x136,
+	CTF_EVENT_LIFO_PUT_ENTER = 0x137,
+	CTF_EVENT_LIFO_PUT_EXIT = 0x138,
+	CTF_EVENT_LIFO_ALLOC_PUT_ENTER = 0x139,
+	CTF_EVENT_LIFO_ALLOC_PUT_EXIT = 0x13A,
+	CTF_EVENT_LIFO_GET_ENTER = 0x13B,
+	CTF_EVENT_LIFO_GET_EXIT = 0x13C,
+	/* Stack */
+	CTF_EVENT_STACK_INIT = 0x13D,
+	CTF_EVENT_STACK_ALLOC_INIT_ENTER = 0x13E,
+	CTF_EVENT_STACK_ALLOC_INIT_EXIT = 0x13F,
+	CTF_EVENT_STACK_CLEANUP_ENTER = 0x140,
+	CTF_EVENT_STACK_CLEANUP_EXIT = 0x141,
+	CTF_EVENT_STACK_PUSH_ENTER = 0x142,
+	CTF_EVENT_STACK_PUSH_EXIT = 0x143,
+	CTF_EVENT_STACK_POP_ENTER = 0x144,
+	CTF_EVENT_STACK_POP_BLOCKING = 0x145,
+	CTF_EVENT_STACK_POP_EXIT = 0x146,
+
 } ctf_event_t;
 
 typedef struct {
@@ -1672,6 +1742,333 @@ static inline void ctf_top_event_wait_blocking(uint32_t event_id, uint32_t event
 static inline void ctf_top_event_wait_exit(uint32_t event_id, uint32_t events, int32_t ret)
 {
 	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_EVENT_WAIT_EXIT), event_id, events, ret);
+}
+
+
+/* Queue / FIFO / LIFO / Stack */
+static inline void ctf_top_queue_init(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_INIT), id);
+}
+
+static inline void ctf_top_queue_cancel_wait(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_CANCEL_WAIT), id);
+}
+
+static inline void ctf_top_queue_queue_insert_enter(uint32_t id, uint8_t alloc)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_QUEUE_INSERT_ENTER), id, alloc);
+}
+
+static inline void ctf_top_queue_queue_insert_blocking(uint32_t id, uint8_t alloc, uint32_t timeout)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_QUEUE_INSERT_BLOCKING), id, alloc, timeout);
+}
+
+static inline void ctf_top_queue_queue_insert_exit(uint32_t id, uint8_t alloc, int32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_QUEUE_INSERT_EXIT), id, alloc, ret);
+}
+
+static inline void ctf_top_queue_append_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_APPEND_ENTER), id);
+}
+
+static inline void ctf_top_queue_append_exit(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_APPEND_EXIT), id);
+}
+
+static inline void ctf_top_queue_alloc_append_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_ALLOC_APPEND_ENTER), id);
+}
+
+static inline void ctf_top_queue_alloc_append_exit(uint32_t id, int32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_ALLOC_APPEND_EXIT), id, ret);
+}
+
+static inline void ctf_top_queue_prepend_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_PREPEND_ENTER), id);
+}
+
+static inline void ctf_top_queue_prepend_exit(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_PREPEND_EXIT), id);
+}
+
+static inline void ctf_top_queue_alloc_prepend_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_ALLOC_PREPEND_ENTER), id);
+}
+
+static inline void ctf_top_queue_alloc_prepend_exit(uint32_t id, int32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_ALLOC_PREPEND_EXIT), id, ret);
+}
+
+static inline void ctf_top_queue_insert_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_INSERT_ENTER), id);
+}
+
+static inline void ctf_top_queue_insert_blocking(uint32_t id, uint32_t timeout)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_INSERT_BLOCKING), id, timeout);
+}
+
+static inline void ctf_top_queue_insert_exit(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_INSERT_EXIT), id);
+}
+
+static inline void ctf_top_queue_append_list_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_APPEND_LIST_ENTER), id);
+}
+
+static inline void ctf_top_queue_append_list_exit(uint32_t id, int32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_APPEND_LIST_EXIT), id, ret);
+}
+
+static inline void ctf_top_queue_merge_slist_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_MERGE_SLIST_ENTER), id);
+}
+
+static inline void ctf_top_queue_merge_slist_exit(uint32_t id, int32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_MERGE_SLIST_EXIT), id, ret);
+}
+
+static inline void ctf_top_queue_get_enter(uint32_t id, uint32_t timeout)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_GET_ENTER), id, timeout);
+}
+
+static inline void ctf_top_queue_get_blocking(uint32_t id, uint32_t timeout)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_GET_BLOCKING), id, timeout);
+}
+
+static inline void ctf_top_queue_get_exit(uint32_t id, uint32_t timeout, uint32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_GET_EXIT), id, timeout, ret);
+}
+
+static inline void ctf_top_queue_remove_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_REMOVE_ENTER), id);
+}
+
+static inline void ctf_top_queue_remove_exit(uint32_t id, uint8_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_REMOVE_EXIT), id, ret);
+}
+
+static inline void ctf_top_queue_unique_append_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_UNIQUE_APPEND_ENTER), id);
+}
+
+static inline void ctf_top_queue_unique_append_exit(uint32_t id, uint8_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_UNIQUE_APPEND_EXIT), id, ret);
+}
+
+static inline void ctf_top_queue_peek_head(uint32_t id, uint32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_PEEK_HEAD), id, ret);
+}
+
+static inline void ctf_top_queue_peek_tail(uint32_t id, uint32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_QUEUE_PEEK_TAIL), id, ret);
+}
+
+static inline void ctf_top_fifo_init_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_INIT_ENTER), id);
+}
+
+static inline void ctf_top_fifo_init_exit(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_INIT_EXIT), id);
+}
+
+static inline void ctf_top_fifo_cancel_wait_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_CANCEL_WAIT_ENTER), id);
+}
+
+static inline void ctf_top_fifo_cancel_wait_exit(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_CANCEL_WAIT_EXIT), id);
+}
+
+static inline void ctf_top_fifo_put_enter(uint32_t id, uint32_t data)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_PUT_ENTER), id, data);
+}
+
+static inline void ctf_top_fifo_put_exit(uint32_t id, uint32_t data)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_PUT_EXIT), id, data);
+}
+
+static inline void ctf_top_fifo_alloc_put_enter(uint32_t id, uint32_t data)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_ALLOC_PUT_ENTER), id, data);
+}
+
+static inline void ctf_top_fifo_alloc_put_exit(uint32_t id, uint32_t data, int32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_ALLOC_PUT_EXIT), id, data, ret);
+}
+
+static inline void ctf_top_fifo_put_list_enter(uint32_t id, uint32_t head, uint32_t tail)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_PUT_LIST_ENTER), id, head, tail);
+}
+
+static inline void ctf_top_fifo_put_list_exit(uint32_t id, uint32_t head, uint32_t tail)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_PUT_LIST_EXIT), id, head, tail);
+}
+
+static inline void ctf_top_fifo_put_slist_enter(uint32_t id, uint32_t list)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_PUT_SLIST_ENTER), id, list);
+}
+
+static inline void ctf_top_fifo_put_slist_exit(uint32_t id, uint32_t list)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_PUT_SLIST_EXIT), id, list);
+}
+
+static inline void ctf_top_fifo_get_enter(uint32_t id, uint32_t timeout)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_GET_ENTER), id, timeout);
+}
+
+static inline void ctf_top_fifo_get_exit(uint32_t id, uint32_t timeout, uint32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_GET_EXIT), id, timeout, ret);
+}
+
+static inline void ctf_top_fifo_peek_head_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_PEEK_HEAD_ENTER), id);
+}
+
+static inline void ctf_top_fifo_peek_head_exit(uint32_t id, uint32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_PEEK_HEAD_EXIT), id, ret);
+}
+
+static inline void ctf_top_fifo_peek_tail_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_PEEK_TAIL_ENTER), id);
+}
+
+static inline void ctf_top_fifo_peek_tail_exit(uint32_t id, uint32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_FIFO_PEEK_TAIL_EXIT), id, ret);
+}
+
+static inline void ctf_top_lifo_init_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_LIFO_INIT_ENTER), id);
+}
+
+static inline void ctf_top_lifo_init_exit(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_LIFO_INIT_EXIT), id);
+}
+
+static inline void ctf_top_lifo_put_enter(uint32_t id, uint32_t data)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_LIFO_PUT_ENTER), id, data);
+}
+
+static inline void ctf_top_lifo_put_exit(uint32_t id, uint32_t data)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_LIFO_PUT_EXIT), id, data);
+}
+
+static inline void ctf_top_lifo_alloc_put_enter(uint32_t id, uint32_t data)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_LIFO_ALLOC_PUT_ENTER), id, data);
+}
+
+static inline void ctf_top_lifo_alloc_put_exit(uint32_t id, uint32_t data, int32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_LIFO_ALLOC_PUT_EXIT), id, data, ret);
+}
+
+static inline void ctf_top_lifo_get_enter(uint32_t id, uint32_t timeout)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_LIFO_GET_ENTER), id, timeout);
+}
+
+static inline void ctf_top_lifo_get_exit(uint32_t id, uint32_t timeout, uint32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_LIFO_GET_EXIT), id, timeout, ret);
+}
+
+static inline void ctf_top_stack_init(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_STACK_INIT), id);
+}
+
+static inline void ctf_top_stack_alloc_init_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_STACK_ALLOC_INIT_ENTER), id);
+}
+
+static inline void ctf_top_stack_alloc_init_exit(uint32_t id, int32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_STACK_ALLOC_INIT_EXIT), id, ret);
+}
+
+static inline void ctf_top_stack_cleanup_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_STACK_CLEANUP_ENTER), id);
+}
+
+static inline void ctf_top_stack_cleanup_exit(uint32_t id, int32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_STACK_CLEANUP_EXIT), id, ret);
+}
+
+static inline void ctf_top_stack_push_enter(uint32_t id)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_STACK_PUSH_ENTER), id);
+}
+
+static inline void ctf_top_stack_push_exit(uint32_t id, int32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_STACK_PUSH_EXIT), id, ret);
+}
+
+static inline void ctf_top_stack_pop_enter(uint32_t id, uint32_t timeout)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_STACK_POP_ENTER), id, timeout);
+}
+
+static inline void ctf_top_stack_pop_blocking(uint32_t id, uint32_t timeout)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_STACK_POP_BLOCKING), id, timeout);
+}
+
+static inline void ctf_top_stack_pop_exit(uint32_t id, uint32_t timeout, int32_t ret)
+{
+	CTF_EVENT(CTF_LITERAL(uint16_t, CTF_EVENT_STACK_POP_EXIT), id, timeout, ret);
 }
 
 #endif /* SUBSYS_DEBUG_TRACING_CTF_TOP_H */

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -243,6 +243,140 @@ extern "C" {
 #define sys_port_trace_k_msgq_peek(msgq, ret) sys_trace_k_msgq_peek(msgq, ret)
 #define sys_port_trace_k_msgq_purge(msgq)     sys_trace_k_msgq_purge(msgq)
 
+/* Queue */
+#define sys_port_trace_k_queue_init(queue) sys_trace_k_queue_init(queue)
+#define sys_port_trace_k_queue_cancel_wait(queue)                              \
+	sys_trace_k_queue_cancel_wait(queue)
+#define sys_port_trace_k_queue_queue_insert_enter(queue, alloc)                \
+	sys_trace_k_queue_queue_insert_enter(queue, alloc)
+#define sys_port_trace_k_queue_queue_insert_blocking(queue, alloc, timeout)    \
+	sys_trace_k_queue_queue_insert_blocking(queue, alloc, timeout)
+#define sys_port_trace_k_queue_queue_insert_exit(queue, alloc, ret)            \
+	sys_trace_k_queue_queue_insert_exit(queue, alloc, ret)
+#define sys_port_trace_k_queue_append_enter(queue)                             \
+	sys_trace_k_queue_append_enter(queue)
+#define sys_port_trace_k_queue_append_exit(queue)                              \
+	sys_trace_k_queue_append_exit(queue)
+#define sys_port_trace_k_queue_prepend_enter(queue)                            \
+	sys_trace_k_queue_prepend_enter(queue)
+#define sys_port_trace_k_queue_prepend_exit(queue)                             \
+	sys_trace_k_queue_prepend_exit(queue)
+#define sys_port_trace_k_queue_alloc_append_enter(queue)                       \
+	sys_trace_k_queue_alloc_append_enter(queue)
+#define sys_port_trace_k_queue_alloc_append_exit(queue, ret)                   \
+	sys_trace_k_queue_alloc_append_exit(queue, ret)
+#define sys_port_trace_k_queue_alloc_prepend_enter(queue)                      \
+	sys_trace_k_queue_alloc_prepend_enter(queue)
+#define sys_port_trace_k_queue_alloc_prepend_exit(queue, ret)                  \
+	sys_trace_k_queue_alloc_prepend_exit(queue, ret)
+#define sys_port_trace_k_queue_insert_enter(queue)                             \
+	sys_trace_k_queue_insert_enter(queue)
+#define sys_port_trace_k_queue_insert_blocking(queue, timeout)                 \
+	sys_trace_k_queue_insert_blocking(queue, timeout)
+#define sys_port_trace_k_queue_insert_exit(queue)                              \
+	sys_trace_k_queue_insert_exit(queue)
+#define sys_port_trace_k_queue_append_list_enter(queue)                        \
+	sys_trace_k_queue_append_list_enter(queue)
+#define sys_port_trace_k_queue_append_list_exit(queue, ret)                    \
+	sys_trace_k_queue_append_list_exit(queue, ret)
+#define sys_port_trace_k_queue_merge_slist_enter(queue)                        \
+	sys_trace_k_queue_merge_slist_enter(queue)
+#define sys_port_trace_k_queue_merge_slist_exit(queue, ret)                    \
+	sys_trace_k_queue_merge_slist_exit(queue, ret)
+#define sys_port_trace_k_queue_get_enter(queue, timeout)                       \
+	sys_trace_k_queue_get_enter(queue, timeout)
+#define sys_port_trace_k_queue_get_blocking(queue, timeout)                    \
+	sys_trace_k_queue_get_blocking(queue, timeout)
+#define sys_port_trace_k_queue_get_exit(queue, timeout, ret)                   \
+	sys_trace_k_queue_get_exit(queue, timeout, ret)
+#define sys_port_trace_k_queue_remove_enter(queue)                             \
+	sys_trace_k_queue_remove_enter(queue)
+#define sys_port_trace_k_queue_remove_exit(queue, ret)                         \
+	sys_trace_k_queue_remove_exit(queue, ret)
+#define sys_port_trace_k_queue_unique_append_enter(queue)                      \
+	sys_trace_k_queue_unique_append_enter(queue)
+#define sys_port_trace_k_queue_unique_append_exit(queue, ret)                  \
+	sys_trace_k_queue_unique_append_exit(queue, ret)
+#define sys_port_trace_k_queue_peek_head(queue, ret)                           \
+	sys_trace_k_queue_peek_head(queue, ret)
+#define sys_port_trace_k_queue_peek_tail(queue, ret)                           \
+	sys_trace_k_queue_peek_tail(queue, ret)
+
+/* FIFO */
+#define sys_port_trace_k_fifo_init_enter(fifo)                                 \
+	sys_trace_k_fifo_init_enter(fifo)
+#define sys_port_trace_k_fifo_cancel_wait_enter(fifo)                          \
+	sys_trace_k_fifo_cancel_wait_enter(fifo)
+#define sys_port_trace_k_fifo_init_exit(fifo) sys_trace_k_fifo_init_exit(fifo)
+#define sys_port_trace_k_fifo_cancel_wait_exit(fifo)                           \
+	sys_trace_k_fifo_cancel_wait_exit(fifo)
+#define sys_port_trace_k_fifo_put_enter(fifo, data)                            \
+	sys_trace_k_fifo_put_enter(fifo, data)
+#define sys_port_trace_k_fifo_put_exit(fifo, data)                             \
+	sys_trace_k_fifo_put_exit(fifo, data)
+#define sys_port_trace_k_fifo_alloc_put_enter(fifo, data)                      \
+	sys_trace_k_fifo_alloc_put_enter(fifo, data)
+#define sys_port_trace_k_fifo_alloc_put_exit(fifo, data, ret)                  \
+	sys_trace_k_fifo_alloc_put_exit(fifo, data, ret)
+#define sys_port_trace_k_fifo_put_list_enter(fifo, head, tail)                 \
+	sys_trace_k_fifo_put_list_enter(fifo, head, tail)
+#define sys_port_trace_k_fifo_put_list_exit(fifo, head, tail)                  \
+	sys_trace_k_fifo_put_list_exit(fifo, head, tail)
+#define sys_port_trace_k_fifo_put_slist_enter(fifo, list)                      \
+	sys_trace_k_fifo_put_slist_enter(fifo, list)
+#define sys_port_trace_k_fifo_put_slist_exit(fifo, list)                       \
+	sys_trace_k_fifo_put_slist_exit(fifo, list)
+#define sys_port_trace_k_fifo_get_enter(fifo, timeout)                         \
+	sys_trace_k_fifo_get_enter(fifo, timeout)
+#define sys_port_trace_k_fifo_get_exit(fifo, timeout, ret)                     \
+	sys_trace_k_fifo_get_exit(fifo, timeout, ret)
+#define sys_port_trace_k_fifo_peek_head_enter(fifo)                            \
+	sys_trace_k_fifo_peek_head_enter(fifo)
+#define sys_port_trace_k_fifo_peek_head_exit(fifo, ret)                        \
+	sys_trace_k_fifo_peek_head_exit(fifo, ret)
+#define sys_port_trace_k_fifo_peek_tail_enter(fifo)                            \
+	sys_trace_k_fifo_peek_tail_enter(fifo)
+#define sys_port_trace_k_fifo_peek_tail_exit(fifo, ret)                        \
+	sys_trace_k_fifo_peek_tail_exit(fifo, ret)
+
+/* LIFO */
+#define sys_port_trace_k_lifo_init_enter(lifo)                                 \
+	sys_trace_k_lifo_init_enter(lifo)
+#define sys_port_trace_k_lifo_init_exit(lifo) sys_trace_k_lifo_init_exit(lifo)
+#define sys_port_trace_k_lifo_put_enter(lifo, data)                            \
+	sys_trace_k_lifo_put_enter(lifo, data)
+#define sys_port_trace_k_lifo_put_exit(lifo, data)                             \
+	sys_trace_k_lifo_put_exit(lifo, data)
+#define sys_port_trace_k_lifo_alloc_put_enter(lifo, data)                      \
+	sys_trace_k_lifo_alloc_put_enter(lifo, data)
+#define sys_port_trace_k_lifo_alloc_put_exit(lifo, data, ret)                  \
+	sys_trace_k_lifo_alloc_put_exit(lifo, data, ret)
+#define sys_port_trace_k_lifo_get_enter(lifo, timeout)                         \
+	sys_trace_k_lifo_get_enter(lifo, timeout)
+#define sys_port_trace_k_lifo_get_exit(lifo, timeout, ret)                     \
+	sys_trace_k_lifo_get_exit(lifo, timeout, ret)
+
+/* Stack */
+#define sys_port_trace_k_stack_init(stack) sys_trace_k_stack_init(stack)
+#define sys_port_trace_k_stack_alloc_init_enter(stack)                         \
+	sys_trace_k_stack_alloc_init_enter(stack)
+#define sys_port_trace_k_stack_alloc_init_exit(stack, ret)                     \
+	sys_trace_k_stack_alloc_init_exit(stack, ret)
+#define sys_port_trace_k_stack_cleanup_enter(stack)                            \
+	sys_trace_k_stack_cleanup_enter(stack)
+#define sys_port_trace_k_stack_cleanup_exit(stack, ret)                        \
+	sys_trace_k_stack_cleanup_exit(stack, ret)
+#define sys_port_trace_k_stack_push_enter(stack)                               \
+	sys_trace_k_stack_push_enter(stack)
+#define sys_port_trace_k_stack_push_exit(stack, ret)                           \
+	sys_trace_k_stack_push_exit(stack, ret)
+#define sys_port_trace_k_stack_pop_enter(stack, timeout)                       \
+	sys_trace_k_stack_pop_enter(stack, timeout)
+#define sys_port_trace_k_stack_pop_blocking(stack, timeout)                    \
+	sys_trace_k_stack_pop_blocking(stack, timeout)
+#define sys_port_trace_k_stack_pop_exit(stack, timeout, ret)                   \
+	sys_trace_k_stack_pop_exit(stack, timeout, ret)
+
 #define sys_port_trace_k_mbox_init(mbox) sys_trace_k_mbox_init(mbox)
 #define sys_port_trace_k_mbox_message_put_enter(mbox, timeout)                                     \
 	sys_trace_k_mbox_message_put_enter(mbox, timeout)
@@ -368,6 +502,79 @@ void sys_trace_k_msgq_get_blocking(struct k_msgq *msgq, k_timeout_t timeout);
 void sys_trace_k_msgq_get_exit(struct k_msgq *msgq, k_timeout_t timeout, int ret);
 void sys_trace_k_msgq_peek(struct k_msgq *msgq, int ret);
 void sys_trace_k_msgq_purge(struct k_msgq *msgq);
+
+/* Queue */
+void sys_trace_k_queue_init(struct k_queue *queue);
+void sys_trace_k_queue_cancel_wait(struct k_queue *queue);
+void sys_trace_k_queue_queue_insert_enter(struct k_queue *queue, bool alloc);
+void sys_trace_k_queue_queue_insert_blocking(struct k_queue *queue, bool alloc, k_timeout_t timeout);
+void sys_trace_k_queue_queue_insert_exit(struct k_queue *queue, bool alloc, int ret);
+void sys_trace_k_queue_append_enter(struct k_queue *queue);
+void sys_trace_k_queue_append_exit(struct k_queue *queue);
+void sys_trace_k_queue_prepend_enter(struct k_queue *queue);
+void sys_trace_k_queue_prepend_exit(struct k_queue *queue);
+void sys_trace_k_queue_alloc_append_enter(struct k_queue *queue);
+void sys_trace_k_queue_alloc_append_exit(struct k_queue *queue, int ret);
+void sys_trace_k_queue_alloc_prepend_enter(struct k_queue *queue);
+void sys_trace_k_queue_alloc_prepend_exit(struct k_queue *queue, int ret);
+void sys_trace_k_queue_insert_enter(struct k_queue *queue);
+void sys_trace_k_queue_insert_blocking(struct k_queue *queue, k_timeout_t timeout);
+void sys_trace_k_queue_insert_exit(struct k_queue *queue);
+void sys_trace_k_queue_append_list_enter(struct k_queue *queue);
+void sys_trace_k_queue_append_list_exit(struct k_queue *queue, int ret);
+void sys_trace_k_queue_merge_slist_enter(struct k_queue *queue);
+void sys_trace_k_queue_merge_slist_exit(struct k_queue *queue, int ret);
+void sys_trace_k_queue_get_enter(struct k_queue *queue, k_timeout_t timeout);
+void sys_trace_k_queue_get_blocking(struct k_queue *queue, k_timeout_t timeout);
+void sys_trace_k_queue_get_exit(struct k_queue *queue, k_timeout_t timeout, void *ret);
+void sys_trace_k_queue_remove_enter(struct k_queue *queue);
+void sys_trace_k_queue_remove_exit(struct k_queue *queue, bool ret);
+void sys_trace_k_queue_unique_append_enter(struct k_queue *queue);
+void sys_trace_k_queue_unique_append_exit(struct k_queue *queue, bool ret);
+void sys_trace_k_queue_peek_head(struct k_queue *queue, void *ret);
+void sys_trace_k_queue_peek_tail(struct k_queue *queue, void *ret);
+
+/* FIFO */
+void sys_trace_k_fifo_init_enter(struct k_fifo *fifo);
+void sys_trace_k_fifo_cancel_wait_enter(struct k_fifo *fifo);
+void sys_trace_k_fifo_init_exit(struct k_fifo *fifo);
+void sys_trace_k_fifo_cancel_wait_exit(struct k_fifo *fifo);
+void sys_trace_k_fifo_put_enter(struct k_fifo *fifo, void *data);
+void sys_trace_k_fifo_put_exit(struct k_fifo *fifo, void *data);
+void sys_trace_k_fifo_alloc_put_enter(struct k_fifo *fifo, void *data);
+void sys_trace_k_fifo_alloc_put_exit(struct k_fifo *fifo, void *data, int ret);
+void sys_trace_k_fifo_put_list_enter(struct k_fifo *fifo, void *head, void *tail);
+void sys_trace_k_fifo_put_list_exit(struct k_fifo *fifo, void *head, void *tail);
+void sys_trace_k_fifo_put_slist_enter(struct k_fifo *fifo, sys_slist_t *list);
+void sys_trace_k_fifo_put_slist_exit(struct k_fifo *fifo, sys_slist_t *list);
+void sys_trace_k_fifo_get_enter(struct k_fifo *fifo, k_timeout_t timeout);
+void sys_trace_k_fifo_get_exit(struct k_fifo *fifo, k_timeout_t timeout, void *ret);
+void sys_trace_k_fifo_peek_head_enter(struct k_fifo *fifo);
+void sys_trace_k_fifo_peek_head_exit(struct k_fifo *fifo, void *ret);
+void sys_trace_k_fifo_peek_tail_enter(struct k_fifo *fifo);
+void sys_trace_k_fifo_peek_tail_exit(struct k_fifo *fifo, void *ret);
+
+/* LIFO */
+void sys_trace_k_lifo_init_enter(struct k_lifo *lifo);
+void sys_trace_k_lifo_init_exit(struct k_lifo *lifo);
+void sys_trace_k_lifo_put_enter(struct k_lifo *lifo, void *data);
+void sys_trace_k_lifo_put_exit(struct k_lifo *lifo, void *data);
+void sys_trace_k_lifo_alloc_put_enter(struct k_lifo *lifo, void *data);
+void sys_trace_k_lifo_alloc_put_exit(struct k_lifo *lifo, void *data, int ret);
+void sys_trace_k_lifo_get_enter(struct k_lifo *lifo, k_timeout_t timeout);
+void sys_trace_k_lifo_get_exit(struct k_lifo *lifo, k_timeout_t timeout, void *ret);
+
+/* Stack */
+void sys_trace_k_stack_init(struct k_stack *stack);
+void sys_trace_k_stack_alloc_init_enter(struct k_stack *stack);
+void sys_trace_k_stack_alloc_init_exit(struct k_stack *stack, int ret);
+void sys_trace_k_stack_cleanup_enter(struct k_stack *stack);
+void sys_trace_k_stack_cleanup_exit(struct k_stack *stack, int ret);
+void sys_trace_k_stack_push_enter(struct k_stack *stack);
+void sys_trace_k_stack_push_exit(struct k_stack *stack, int ret);
+void sys_trace_k_stack_pop_enter(struct k_stack *stack, k_timeout_t timeout);
+void sys_trace_k_stack_pop_blocking(struct k_stack *stack, k_timeout_t timeout);
+void sys_trace_k_stack_pop_exit(struct k_stack *stack, k_timeout_t timeout, int ret);
 
 /* Condition Variables */
 void sys_trace_k_condvar_init(struct k_condvar *condvar, int ret);

--- a/subsys/tracing/ctf/tsdl/metadata
+++ b/subsys/tracing/ctf/tsdl/metadata
@@ -2250,3 +2250,579 @@ event {
 		int32_t result;
 	};
 };
+
+/* Queue */
+event {
+	name = queue_init;
+	id = 0x106;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_cancel_wait;
+	id = 0x107;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_queue_insert_enter;
+	id = 0x108;
+	fields := struct {
+		uint32_t id;
+		uint8_t alloc;
+	};
+};
+
+event {
+	name = queue_queue_insert_blocking;
+	id = 0x109;
+	fields := struct {
+		uint32_t id;
+		uint8_t alloc;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = queue_queue_insert_exit;
+	id = 0x10A;
+	fields := struct {
+		uint32_t id;
+		uint8_t alloc;
+		int32_t ret;
+	};
+};
+
+event {
+	name = queue_append_enter;
+	id = 0x10B;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_append_exit;
+	id = 0x10C;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_alloc_append_enter;
+	id = 0x10D;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_alloc_append_exit;
+	id = 0x10E;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = queue_prepend_enter;
+	id = 0x10F;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_prepend_exit;
+	id = 0x110;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_alloc_prepend_enter;
+	id = 0x111;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_alloc_prepend_exit;
+	id = 0x112;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = queue_insert_enter;
+	id = 0x113;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_insert_blocking;
+	id = 0x114;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = queue_insert_exit;
+	id = 0x115;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_append_list_enter;
+	id = 0x116;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_append_list_exit;
+	id = 0x117;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = queue_merge_slist_enter;
+	id = 0x118;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_merge_slist_exit;
+	id = 0x119;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = queue_get_enter;
+	id = 0x11A;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = queue_get_blocking;
+	id = 0x11B;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = queue_get_exit;
+	id = 0x11C;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = queue_remove_enter;
+	id = 0x11D;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_remove_exit;
+	id = 0x11E;
+	fields := struct {
+		uint32_t id;
+		uint8_t ret;
+	};
+};
+
+event {
+	name = queue_unique_append_enter;
+	id = 0x11F;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = queue_unique_append_exit;
+	id = 0x120;
+	fields := struct {
+		uint32_t id;
+		uint8_t ret;
+	};
+};
+
+event {
+	name = queue_peek_head;
+	id = 0x121;
+	fields := struct {
+		uint32_t id;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = queue_peek_tail;
+	id = 0x122;
+	fields := struct {
+		uint32_t id;
+		uint32_t ret;
+	};
+};
+
+
+/* FIFO */
+event {
+	name = fifo_init_enter;
+	id = 0x123;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = fifo_init_exit;
+	id = 0x124;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = fifo_cancel_wait_enter;
+	id = 0x125;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = fifo_cancel_wait_exit;
+	id = 0x126;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = fifo_put_enter;
+	id = 0x127;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+	};
+};
+
+event {
+	name = fifo_put_exit;
+	id = 0x128;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+	};
+};
+
+event {
+	name = fifo_alloc_put_enter;
+	id = 0x129;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+	};
+};
+
+event {
+	name = fifo_alloc_put_exit;
+	id = 0x12A;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+		int32_t ret;
+	};
+};
+
+event {
+	name = fifo_put_list_enter;
+	id = 0x12B;
+	fields := struct {
+		uint32_t id;
+		uint32_t head;
+		uint32_t tail;
+	};
+};
+
+event {
+	name = fifo_put_list_exit;
+	id = 0x12C;
+	fields := struct {
+		uint32_t id;
+		uint32_t head;
+		uint32_t tail;
+	};
+};
+
+event {
+	name = fifo_put_slist_enter;
+	id = 0x12D;
+	fields := struct {
+		uint32_t id;
+		uint32_t list;
+	};
+};
+
+event {
+	name = fifo_put_slist_exit;
+	id = 0x12E;
+	fields := struct {
+		uint32_t id;
+		uint32_t list;
+	};
+};
+
+event {
+	name = fifo_get_enter;
+	id = 0x12F;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = fifo_get_exit;
+	id = 0x130;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = fifo_peek_head_enter;
+	id = 0x131;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = fifo_peek_head_exit;
+	id = 0x132;
+	fields := struct {
+		uint32_t id;
+		uint32_t ret;
+	};
+};
+
+event {
+	name = fifo_peek_tail_enter;
+	id = 0x133;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = fifo_peek_tail_exit;
+	id = 0x134;
+	fields := struct {
+		uint32_t id;
+		uint32_t ret;
+	};
+};
+
+
+/* LIFO */
+event {
+	name = lifo_init_enter;
+	id = 0x135;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = lifo_init_exit;
+	id = 0x136;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = lifo_put_enter;
+	id = 0x137;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+	};
+};
+
+event {
+	name = lifo_put_exit;
+	id = 0x138;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+	};
+};
+
+event {
+	name = lifo_alloc_put_enter;
+	id = 0x139;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+	};
+};
+
+event {
+	name = lifo_alloc_put_exit;
+	id = 0x13A;
+	fields := struct {
+		uint32_t id;
+		uint32_t data;
+		int32_t ret;
+	};
+};
+
+event {
+	name = lifo_get_enter;
+	id = 0x13B;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = lifo_get_exit;
+	id = 0x13C;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		uint32_t ret;
+	};
+};
+
+
+/* Stack */
+event {
+	name = stack_init;
+	id = 0x13D;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = stack_alloc_init_enter;
+	id = 0x13E;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = stack_alloc_init_exit;
+	id = 0x13F;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = stack_cleanup_enter;
+	id = 0x140;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = stack_cleanup_exit;
+	id = 0x141;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = stack_push_enter;
+	id = 0x142;
+	fields := struct {
+		uint32_t id;
+	};
+};
+
+event {
+	name = stack_push_exit;
+	id = 0x143;
+	fields := struct {
+		uint32_t id;
+		int32_t ret;
+	};
+};
+
+event {
+	name = stack_pop_enter;
+	id = 0x144;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = stack_pop_blocking;
+	id = 0x145;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+	};
+};
+
+event {
+	name = stack_pop_exit;
+	id = 0x146;
+	fields := struct {
+		uint32_t id;
+		uint32_t timeout;
+		int32_t ret;
+	};
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CTF never emitted events for `k_queue` / `k_fifo` / `k_lifo` / `k_stack`. Those hooks were empty stubs from the 2021 tracing-macro migration and later fell through to the canonical no-ops in `tracing_hooks.h`, while SysView and the test backend already implemented them.

This wires all 65 hooks for those object types into the CTF backend:

- Event IDs `0x106`–`0x146` in `ctf_top.h`
- `ctf_top_*` helpers + `sys_trace_*` trampolines in `ctf_top.c`
- `sys_port_trace_*` macros in `tracing_ctf.h`
- Matching TSDL metadata

`CONFIG_TRACING_{QUEUE,FIFO,LIFO,STACK}` (all default `y`) now produce real CTF records.

## Note on double-tracing

`k_fifo` / `k_lifo` are thin wrappers over `k_queue_*`. With both FIFO/LIFO and QUEUE tracing enabled, a FIFO/LIFO call emits both the wrapper event and the underlying queue event — same behavior as SysView. Disable one of the Kconfig options if that is undesired.

## Test plan

- [ ] Build a CTF-enabled sample (`CONFIG_TRACING=y`, `CONFIG_TRACING_CTF=y`) that exercises `k_fifo_*` / `k_lifo_*` / `k_queue_*` / `k_stack_*`
- [ ] Confirm new event names appear in the CTF stream / babeltrace output (`fifo_put_enter`, `lifo_get_exit`, `queue_append_enter`, `stack_push_enter`, etc.)
- [ ] With `CONFIG_TRACING_QUEUE=n`, confirm FIFO/LIFO events still appear without nested queue events

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612e27b5-7a8d-4ffa-9694-75f4c723c566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612e27b5-7a8d-4ffa-9694-75f4c723c566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

