### PR TITLE
build: bump minimum CMake version to 3.28.0 in new CMakeLists files

### DIFF
--- a/samples/boards/espressif/qdec_trigger/CMakeLists.txt
+++ b/samples/boards/espressif/qdec_trigger/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pcnt_trigger)
 

--- a/samples/boards/espressif/wifi_mesh/CMakeLists.txt
+++ b/samples/boards/espressif/wifi_mesh/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(wifi_mesh)

--- a/samples/boards/espressif/wifi_mesh_ip/CMakeLists.txt
+++ b/samples/boards/espressif/wifi_mesh_ip/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(wifi_mesh_ip)

--- a/samples/drivers/misc/tmc6460/CMakeLists.txt
+++ b/samples/drivers/misc/tmc6460/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 Cherrence Sarip <cherrence.sarip@analog.com>
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(tmc6460)
 

--- a/samples/net/rtp/CMakeLists.txt
+++ b/samples/net/rtp/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(rtp)
 

--- a/samples/sensor/qdec_multi/CMakeLists.txt
+++ b/samples/sensor/qdec_multi/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pcnt_multi)
 

--- a/tests/boards/espressif/qdec/CMakeLists.txt
+++ b/tests/boards/espressif/qdec/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(qdec_esp32_test)

--- a/tests/boards/rpi_pico/dma_reload/CMakeLists.txt
+++ b/tests/boards/rpi_pico/dma_reload/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dma_reload)

--- a/tests/drivers/audio/wm8960/CMakeLists.txt
+++ b/tests/drivers/audio/wm8960/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(wm8960_test)
 

--- a/tests/drivers/counter/counter_conversions/CMakeLists.txt
+++ b/tests/drivers/counter/counter_conversions/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(counter_conversions)

--- a/tests/drivers/input/touchscreen_common/CMakeLists.txt
+++ b/tests/drivers/input/touchscreen_common/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project(input_touchscreen_common)

--- a/tests/drivers/memc/ram_api/CMakeLists.txt
+++ b/tests/drivers/memc/ram_api/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(memc_ram_api)
 

--- a/tests/drivers/modem/bc66x_parsing/CMakeLists.txt
+++ b/tests/drivers/modem/bc66x_parsing/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bc66x_parsing)
 

--- a/tests/drivers/modem/cellular_network_status/CMakeLists.txt
+++ b/tests/drivers/modem/cellular_network_status/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Leica Geosystems AG
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(cellular_network_status)
 

--- a/tests/drivers/mux/adgm3121/CMakeLists.txt
+++ b/tests/drivers/mux/adgm3121/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2026 Analog Devices Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(adgm3121)

--- a/tests/drivers/mux/mux_api/CMakeLists.txt
+++ b/tests/drivers/mux/mux_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mux_api)

--- a/tests/drivers/smbus/smbus_it51xxx/CMakeLists.txt
+++ b/tests/drivers/smbus/smbus_it51xxx/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 ITE Corporation. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.5)
+cmake_minimum_required(VERSION 3.28.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(smbus_it51xxx_test)

--- a/tests/kernel/timer/timeout_churn/CMakeLists.txt
+++ b/tests/kernel/timer/timeout_churn/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(timeout_churn)
 

--- a/tests/lib/devicetree/cpu/CMakeLists.txt
+++ b/tests/lib/devicetree/cpu/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(devicetree_cpu)

--- a/tests/net/lib/coap_oscore/CMakeLists.txt
+++ b/tests/net/lib/coap_oscore/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(coap_oscore)
 

--- a/tests/net/lib/mdns_responder_probe/CMakeLists.txt
+++ b/tests/net/lib/mdns_responder_probe/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mdns_responder_probe)
 

--- a/tests/net/lib/zperf/CMakeLists.txt
+++ b/tests/net/lib/zperf/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(zperf_api)
 

--- a/tests/net/rtp/loopback/CMakeLists.txt
+++ b/tests/net/rtp/loopback/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(rtp_loopback)
 

--- a/tests/subsys/fs/virtiofs/CMakeLists.txt
+++ b/tests/subsys/fs/virtiofs/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(virtiofs)
 

--- a/tests/subsys/ipc/ipc_service_api/CMakeLists.txt
+++ b/tests/subsys/ipc/ipc_service_api/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 

--- a/tests/subsys/ipc/ipc_service_api/remote/CMakeLists.txt
+++ b/tests/subsys/ipc/ipc_service_api/remote/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ipc_service_api_remote)

--- a/tests/subsys/tracing/ctf_trace/CMakeLists.txt
+++ b/tests/subsys/tracing/ctf_trace/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The Zephyr Project Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(ctf_trace)
 

--- a/tests/subsys/zbus/runtime_channels/CMakeLists.txt
+++ b/tests/subsys/zbus/runtime_channels/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.28.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(test_runtime_channels)


### PR DESCRIPTION
A handful of samples and tests were merged in parallel with the
tree-wide bump to CMake 3.28.0 and still declare 3.20.0 (or 3.20.5) as
their minimum required version. Update them so the whole tree is
consistent again.

Assisted-by: Claude:opus-5
Signed-off-by: Benjamin Cabé <benjamin@zephyrproject.org>