### PR TITLE
tests: cmsis_dsp: matrix: fix out-of-bounds read in mat_vec_mult tests

### DIFF
--- a/tests/lib/cmsis_dsp/matrix/src/unary_f16.c
+++ b/tests/lib/cmsis_dsp/matrix/src/unary_f16.c
@@ -306,8 +306,8 @@ static void test_op2v(int op, const uint16_t *ref, size_t length)
 
 		/* Load matrix data */
 		memcpy(mat_in1.pData, in_com1,
-		       2 * rows * internal * sizeof(float16_t));
-		memcpy(vec, in_vec1, 2 * internal * sizeof(float16_t));
+		       rows * internal * sizeof(float16_t));
+		memcpy(vec, in_vec1, internal * sizeof(float16_t));
 
 		/* Run test function */
 		switch (op) {

--- a/tests/lib/cmsis_dsp/matrix/src/unary_f32.c
+++ b/tests/lib/cmsis_dsp/matrix/src/unary_f32.c
@@ -302,8 +302,8 @@ static void test_op2v(int op, const uint32_t *ref, size_t length)
 
 		/* Load matrix data */
 		memcpy(mat_in1.pData, in_com1,
-		       2 * rows * internal * sizeof(float32_t));
-		memcpy(vec, in_vec1, 2 * internal * sizeof(float32_t));
+		       rows * internal * sizeof(float32_t));
+		memcpy(vec, in_vec1, internal * sizeof(float32_t));
 
 		/* Run test function */
 		switch (op) {

--- a/tests/lib/cmsis_dsp/matrix/src/unary_q15.c
+++ b/tests/lib/cmsis_dsp/matrix/src/unary_q15.c
@@ -223,8 +223,8 @@ static void test_op2v(int op, const q15_t *ref, size_t length)
 
 		/* Load matrix data */
 		memcpy(mat_in1.pData, in_com1,
-		       2 * rows * internal * sizeof(q15_t));
-		memcpy(vec, in_vec1, 2 * internal * sizeof(q15_t));
+		       rows * internal * sizeof(q15_t));
+		memcpy(vec, in_vec1, internal * sizeof(q15_t));
 
 		/* Run test function */
 		switch (op) {

--- a/tests/lib/cmsis_dsp/matrix/src/unary_q31.c
+++ b/tests/lib/cmsis_dsp/matrix/src/unary_q31.c
@@ -223,8 +223,8 @@ static void test_op2v(int op, const q31_t *ref, size_t length)
 
 		/* Load matrix data */
 		memcpy(mat_in1.pData, in_com1,
-		       2 * rows * internal * sizeof(q31_t));
-		memcpy(vec, in_vec1, 2 * internal * sizeof(q31_t));
+		       rows * internal * sizeof(q31_t));
+		memcpy(vec, in_vec1, internal * sizeof(q31_t));
 
 		/* Run test function */
 		switch (op) {

--- a/tests/lib/cmsis_dsp/matrix/src/unary_q7.c
+++ b/tests/lib/cmsis_dsp/matrix/src/unary_q7.c
@@ -128,8 +128,8 @@ static void test_op2v(int op, const q7_t *ref, size_t length)
 
 		/* Load matrix data */
 		memcpy(mat_in1.pData, in_com1,
-		       2 * rows * internal * sizeof(q7_t));
-		memcpy(vec, in_vec1, 2 * internal * sizeof(q7_t));
+		       rows * internal * sizeof(q7_t));
+		memcpy(vec, in_vec1, internal * sizeof(q7_t));
 
 		/* Run test function */
 		switch (op) {


### PR DESCRIPTION
test_op2v() loads the matrix and vector operands for arm_mat_vec_mult_*()
with a spurious factor of two:

	memcpy(mat_in1.pData, in_com1, 2 * rows * internal * sizeof(q7_t));
	memcpy(vec, in_vec1, 2 * internal * sizeof(q7_t));

That factor is only meaningful for the complex matrix tests in the same
files, where each element is a pair of values. arm_mat_vec_mult_*() takes
a real numRows x numCols matrix and a vector of numCols elements, so the
copies read past the end of the const pattern arrays.

In unary_q7.c the pattern dimensions go up to 47, so the loads ask for
4418 elements of in_com1[2209] and 94 elements of in_vec1[47], reading
2209 and 47 elements out of bounds respectively. AddressSanitizer flags
this when running the test on native_sim. The other variants have the
same defect but happen not to trip it because their pattern dimensions
are smaller.

Copy exactly what arm_mat_vec_mult_*() consumes. Both copies already
started at offset zero, so the data the operation actually reads is
unchanged and the reference outputs still hold.

Signed-off-by: Benjamin Cabé <kartben@gmail.com>